### PR TITLE
feat(#8): typed in-process event bus with backpressure

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2,8 +2,13 @@
   "version": "5",
   "specifiers": {
     "jsr:@std/assert@1": "1.0.10",
+    "jsr:@std/async@1": "1.3.0",
     "jsr:@std/cli@1": "1.0.29",
+    "jsr:@std/fmt@^1.0.5": "1.0.10",
+    "jsr:@std/fs@^1.0.11": "1.0.23",
     "jsr:@std/internal@^1.0.5": "1.0.5",
+    "jsr:@std/io@~0.225.2": "0.225.3",
+    "jsr:@std/log@0.224": "0.224.14",
     "npm:@anthropic-ai/claude-agent-sdk@*": "0.2.119_zod@3.25.76",
     "npm:@octokit/auth-app@7": "7.2.2",
     "npm:@octokit/core@5": "5.2.2",
@@ -18,11 +23,31 @@
         "jsr:@std/internal"
       ]
     },
+    "@std/async@1.3.0": {
+      "integrity": "80485538a4f7baaa46bfe2246168069e02ed142b9f9079cd164f43bb060ad9e9"
+    },
     "@std/cli@1.0.29": {
       "integrity": "fa4ef29130baa834d8a13b7d138240c3a2fcfba740bfb7afa646a360a15ec84f"
     },
+    "@std/fmt@1.0.10": {
+      "integrity": "90dfba288802ac6de82fb31d0917eb9e4450b9925b954d5e51fc29ac07419db5"
+    },
+    "@std/fs@1.0.23": {
+      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37"
+    },
     "@std/internal@1.0.5": {
       "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
+    },
+    "@std/io@0.225.3": {
+      "integrity": "27b07b591384d12d7b568f39e61dff966b8230559122df1e9fd11cc068f7ddd1"
+    },
+    "@std/log@0.224.14": {
+      "integrity": "257f7adceee3b53bb2bc86c7242e7d1bc59729e57d4981c4a7e5b876c808f05e",
+      "dependencies": [
+        "jsr:@std/fmt",
+        "jsr:@std/fs",
+        "jsr:@std/io"
+      ]
     }
   },
   "npm": {

--- a/docs/adrs/010-event-bus-backpressure-and-sync-callbacks.md
+++ b/docs/adrs/010-event-bus-backpressure-and-sync-callbacks.md
@@ -1,0 +1,112 @@
+# ADR-010: In-process event bus — drop-on-overflow + synchronous callbacks
+
+## Status
+
+Accepted (2026-04-26).
+
+## Context
+
+`src/daemon/event-bus.ts` (Wave 2) is the in-process seam between the supervisor (which produces
+`TaskEvent`s) and every consumer that wants to observe them — the daemon server (which fans events
+out across IPC), the TUI in dev/embedded mode, and the unit tests. Two design questions are
+load-bearing enough that they need to be pinned down before the daemon server, the TUI client, and
+the persistence layer all start depending on the bus's exact contract:
+
+1. **What happens when a subscriber is slower than the publisher?** A bounded queue is mandatory —
+   the bus runs inside a long-lived daemon and a slow handler must not grow the heap without limit —
+   but the choice between `drop`, `block`, and `coalesce` is a real decision with externally visible
+   consequences for the TUI's event stream and any future audit log.
+2. **What is the handler signature: synchronous callback, async callback, or `ReadableStream`?**
+   This shapes every consumer.
+
+We did not write this down before merging the implementation. Copilot flagged the omission against
+the issue's Definition of Done in PR #23. This ADR captures the rationale before later waves layer
+on top of the contract.
+
+## Decision
+
+### 1. Backpressure: bounded per-subscriber queue, drop-on-overflow with a single warning per episode
+
+Each subscriber owns a bounded queue (default capacity `EVENT_BUS_DEFAULT_BUFFER_SIZE = 256`). When
+a publish would push the queue past capacity:
+
+- The event is **dropped** for that subscriber. Other subscribers are unaffected.
+- A **single** warning is logged via `@std/log` per overflow episode. The flag re-arms the next time
+  the pump successfully drains an event, so a sustained overflow yields one log line and
+  intermittent overflows each get their own. This is a deliberate compromise between "log every
+  drop" (noisy) and "log once per process" (silently swallows new failures).
+
+Alternatives considered and rejected:
+
+- **Block the publisher.** The publisher is the supervisor's hot path; backpressure on the
+  supervisor would couple TaskEvent throughput to the slowest subscriber and could deadlock if a
+  subscriber's handler ever publishes back through the bus.
+- **Unbounded queue.** Trivially exposes a heap-growth DoS — a buggy or hung TUI client could pin
+  the daemon's RSS.
+- **Coalesce / ring-buffer (overwrite oldest).** Reasonable for "latest known state" feeds, wrong
+  for `TaskEvent`s where the consumer cares about the _sequence_ (`started → log → log → finished`).
+  Dropping the _newest_ events keeps the consumer's view internally consistent — what it has seen is
+  a true prefix of what was published — at the cost of missing the tail.
+- **Per-subscriber on-disk overflow.** Defers the problem rather than solving it; adds a write path
+  inside the daemon for events that are explicitly best-effort.
+
+Drop-on-overflow is the right policy because `TaskEvent`s are observability signals, not operational
+state. The supervisor's persisted state (ADR forthcoming for the persistence layer) is the source of
+truth; events are a derived stream consumers can resync from.
+
+### 2. Handler signature: synchronous callback `(event: TaskEvent) => void`
+
+The contract surface (`EventBus.subscribe` in `src/types.ts`) accepts a synchronous callback. The
+implementation guards against three failure modes inside the pump:
+
+- A **synchronous throw** is caught and logged at `warn`; the pump moves on.
+- An **async handler** (TypeScript permits an `async () => Promise<void>` where `() => void` is
+  expected) returning a rejected promise: the pump detects the `PromiseLike` return and attaches a
+  `.catch` so the rejection is funneled through the same warn-and-continue path. This was a real
+  hole flagged by Copilot review on PR #23 and is now covered by tests.
+- A **handler that subscribes or unsubscribes during delivery** does not perturb the in-flight
+  publish: `publish` snapshots the subscriber set before iterating.
+
+Alternatives considered and rejected:
+
+- **`ReadableStream<TaskEvent>` per subscriber.** Forces every consumer (and every test) to write
+  `for await` boilerplate or call `getReader()` and manage cancellation. The bus already uses a
+  `ReadableStream`-backed queue _internally_ for the publisher/consumer decoupling — exposing it
+  externally would leak that implementation choice into the contract.
+- **Async-only handler.** Most consumers (TUI render, IPC fan-out) are happy synchronous; forcing
+  them to be `async` adds turn boundaries with no benefit. A consumer that genuinely needs async
+  work can pass an `async` function and rely on the rejection-handling path above.
+- **Event emitter with array-of-handlers.** No isolation guarantee — a synchronous throw from one
+  handler stops downstream handlers for the same event. The per-subscriber pump model is
+  isolation-by-construction.
+
+## Consequences
+
+**Positive:**
+
+- Publisher is never blocked by a slow subscriber; the supervisor's hot path stays bounded.
+- Heap growth is bounded by `bufferSize × subscriberCount`.
+- Handler API is the simplest thing that works (sync callback) without losing the async escape
+  hatch.
+- A misbehaving subscriber (sync throw, async rejection, or self-unsubscribe mid-publish) cannot
+  poison the bus or other subscribers.
+
+**Negative:**
+
+- Drop-on-overflow means consumers cannot assume they have seen every event. Any consumer that needs
+  strong ordering or completeness guarantees (e.g. an audit log) must read from the persisted state
+  store, not from the bus. This is a deliberate split: the bus is the _fast, best-effort_
+  observability path; the state store is the _durable, complete_ source of truth.
+- A consumer that wants to do meaningful async work per event has to accept that successive events
+  arrive on the same logical pump and that a slow async handler will drop newer events past the
+  buffer. Consumers that need async fan-out should attach a sync handler that hands the event to
+  their own work queue.
+- Re-evaluating the policy later (e.g. switching to coalesce for a particular subscriber, or
+  exposing a `mode: "block"` option) is a contract change that ripples to every consumer; this ADR
+  is the gate for any such change.
+
+## References
+
+- Issue #8 (Definition of Done requires ADR for new architectural choices).
+- PR #23 Copilot review: `https://github.com/koraytaylan/makina/pull/23`.
+- ADR-004 (dependency policy — `@std/log` and `@std/async` are first-party JSR).

--- a/docs/adrs/012-event-bus-backpressure-and-sync-callbacks.md
+++ b/docs/adrs/012-event-bus-backpressure-and-sync-callbacks.md
@@ -1,4 +1,4 @@
-# ADR-010: In-process event bus — drop-on-overflow + synchronous callbacks
+# ADR-012: In-process event bus — drop-on-overflow + synchronous callbacks
 
 ## Status
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ Two cooperating processes communicate over a Unix domain socket using NDJSON:
 | GitHubClient    | `src/github/client.ts`           | W2   | High-level methods over `@octokit/core`.      |
 | Poller          | `src/daemon/poller.ts`           | W3   | Per-task polling with backoff.                |
 | Persistence     | `src/daemon/persistence.ts`      | W2   | Atomic JSON state store.                      |
-| EventBus        | `src/daemon/event-bus.ts`        | W2   | In-process pub/sub.                           |
+| EventBus        | `src/daemon/event-bus.ts`        | W2   | In-process pub/sub (see ADR-010).             |
 | Daemon server   | `src/daemon/server.ts`           | W2   | Unix socket listener + dispatch.              |
 
 ## TUI

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ Two cooperating processes communicate over a Unix domain socket using NDJSON:
 | GitHubClient    | `src/github/client.ts`           | W2   | High-level methods over `@octokit/core`.      |
 | Poller          | `src/daemon/poller.ts`           | W3   | Per-task polling with backoff.                |
 | Persistence     | `src/daemon/persistence.ts`      | W2   | Atomic JSON state store.                      |
-| EventBus        | `src/daemon/event-bus.ts`        | W2   | In-process pub/sub (see ADR-010).             |
+| EventBus        | `src/daemon/event-bus.ts`        | W2   | In-process pub/sub (see ADR-012).             |
 | Daemon server   | `src/daemon/server.ts`           | W2   | Unix socket listener + dispatch.              |
 
 ## TUI

--- a/src/daemon/event-bus.ts
+++ b/src/daemon/event-bus.ts
@@ -39,7 +39,7 @@
  *
  * The drop-on-overflow policy and the synchronous-callback contract are
  * both load-bearing design choices captured in
- * `docs/adrs/010-event-bus-backpressure-and-sync-callbacks.md`. Any change
+ * `docs/adrs/012-event-bus-backpressure-and-sync-callbacks.md`. Any change
  * to either is a contract change and needs an ADR amendment.
  *
  * @module

--- a/src/daemon/event-bus.ts
+++ b/src/daemon/event-bus.ts
@@ -23,13 +23,24 @@
  * `ReadableStream`-style queue so the publisher/consumer decoupling is
  * preserved and a misbehaving handler cannot poison sibling subscribers.
  *
- * **Wildcard fan-out.** A publish to `task:42` is delivered to every
- * subscriber whose target is either `task:42` (exact match on
- * {@link TaskEvent.taskId}) or `"*"` (every event regardless of task).
+ * **Wildcard fan-out.** A publish carrying {@link TaskEvent.taskId} `id`
+ * is delivered to every subscriber whose `target` is either the same
+ * {@link TaskId} `id` (exact match) or the literal wildcard `"*"` (every
+ * event regardless of task). `target` is always a {@link TaskId} value or
+ * `"*"`, never a `task:<id>` string — the `task:` prefix only appears in
+ * log messages emitted by the bus itself.
  *
  * **Handler safety.** A handler that throws is caught at the pump
  * boundary; the throw is logged at `warn` and the pump moves on to the
- * next event. The bus survives an arbitrarily-buggy subscriber.
+ * next event. The bus survives an arbitrarily-buggy subscriber. An
+ * `async` handler whose returned promise *rejects* is also caught — the
+ * pump detects the `PromiseLike` return and attaches a `.catch` so the
+ * rejection takes the same warn-and-continue path.
+ *
+ * The drop-on-overflow policy and the synchronous-callback contract are
+ * both load-bearing design choices captured in
+ * `docs/adrs/010-event-bus-backpressure-and-sync-callbacks.md`. Any change
+ * to either is a contract change and needs an ADR amendment.
  *
  * @module
  */
@@ -204,7 +215,23 @@ function createSubscriber(
         overflowing = false;
       }
       try {
-        handler(next.value);
+        // The contract type is `(event) => void`, but TypeScript still
+        // permits passing an `async` function (an `async () => void`
+        // returns `Promise<void>` which is assignable to `void`). A
+        // synchronous throw lands in this catch; a *rejected* Promise
+        // would otherwise become an unhandled rejection. We detect a
+        // PromiseLike return and attach a `.catch` so async handlers are
+        // isolated to the same warn-and-continue policy as sync ones.
+        const result = handler(next.value) as unknown;
+        if (isPromiseLike(result)) {
+          result.then(undefined, (caught: unknown) => {
+            logger.warn(
+              `event-bus subscriber handler rejected; bus continues. error=${
+                stringifyError(caught)
+              }`,
+            );
+          });
+        }
       } catch (caught) {
         logger.warn(
           `event-bus subscriber handler threw; bus continues. error=${stringifyError(caught)}`,
@@ -273,4 +300,12 @@ function stringifyError(caught: unknown): string {
     return `${caught.name}: ${caught.message}`;
   }
   return String(caught);
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    value !== null &&
+    (typeof value === "object" || typeof value === "function") &&
+    typeof (value as { then?: unknown }).then === "function"
+  );
 }

--- a/src/daemon/event-bus.ts
+++ b/src/daemon/event-bus.ts
@@ -1,0 +1,276 @@
+/**
+ * daemon/event-bus.ts — typed in-process pub/sub for {@link TaskEvent}s.
+ *
+ * The bus is the seam between the supervisor (which produces task events)
+ * and every consumer that wants to observe them — the daemon server (which
+ * fans them out across IPC), the TUI in dev/embedded mode, and the unit
+ * tests. Wave 2 implements only the **in-process** layer; cross-process
+ * fan-out lives in `[W2-daemon-server]`.
+ *
+ * **Design.** Each subscriber owns a bounded queue plus a background pump
+ * that drains the queue into the user's callback. Publish is synchronous
+ * and never blocks the caller: events are appended to every matching
+ * subscriber's queue and the pumps deliver them on the microtask queue.
+ * The queue is bounded so a slow handler cannot grow the daemon's heap
+ * without limit — once full, **subsequent** publishes for that subscriber
+ * are dropped and a single warning is logged per overflow episode (a fresh
+ * warning fires the next time the queue fills after draining).
+ *
+ * The contract surface ({@link EventBus} from `src/types.ts`) uses a
+ * synchronous handler callback rather than a `ReadableStream` — that is
+ * deliberate so consumers can write linear test code without `for await`
+ * boilerplate. Internally each subscriber is backed by a
+ * `ReadableStream`-style queue so the publisher/consumer decoupling is
+ * preserved and a misbehaving handler cannot poison sibling subscribers.
+ *
+ * **Wildcard fan-out.** A publish to `task:42` is delivered to every
+ * subscriber whose target is either `task:42` (exact match on
+ * {@link TaskEvent.taskId}) or `"*"` (every event regardless of task).
+ *
+ * **Handler safety.** A handler that throws is caught at the pump
+ * boundary; the throw is logged at `warn` and the pump moves on to the
+ * next event. The bus survives an arbitrarily-buggy subscriber.
+ *
+ * @module
+ */
+
+import { getLogger } from "@std/log";
+
+import { EVENT_BUS_DEFAULT_BUFFER_SIZE } from "../constants.ts";
+import type { EventBus, EventSubscription, TaskEvent, TaskId } from "../types.ts";
+
+/**
+ * Subscription handle returned by {@link EventBus.subscribe}.
+ *
+ * Re-exported as a named alias for the design-document term used by the
+ * Wave 2 issue brief; callers should prefer the contract type
+ * {@link EventSubscription} from `src/types.ts`.
+ */
+export type SubscriptionHandle = EventSubscription;
+
+/**
+ * Narrow logger surface used by the event bus. The `@std/log` `Logger`
+ * class satisfies this shape (its `warn` accepts a string), but the
+ * narrower interface lets tests inject a recording double without
+ * matching the SDK's full overload signature.
+ */
+export interface EventBusLogger {
+  /** Emit a warning. */
+  warn(message: string): void;
+}
+
+/**
+ * Optional construction-time knobs for {@link createEventBus}.
+ */
+export interface EventBusOptions {
+  /**
+   * Maximum number of events buffered per subscriber before publishes start
+   * dropping with a warning. Defaults to {@link EVENT_BUS_DEFAULT_BUFFER_SIZE}.
+   *
+   * Must be a positive integer.
+   */
+  readonly bufferSize?: number;
+  /**
+   * Logger used to emit slow-consumer warnings and handler-throw warnings.
+   * Defaults to `getLogger()` from `@std/log` (the default-namespace logger),
+   * adapted to the {@link EventBusLogger} surface.
+   *
+   * Tests inject a recording logger to assert warning behavior without
+   * touching the global logger registry.
+   */
+  readonly logger?: EventBusLogger;
+}
+
+/**
+ * Construct an in-process {@link EventBus}.
+ *
+ * The returned bus supports unbounded publishes from many producers and a
+ * bounded queue per subscriber. See the module doc for the full contract.
+ *
+ * @param options Optional configuration overrides.
+ * @returns A fresh `EventBus` ready to wire into the supervisor and the
+ *   daemon server.
+ *
+ * @example
+ * ```ts
+ * const bus = createEventBus();
+ * const sub = bus.subscribe("*", (event) => {
+ *   console.log(`[${event.taskId}] ${event.kind}`);
+ * });
+ * bus.publish({
+ *   taskId: makeTaskId("task_demo"),
+ *   atIso: new Date().toISOString(),
+ *   kind: "log",
+ *   data: { level: "info", message: "hello" },
+ * });
+ * sub.unsubscribe();
+ * ```
+ */
+export function createEventBus(options: EventBusOptions = {}): EventBus {
+  const bufferSize = options.bufferSize ?? EVENT_BUS_DEFAULT_BUFFER_SIZE;
+  if (!Number.isInteger(bufferSize) || bufferSize <= 0) {
+    throw new RangeError(
+      `EventBus bufferSize must be a positive integer; got ${bufferSize}`,
+    );
+  }
+  const logger = options.logger ?? defaultLogger();
+  const subscribers = new Set<Subscriber>();
+
+  return {
+    publish(event: TaskEvent): void {
+      // Snapshot the subscriber set so a handler that subscribes (or
+      // unsubscribes) during delivery does not mutate the iteration order.
+      const snapshot = [...subscribers];
+      for (const subscriber of snapshot) {
+        if (matches(subscriber.target, event.taskId)) {
+          subscriber.enqueue(event);
+        }
+      }
+    },
+    subscribe(
+      target: TaskId | "*",
+      handler: (event: TaskEvent) => void,
+    ): EventSubscription {
+      const subscriber = createSubscriber(target, handler, bufferSize, logger);
+      subscribers.add(subscriber);
+      let unsubscribed = false;
+      return {
+        unsubscribe(): void {
+          if (unsubscribed) return;
+          unsubscribed = true;
+          subscribers.delete(subscriber);
+          subscriber.close();
+        },
+      };
+    },
+  };
+}
+
+/**
+ * Internal per-subscriber state. Holds the bounded queue, the pump task,
+ * and the overflow flag used to suppress duplicate warnings.
+ */
+interface Subscriber {
+  /** The subscriber's filter: a specific {@link TaskId} or the wildcard `"*"`. */
+  readonly target: TaskId | "*";
+  /** Append `event` to the queue or drop it if the queue is full. */
+  enqueue(event: TaskEvent): void;
+  /** Tear down the queue and stop the pump. Idempotent. */
+  close(): void;
+}
+
+function matches(target: TaskId | "*", taskId: TaskId): boolean {
+  return target === "*" || target === taskId;
+}
+
+function createSubscriber(
+  target: TaskId | "*",
+  handler: (event: TaskEvent) => void,
+  bufferSize: number,
+  logger: EventBusLogger,
+): Subscriber {
+  // Per-subscriber bounded queue, exposed externally via a ReadableStream so
+  // the pump can `await reader.read()` and yield to the event loop between
+  // deliveries. This keeps the publisher synchronous while letting handlers
+  // run on the microtask queue.
+  let controller!: ReadableStreamDefaultController<TaskEvent>;
+  const stream = new ReadableStream<TaskEvent>({
+    start(c) {
+      controller = c;
+    },
+  });
+  const reader = stream.getReader();
+
+  let queueDepth = 0;
+  let overflowing = false;
+  let closed = false;
+
+  const pump = async () => {
+    while (true) {
+      let next: ReadableStreamReadResult<TaskEvent>;
+      try {
+        next = await reader.read();
+      } catch {
+        // Stream errored or was cancelled; nothing more to do.
+        return;
+      }
+      if (next.done) return;
+      queueDepth--;
+      // Re-arm the warning so the *next* time the queue fills we get a
+      // fresh log line. We re-arm on the first successful drain, not at
+      // queue-empty, so the warning rate scales with overflow episodes
+      // and not with publish bursts.
+      if (overflowing) {
+        overflowing = false;
+      }
+      try {
+        handler(next.value);
+      } catch (caught) {
+        logger.warn(
+          `event-bus subscriber handler threw; bus continues. error=${stringifyError(caught)}`,
+        );
+      }
+    }
+  };
+  // Detached pump promise: failures are surfaced through the per-handler
+  // try/catch above so this `.catch` is defensive only.
+  pump().catch((caught) => {
+    logger.warn(`event-bus pump exited unexpectedly: ${stringifyError(caught)}`);
+  });
+
+  return {
+    target,
+    enqueue(event: TaskEvent): void {
+      if (closed) return;
+      if (queueDepth >= bufferSize) {
+        // Drop the event. Log exactly once per overflow episode: the flag
+        // is cleared the next time the pump successfully drains an event
+        // (see above), so a sustained overflow yields one warning while
+        // intermittent overflows each get their own.
+        if (!overflowing) {
+          overflowing = true;
+          logger.warn(
+            `event-bus subscriber dropping events: queue full (capacity=${bufferSize}, target=${
+              stringifyTarget(target)
+            })`,
+          );
+        }
+        return;
+      }
+      queueDepth++;
+      controller.enqueue(event);
+    },
+    close(): void {
+      if (closed) return;
+      closed = true;
+      try {
+        controller.close();
+      } catch {
+        // Already closed (e.g. via cancel); nothing to do.
+      }
+    },
+  };
+}
+
+function defaultLogger(): EventBusLogger {
+  // `getLogger()` returns the default-namespace logger from `@std/log`. Its
+  // `warn` overload accepts a plain string, but TypeScript needs a thin
+  // adapter to project the SDK's shape onto our narrow surface.
+  const inner = getLogger();
+  return {
+    warn(message: string): void {
+      inner.warn(message);
+    },
+  };
+}
+
+function stringifyTarget(target: TaskId | "*"): string {
+  return target === "*" ? "*" : `task:${target}`;
+}
+
+function stringifyError(caught: unknown): string {
+  if (caught instanceof Error) {
+    return `${caught.name}: ${caught.message}`;
+  }
+  return String(caught);
+}

--- a/tests/unit/event_bus_test.ts
+++ b/tests/unit/event_bus_test.ts
@@ -15,7 +15,7 @@
  *  - Construction: invalid `bufferSize` values are rejected.
  */
 
-import { assertEquals, assertRejects, assertStrictEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertStrictEquals, assertThrows } from "@std/assert";
 import { delay } from "@std/async";
 
 import { createEventBus } from "../../src/daemon/event-bus.ts";
@@ -338,6 +338,103 @@ Deno.test("handler that throws does not poison the bus", async () => {
   subLate.unsubscribe();
 });
 
+Deno.test("async handler whose promise rejects is caught and logged (no unhandled rejection)", async () => {
+  const logger = recordingLogger();
+  const bus = createEventBus({ logger });
+  const id = makeTaskId("task_async_reject");
+  const goodSeen: TaskEvent[] = [];
+
+  // TypeScript allows passing an `async` function where `(event) => void`
+  // is expected (Promise<void> is assignable to void). The bus must
+  // detect the returned Promise and attach a `.catch` so the rejection
+  // is funneled through the same warn-and-continue path as sync throws.
+  const subAsync = bus.subscribe(
+    id,
+    (async (_event) => {
+      // The `await` makes the throw happen on a microtask boundary, which
+      // is the realistic shape of an async handler that does any I/O
+      // before failing. Without an `await`, lint's `require-await` would
+      // flag this — and the test would still pass thanks to the
+      // PromiseLike detection branch — but this is closer to what the
+      // bus is actually defending against.
+      await Promise.resolve();
+      throw new Error("async handler exploded");
+    }) as (event: TaskEvent) => void,
+  );
+  const subGood = bus.subscribe("*", (event) => goodSeen.push(event));
+
+  bus.publish(fakeEvent(id, "first"));
+  bus.publish(fakeEvent(id, "second"));
+
+  await flush();
+
+  // Sibling subscriber kept seeing events.
+  assertEquals(goodSeen.length, 2);
+  // One warn per rejection, carrying the rejection-specific phrase.
+  const rejectWarnings = logger.messages.filter((m) => m.includes("handler rejected"));
+  assertEquals(
+    rejectWarnings.length,
+    2,
+    `expected 2 rejection warnings, got ${rejectWarnings.length}: ${logger.messages.join(" | ")}`,
+  );
+  assertEquals(rejectWarnings[0]?.includes("async handler exploded"), true);
+
+  subAsync.unsubscribe();
+  subGood.unsubscribe();
+});
+
+Deno.test("async handler that resolves cleanly does not log a warning", async () => {
+  const logger = recordingLogger();
+  const bus = createEventBus({ logger });
+  const id = makeTaskId("task_async_ok");
+  const seen: TaskEvent[] = [];
+
+  const sub = bus.subscribe(
+    id,
+    (async (event) => {
+      await Promise.resolve();
+      seen.push(event);
+    }) as (event: TaskEvent) => void,
+  );
+
+  bus.publish(fakeEvent(id));
+  await flush();
+
+  assertEquals(seen.length, 1);
+  assertEquals(logger.messages.length, 0);
+
+  sub.unsubscribe();
+});
+
+Deno.test("handler returning a thenable that rejects is treated like an async handler", async () => {
+  const logger = recordingLogger();
+  const bus = createEventBus({ logger });
+  const id = makeTaskId("task_thenable");
+
+  // A bare thenable (not a real Promise) still trips the PromiseLike
+  // detection branch, exercising the duck-typed `then`-as-function check
+  // in `isPromiseLike` rather than the `instanceof Promise` shortcut.
+  const sub = bus.subscribe(
+    id,
+    (() => {
+      return {
+        then(_onFulfilled: unknown, onRejected: (reason: unknown) => void): void {
+          onRejected(new Error("thenable boom"));
+        },
+      };
+    }) as (event: TaskEvent) => void,
+  );
+
+  bus.publish(fakeEvent(id));
+  await flush();
+
+  const rejectWarnings = logger.messages.filter((m) => m.includes("handler rejected"));
+  assertEquals(rejectWarnings.length, 1);
+  assertEquals(rejectWarnings[0]?.includes("thenable boom"), true);
+
+  sub.unsubscribe();
+});
+
 Deno.test("handler that throws a non-Error is logged with String() coercion", async () => {
   const logger = recordingLogger();
   const bus = createEventBus({ logger });
@@ -488,22 +585,10 @@ Deno.test("publish after unsubscribe is a silent no-op (does not throw)", async 
   const seen: TaskEvent[] = [];
   const sub = bus.subscribe(id, (event) => seen.push(event));
   sub.unsubscribe();
-  // Publish-while-closed exercises the `if (closed) return` guard inside
-  // `enqueue` indirectly: although the outer subscribe layer removes the
-  // subscriber from the set on unsubscribe (so `publish` skips it), the
-  // inner guard is a defense in depth that we exercise here by holding a
-  // reference to the inner subscriber via a fresh subscribe call that is
-  // closed mid-publish via close().
+  // After unsubscribe, the subscriber is removed from the active set, so
+  // `publish` skips it. The handler must not run and the publish must
+  // not throw.
   bus.publish(fakeEvent(id));
   await flush();
   assertEquals(seen.length, 0);
-});
-
-// ---------------------------------------------------------------------------
-// Sanity: assertRejects re-export consumed (keeps the import meaningful in
-// the linter's eyes if tests evolve to test rejected promises explicitly).
-// ---------------------------------------------------------------------------
-
-Deno.test("assertRejects is reachable for future async error assertions", async () => {
-  await assertRejects(() => Promise.reject(new Error("x")), Error, "x");
 });

--- a/tests/unit/event_bus_test.ts
+++ b/tests/unit/event_bus_test.ts
@@ -1,0 +1,509 @@
+/**
+ * Unit tests for `src/daemon/event-bus.ts`. Covers:
+ *
+ *  - Exact-match delivery: a publish to `task:42` reaches a `task:42`
+ *    subscriber but **not** a `task:99` subscriber.
+ *  - Wildcard fan-out: a publish to `task:42` reaches both `task:42`
+ *    subscribers and `*` subscribers.
+ *  - Unsubscribe: an unsubscribed handler stops receiving; unsubscribe is
+ *    idempotent.
+ *  - Backpressure: a slow consumer overflowing the bounded queue drops
+ *    further publishes and a single warning is logged per overflow
+ *    episode (re-arming after a drain).
+ *  - Handler-throws: an exception inside one subscriber's handler is
+ *    isolated; sibling subscribers and subsequent publishes survive.
+ *  - Construction: invalid `bufferSize` values are rejected.
+ */
+
+import { assertEquals, assertRejects, assertStrictEquals, assertThrows } from "@std/assert";
+import { delay } from "@std/async";
+
+import { createEventBus } from "../../src/daemon/event-bus.ts";
+import { makeTaskId, type TaskEvent, type TaskId } from "../../src/types.ts";
+import { EVENT_BUS_DEFAULT_BUFFER_SIZE } from "../../src/constants.ts";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Recording logger that captures every `warn` call. */
+function recordingLogger(): { warn: (message: string) => void; messages: string[] } {
+  const messages: string[] = [];
+  return {
+    messages,
+    warn(message: string): void {
+      messages.push(message);
+    },
+  };
+}
+
+/** Construct a minimal valid {@link TaskEvent} for tests. */
+function fakeEvent(
+  taskId: TaskId,
+  message = "tick",
+): TaskEvent {
+  return {
+    taskId,
+    atIso: "2026-04-26T00:00:00.000Z",
+    kind: "log",
+    data: { level: "info", message },
+  };
+}
+
+/**
+ * Yield enough microtasks for the event-bus pump to drain `events.length`
+ * deliveries. The pump uses `await reader.read()`, which resolves on the
+ * microtask queue, so a small `delay(0)` is enough to let the pump catch
+ * up. We optionally take a `count` for sanity in flooding tests.
+ */
+async function flush(): Promise<void> {
+  // Three turns of the microtask + macrotask cycle is enough for any
+  // realistic burst the tests publish (under 1000 events). `delay(0)`
+  // schedules a `setTimeout(0)` macrotask, which always lands after every
+  // microtask the previous turn enqueued.
+  await delay(0);
+  await delay(0);
+  await delay(0);
+}
+
+// ---------------------------------------------------------------------------
+// Exact-match delivery
+// ---------------------------------------------------------------------------
+
+Deno.test("publish delivers to exact-match subscribers and skips others", async () => {
+  const bus = createEventBus({ logger: recordingLogger() });
+  const a = makeTaskId("task_a");
+  const b = makeTaskId("task_b");
+  const aSeen: TaskEvent[] = [];
+  const bSeen: TaskEvent[] = [];
+  const subA = bus.subscribe(a, (event) => aSeen.push(event));
+  const subB = bus.subscribe(b, (event) => bSeen.push(event));
+
+  bus.publish(fakeEvent(a, "to-a"));
+  bus.publish(fakeEvent(b, "to-b"));
+  bus.publish(fakeEvent(a, "to-a-again"));
+
+  await flush();
+
+  assertEquals(aSeen.length, 2);
+  assertEquals(bSeen.length, 1);
+  assertEquals((aSeen[0]?.data as { message: string }).message, "to-a");
+  assertEquals((aSeen[1]?.data as { message: string }).message, "to-a-again");
+  assertEquals((bSeen[0]?.data as { message: string }).message, "to-b");
+
+  subA.unsubscribe();
+  subB.unsubscribe();
+});
+
+// ---------------------------------------------------------------------------
+// Wildcard fan-out
+// ---------------------------------------------------------------------------
+
+Deno.test("wildcard subscriber receives events for every task", async () => {
+  const bus = createEventBus({ logger: recordingLogger() });
+  const a = makeTaskId("task_a");
+  const b = makeTaskId("task_b");
+  const wildcardSeen: TaskEvent[] = [];
+  const aSeen: TaskEvent[] = [];
+
+  const subWild = bus.subscribe("*", (event) => wildcardSeen.push(event));
+  const subA = bus.subscribe(a, (event) => aSeen.push(event));
+
+  bus.publish(fakeEvent(a, "first"));
+  bus.publish(fakeEvent(b, "second"));
+  bus.publish(fakeEvent(a, "third"));
+
+  await flush();
+
+  assertEquals(wildcardSeen.length, 3);
+  assertEquals(aSeen.length, 2);
+  assertEquals(wildcardSeen.map((e) => (e.data as { message: string }).message), [
+    "first",
+    "second",
+    "third",
+  ]);
+  assertEquals(aSeen.map((e) => (e.data as { message: string }).message), [
+    "first",
+    "third",
+  ]);
+
+  subWild.unsubscribe();
+  subA.unsubscribe();
+});
+
+Deno.test("publish to a task reaches both task and wildcard subscribers", async () => {
+  const bus = createEventBus({ logger: recordingLogger() });
+  const id = makeTaskId("task_42");
+  const taskSeen: TaskEvent[] = [];
+  const wildcardSeen: TaskEvent[] = [];
+
+  const subTask = bus.subscribe(id, (event) => taskSeen.push(event));
+  const subWild = bus.subscribe("*", (event) => wildcardSeen.push(event));
+
+  bus.publish(fakeEvent(id));
+  await flush();
+
+  assertEquals(taskSeen.length, 1);
+  assertEquals(wildcardSeen.length, 1);
+  assertStrictEquals(taskSeen[0]?.taskId, id);
+  assertStrictEquals(wildcardSeen[0]?.taskId, id);
+
+  subTask.unsubscribe();
+  subWild.unsubscribe();
+});
+
+// ---------------------------------------------------------------------------
+// Unsubscribe
+// ---------------------------------------------------------------------------
+
+Deno.test("unsubscribed handler stops receiving events", async () => {
+  const bus = createEventBus({ logger: recordingLogger() });
+  const id = makeTaskId("task_x");
+  const seen: TaskEvent[] = [];
+
+  const sub = bus.subscribe(id, (event) => seen.push(event));
+  bus.publish(fakeEvent(id, "before"));
+  await flush();
+  assertEquals(seen.length, 1);
+
+  sub.unsubscribe();
+  bus.publish(fakeEvent(id, "after"));
+  await flush();
+  // No new event arrived after unsubscribe.
+  assertEquals(seen.length, 1);
+});
+
+Deno.test("unsubscribe is idempotent", async () => {
+  const bus = createEventBus({ logger: recordingLogger() });
+  const id = makeTaskId("task_y");
+  const seen: TaskEvent[] = [];
+
+  const sub = bus.subscribe(id, (event) => seen.push(event));
+  sub.unsubscribe();
+  sub.unsubscribe(); // Second call is a no-op, must not throw.
+
+  bus.publish(fakeEvent(id));
+  await flush();
+  assertEquals(seen.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Backpressure: bounded queue and slow-consumer drop
+// ---------------------------------------------------------------------------
+
+Deno.test("slow consumer drops events past bufferSize and warns once", async () => {
+  const logger = recordingLogger();
+  // bufferSize: 4 keeps the test fast; the publisher floods with 10
+  // events while the handler blocks, so 6 events should drop.
+  const bufferSize = 4;
+  const bus = createEventBus({ bufferSize, logger });
+  const id = makeTaskId("task_flood");
+
+  // The handler blocks on a promise the test resolves later. Because the
+  // pump awaits `handler(next.value)` only via the synchronous-throw
+  // catch, a Promise-returning handler does NOT pause the pump — the
+  // handler signature is sync. So instead we make the handler busy-wait
+  // synchronously? No: that would block the pump too tightly. Use a
+  // counter that records but never blocks; the slow-consumer scenario
+  // we model is "publisher flooded faster than the pump can read", which
+  // happens any time more than `bufferSize` events are enqueued before
+  // the pump's next microtask turn.
+
+  const seen: TaskEvent[] = [];
+  const sub = bus.subscribe(id, (event) => {
+    seen.push(event);
+  });
+
+  // Synchronous flood: the pump cannot drain between iterations of this
+  // loop because we never yield to the microtask queue. So events
+  // 0..bufferSize-1 land in the queue, events bufferSize..N-1 drop.
+  const totalPublished = 10;
+  for (let i = 0; i < totalPublished; i++) {
+    bus.publish(fakeEvent(id, `m${i}`));
+  }
+
+  await flush();
+
+  // Exactly bufferSize events made it through.
+  assertEquals(seen.length, bufferSize, `expected ${bufferSize} delivered, got ${seen.length}`);
+  // First bufferSize events are the ones queued; later ones dropped.
+  assertEquals(
+    seen.map((e) => (e.data as { message: string }).message),
+    Array.from({ length: bufferSize }, (_, i) => `m${i}`),
+  );
+
+  // Exactly one warning per overflow episode.
+  const overflowWarnings = logger.messages.filter((m) => m.includes("queue full"));
+  assertEquals(
+    overflowWarnings.length,
+    1,
+    `expected exactly 1 overflow warning, got ${overflowWarnings.length}: ${
+      overflowWarnings.join(" | ")
+    }`,
+  );
+
+  sub.unsubscribe();
+});
+
+Deno.test("overflow warning re-arms after a successful drain", async () => {
+  const logger = recordingLogger();
+  const bufferSize = 2;
+  const bus = createEventBus({ bufferSize, logger });
+  const id = makeTaskId("task_re_arm");
+
+  const seen: TaskEvent[] = [];
+  const sub = bus.subscribe(id, (event) => {
+    seen.push(event);
+  });
+
+  // First overflow burst.
+  for (let i = 0; i < 5; i++) bus.publish(fakeEvent(id, `a${i}`));
+  await flush();
+  // After the drain the queue is empty and the warning flag is re-armed.
+  assertEquals(seen.length, bufferSize); // 2 delivered out of the burst
+
+  // Second overflow burst.
+  for (let i = 0; i < 5; i++) bus.publish(fakeEvent(id, `b${i}`));
+  await flush();
+  assertEquals(seen.length, bufferSize * 2); // 2 more delivered = 4 total
+
+  const overflowWarnings = logger.messages.filter((m) => m.includes("queue full"));
+  // One warning per episode = two total.
+  assertEquals(
+    overflowWarnings.length,
+    2,
+    `expected 2 overflow warnings (one per episode), got ${overflowWarnings.length}`,
+  );
+
+  sub.unsubscribe();
+});
+
+Deno.test("non-overflowing publish stream produces no warnings", async () => {
+  const logger = recordingLogger();
+  const bus = createEventBus({ bufferSize: 8, logger });
+  const id = makeTaskId("task_calm");
+
+  const seen: TaskEvent[] = [];
+  const sub = bus.subscribe(id, (event) => seen.push(event));
+
+  for (let i = 0; i < 8; i++) bus.publish(fakeEvent(id, `n${i}`));
+  await flush();
+
+  assertEquals(seen.length, 8);
+  assertEquals(logger.messages.length, 0);
+
+  sub.unsubscribe();
+});
+
+// ---------------------------------------------------------------------------
+// Handler-throws-don't-kill-the-bus
+// ---------------------------------------------------------------------------
+
+Deno.test("handler that throws does not poison the bus", async () => {
+  const logger = recordingLogger();
+  const bus = createEventBus({ logger });
+  const id = makeTaskId("task_throwy");
+  const goodSeen: TaskEvent[] = [];
+  let throwCount = 0;
+
+  const subThrow = bus.subscribe(id, (_event) => {
+    throwCount++;
+    throw new Error("handler exploded");
+  });
+  const subGood = bus.subscribe("*", (event) => goodSeen.push(event));
+
+  bus.publish(fakeEvent(id, "first"));
+  bus.publish(fakeEvent(id, "second"));
+  bus.publish(fakeEvent(id, "third"));
+
+  await flush();
+
+  // The throwing handler ran for every event…
+  assertEquals(throwCount, 3);
+  // …and the sibling subscriber kept getting events the whole time.
+  assertEquals(goodSeen.length, 3);
+  // …and a warning was logged for each throw.
+  const handlerWarnings = logger.messages.filter((m) => m.includes("handler threw"));
+  assertEquals(handlerWarnings.length, 3);
+
+  subThrow.unsubscribe();
+  subGood.unsubscribe();
+
+  // The bus survives a fresh publish after the throwing subscriber leaves.
+  const lateSeen: TaskEvent[] = [];
+  const subLate = bus.subscribe("*", (event) => lateSeen.push(event));
+  bus.publish(fakeEvent(id, "late"));
+  await flush();
+  assertEquals(lateSeen.length, 1);
+  subLate.unsubscribe();
+});
+
+Deno.test("handler that throws a non-Error is logged with String() coercion", async () => {
+  const logger = recordingLogger();
+  const bus = createEventBus({ logger });
+  const id = makeTaskId("task_weird_throw");
+
+  const sub = bus.subscribe(id, () => {
+    // Throwing a literal exercises the non-Error branch in stringifyError.
+    // This is intentional even though `no-throw-literal` would normally
+    // flag it — we are deliberately testing the bus's resilience to
+    // misbehaving handlers.
+    // deno-lint-ignore no-throw-literal
+    throw "stringly typed";
+  });
+
+  bus.publish(fakeEvent(id));
+  await flush();
+
+  const handlerWarnings = logger.messages.filter((m) => m.includes("handler threw"));
+  assertEquals(handlerWarnings.length, 1);
+  // The warning carries the coerced string rather than `[object Object]`.
+  assertEquals(handlerWarnings[0]?.includes("stringly typed"), true);
+
+  sub.unsubscribe();
+});
+
+// ---------------------------------------------------------------------------
+// Subscribe/unsubscribe during delivery
+// ---------------------------------------------------------------------------
+
+Deno.test("subscribe inside a handler does not affect the current publish", async () => {
+  const bus = createEventBus({ logger: recordingLogger() });
+  const id = makeTaskId("task_dyn");
+  const lateSeen: TaskEvent[] = [];
+
+  // The handler subscribes a *new* subscriber the first time it runs.
+  // The new subscriber must not retroactively receive the in-flight
+  // event but must receive subsequent publishes.
+  let lateSub: { unsubscribe(): void } | undefined;
+  const sub = bus.subscribe(id, (_event) => {
+    if (!lateSub) {
+      lateSub = bus.subscribe("*", (event) => lateSeen.push(event));
+    }
+  });
+
+  bus.publish(fakeEvent(id, "before"));
+  await flush();
+  // Late subscriber missed the in-flight event.
+  assertEquals(lateSeen.length, 0);
+
+  bus.publish(fakeEvent(id, "after"));
+  await flush();
+  assertEquals(lateSeen.length, 1);
+  assertEquals((lateSeen[0]?.data as { message: string }).message, "after");
+
+  sub.unsubscribe();
+  lateSub?.unsubscribe();
+});
+
+Deno.test("unsubscribe inside a handler stops the subscriber from receiving future publishes", async () => {
+  const bus = createEventBus({ logger: recordingLogger() });
+  const id = makeTaskId("task_self_unsub");
+  let count = 0;
+
+  const sub: { unsubscribe(): void } = bus.subscribe(id, (_event) => {
+    count++;
+    sub.unsubscribe();
+  });
+
+  // First publish — handler will run and self-unsubscribe.
+  bus.publish(fakeEvent(id, "first"));
+  await flush();
+  assertEquals(count, 1, "handler should have run exactly once for the first publish");
+
+  // Second publish happens after the unsubscribe took effect; the
+  // subscriber is no longer in the set so the publish skips it. This
+  // verifies that unsubscribe takes effect for *new* publishes — events
+  // already buffered before unsubscribe still drain (they were committed
+  // to the queue at publish time).
+  bus.publish(fakeEvent(id, "second"));
+  await flush();
+  assertEquals(count, 1, "handler must not run for events published after unsubscribe");
+});
+
+// ---------------------------------------------------------------------------
+// Construction-time validation
+// ---------------------------------------------------------------------------
+
+Deno.test("createEventBus rejects non-positive bufferSize", () => {
+  assertThrows(
+    () => createEventBus({ bufferSize: 0 }),
+    RangeError,
+    "bufferSize",
+  );
+  assertThrows(
+    () => createEventBus({ bufferSize: -1 }),
+    RangeError,
+    "bufferSize",
+  );
+  assertThrows(
+    () => createEventBus({ bufferSize: 1.5 }),
+    RangeError,
+    "bufferSize",
+  );
+  assertThrows(
+    () => createEventBus({ bufferSize: Number.NaN }),
+    RangeError,
+    "bufferSize",
+  );
+});
+
+Deno.test("createEventBus uses EVENT_BUS_DEFAULT_BUFFER_SIZE when bufferSize omitted", async () => {
+  const logger = recordingLogger();
+  const bus = createEventBus({ logger });
+  const id = makeTaskId("task_default");
+  const seen: TaskEvent[] = [];
+  const sub = bus.subscribe(id, (event) => seen.push(event));
+
+  // Publishing exactly the default capacity must not warn.
+  for (let i = 0; i < EVENT_BUS_DEFAULT_BUFFER_SIZE; i++) {
+    bus.publish(fakeEvent(id, `c${i}`));
+  }
+  await flush();
+  assertEquals(seen.length, EVENT_BUS_DEFAULT_BUFFER_SIZE);
+  assertEquals(logger.messages.length, 0);
+
+  sub.unsubscribe();
+});
+
+Deno.test("createEventBus with no options uses the default @std/log logger", async () => {
+  // Exercises the `defaultLogger()` factory branch so coverage reflects
+  // it. We can't easily assert on the global logger's output without
+  // reaching into the std/log registry, but we can prove the bus runs
+  // end-to-end without injection — any uncaught exception inside the
+  // adapter would propagate out of `createEventBus` or the publish path.
+  const bus = createEventBus();
+  const id = makeTaskId("task_no_opts");
+  const seen: TaskEvent[] = [];
+  const sub = bus.subscribe(id, (event) => seen.push(event));
+  bus.publish(fakeEvent(id, "no-opts"));
+  await flush();
+  assertEquals(seen.length, 1);
+  sub.unsubscribe();
+});
+
+Deno.test("publish after unsubscribe is a silent no-op (does not throw)", async () => {
+  const bus = createEventBus({ logger: recordingLogger() });
+  const id = makeTaskId("task_post_unsub");
+  const seen: TaskEvent[] = [];
+  const sub = bus.subscribe(id, (event) => seen.push(event));
+  sub.unsubscribe();
+  // Publish-while-closed exercises the `if (closed) return` guard inside
+  // `enqueue` indirectly: although the outer subscribe layer removes the
+  // subscriber from the set on unsubscribe (so `publish` skips it), the
+  // inner guard is a defense in depth that we exercise here by holding a
+  // reference to the inner subscriber via a fresh subscribe call that is
+  // closed mid-publish via close().
+  bus.publish(fakeEvent(id));
+  await flush();
+  assertEquals(seen.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Sanity: assertRejects re-export consumed (keeps the import meaningful in
+// the linter's eyes if tests evolve to test rejected promises explicitly).
+// ---------------------------------------------------------------------------
+
+Deno.test("assertRejects is reachable for future async error assertions", async () => {
+  await assertRejects(() => Promise.reject(new Error("x")), Error, "x");
+});


### PR DESCRIPTION
## Summary

Implements [#8](https://github.com/koraytaylan/makina/issues/8) — typed pub/sub for task events with bounded backpressure.

## Linked issue

Closes #8

## Definition of Done

- [x] JSDoc on every exported symbol; `deno doc --lint` green.
- [x] Wildcard fan-out, unsubscribe, slow-consumer drop all covered.
- [x] Handler throws do not poison the bus.
- [x] `deno task ci` is green.

## References

- Plan §Architecture (EventBus).
