### PR TITLE
feat(#6): WorktreeManager with bare-clone and per-task worktrees

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,21 +1,52 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/async@1": "1.3.0",
+    "jsr:@std/cli@1": "1.0.29",
     "jsr:@std/fmt@^1.0.5": "1.0.10",
     "jsr:@std/fs@^1.0.11": "1.0.23",
+    "jsr:@std/fs@^1.0.23": "1.0.23",
+    "jsr:@std/internal@^1.0.12": "1.0.13",
+    "jsr:@std/internal@^1.0.13": "1.0.13",
     "jsr:@std/io@~0.225.2": "0.225.3",
     "jsr:@std/log@0.224": "0.224.14",
+    "jsr:@std/path@1": "1.1.4",
+    "jsr:@std/path@^1.1.4": "1.1.4",
+    "jsr:@std/testing@1": "1.0.18",
+    "npm:@anthropic-ai/claude-agent-sdk@*": "0.2.119_zod@3.25.76",
+    "npm:@octokit/auth-app@7": "7.2.2",
+    "npm:@octokit/core@5": "5.2.2",
     "npm:@types/react@18": "18.3.28",
     "npm:ink@5": "5.2.1_@types+react@18.3.28_react@18.3.1",
     "npm:react@18": "18.3.1",
     "npm:zod@3": "3.25.76"
   },
   "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/async@1.3.0": {
+      "integrity": "80485538a4f7baaa46bfe2246168069e02ed142b9f9079cd164f43bb060ad9e9"
+    },
+    "@std/cli@1.0.29": {
+      "integrity": "fa4ef29130baa834d8a13b7d138240c3a2fcfba740bfb7afa646a360a15ec84f"
+    },
     "@std/fmt@1.0.10": {
       "integrity": "90dfba288802ac6de82fb31d0917eb9e4450b9925b954d5e51fc29ac07419db5"
     },
     "@std/fs@1.0.23": {
-      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37"
+      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
+      "dependencies": [
+        "jsr:@std/path@^1.1.4"
+      ]
+    },
+    "@std/internal@1.0.13": {
+      "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
     },
     "@std/io@0.225.3": {
       "integrity": "27b07b591384d12d7b568f39e61dff966b8230559122df1e9fd11cc068f7ddd1"
@@ -24,8 +55,23 @@
       "integrity": "257f7adceee3b53bb2bc86c7242e7d1bc59729e57d4981c4a7e5b876c808f05e",
       "dependencies": [
         "jsr:@std/fmt",
-        "jsr:@std/fs",
+        "jsr:@std/fs@^1.0.11",
         "jsr:@std/io"
+      ]
+    },
+    "@std/path@1.1.4": {
+      "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/testing@1.0.18": {
+      "integrity": "d3152f57b11666bf6358d0e127c7e3488e91178b0c2d8fbf0793e1c53cd13cb1",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.19",
+        "jsr:@std/fs@^1.0.23",
+        "jsr:@std/internal@^1.0.13",
+        "jsr:@std/path@^1.1.4"
       ]
     }
   },
@@ -37,6 +83,248 @@
         "is-fullwidth-code-point@4.0.0"
       ]
     },
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.119": {
+      "integrity": "sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.119": {
+      "integrity": "sha512-9Aj8g3ELsmZuOFg17TCkikeg/Wt2ucVT8hOOPQUatzLd7BKhydrHLA0RP42nBpWECO1B/n/mPdQ4iS/LS3s2Fg==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.119": {
+      "integrity": "sha512-IPGWgtz+gGnD7fxKAvSf913EUT/lYBTBE8EZ7lh3+x5ZP2859LWLmrCm053Lf3nMWo/CWikZsVPwkDVwpz6tIQ==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.119": {
+      "integrity": "sha512-v3o464XkiYehp/OKidQQirxdVb+aGSvdJvHF2zH9p33W8M/NC21zwwh4dhwDnKsyrtBIgkt2CcMwzIl30r0OtA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.119": {
+      "integrity": "sha512-QYxFNAe4FFridPkKhGlNcNBJ0TaIygWYyvfI9g4kX0i+RVbresUWuZVkWY06ioJ0fXoixFJ+HNQBMB7dLrIp8Q==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-linux-x64@0.2.119": {
+      "integrity": "sha512-9ePt4ZN+hsqDw4AgS4KtcWIGKfL9Oq28kwkrTER/QAcSrVKxiLonp81cCLzg7Ok/IUJu4Cfd71GZbFv/WE54zw==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.119": {
+      "integrity": "sha512-p/TjcKQvkCYtXGPlR+mdyNwqCmvRcQL34Wtq0yUZ+iqmI/eyCe59IJ3AZrE0EZoqmiAevEYzatPIt9sncC9uxw==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-win32-x64@0.2.119": {
+      "integrity": "sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@anthropic-ai/claude-agent-sdk@0.2.119_zod@3.25.76": {
+      "integrity": "sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA==",
+      "dependencies": [
+        "@anthropic-ai/sdk",
+        "@modelcontextprotocol/sdk",
+        "zod"
+      ],
+      "optionalDependencies": [
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl",
+        "@anthropic-ai/claude-agent-sdk-linux-x64",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64",
+        "@anthropic-ai/claude-agent-sdk-win32-x64"
+      ]
+    },
+    "@anthropic-ai/sdk@0.81.0_zod@3.25.76": {
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
+      "dependencies": [
+        "json-schema-to-ts",
+        "zod"
+      ],
+      "optionalPeers": [
+        "zod"
+      ],
+      "bin": true
+    },
+    "@babel/runtime@7.29.2": {
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
+    },
+    "@hono/node-server@1.19.14_hono@4.12.15": {
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dependencies": [
+        "hono"
+      ]
+    },
+    "@modelcontextprotocol/sdk@1.29.0_zod@3.25.76": {
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dependencies": [
+        "@hono/node-server",
+        "ajv",
+        "ajv-formats",
+        "content-type",
+        "cors",
+        "cross-spawn",
+        "eventsource",
+        "eventsource-parser",
+        "express",
+        "express-rate-limit",
+        "hono",
+        "jose",
+        "json-schema-typed",
+        "pkce-challenge",
+        "raw-body",
+        "zod",
+        "zod-to-json-schema"
+      ]
+    },
+    "@octokit/auth-app@7.2.2": {
+      "integrity": "sha512-p6hJtEyQDCJEPN9ijjhEC/kpFHMHN4Gca9r+8S0S8EJi7NaWftaEmexjxxpT1DFBeJpN4u/5RE22ArnyypupJw==",
+      "dependencies": [
+        "@octokit/auth-oauth-app",
+        "@octokit/auth-oauth-user",
+        "@octokit/request@9.2.4",
+        "@octokit/request-error@6.1.8",
+        "@octokit/types@14.1.0",
+        "toad-cache",
+        "universal-github-app-jwt",
+        "universal-user-agent@7.0.3"
+      ]
+    },
+    "@octokit/auth-oauth-app@8.1.4": {
+      "integrity": "sha512-71iBa5SflSXcclk/OL3lJzdt4iFs56OJdpBGEBl1wULp7C58uiswZLV6TdRaiAzHP1LT8ezpbHlKuxADb+4NkQ==",
+      "dependencies": [
+        "@octokit/auth-oauth-device",
+        "@octokit/auth-oauth-user",
+        "@octokit/request@9.2.4",
+        "@octokit/types@14.1.0",
+        "universal-user-agent@7.0.3"
+      ]
+    },
+    "@octokit/auth-oauth-device@7.1.5": {
+      "integrity": "sha512-lR00+k7+N6xeECj0JuXeULQ2TSBB/zjTAmNF2+vyGPDEFx1dgk1hTDmL13MjbSmzusuAmuJD8Pu39rjp9jH6yw==",
+      "dependencies": [
+        "@octokit/oauth-methods",
+        "@octokit/request@9.2.4",
+        "@octokit/types@14.1.0",
+        "universal-user-agent@7.0.3"
+      ]
+    },
+    "@octokit/auth-oauth-user@5.1.6": {
+      "integrity": "sha512-/R8vgeoulp7rJs+wfJ2LtXEVC7pjQTIqDab7wPKwVG6+2v/lUnCOub6vaHmysQBbb45FknM3tbHW8TOVqYHxCw==",
+      "dependencies": [
+        "@octokit/auth-oauth-device",
+        "@octokit/oauth-methods",
+        "@octokit/request@9.2.4",
+        "@octokit/types@14.1.0",
+        "universal-user-agent@7.0.3"
+      ]
+    },
+    "@octokit/auth-token@4.0.0": {
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="
+    },
+    "@octokit/core@5.2.2": {
+      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+      "dependencies": [
+        "@octokit/auth-token",
+        "@octokit/graphql",
+        "@octokit/request@8.4.1",
+        "@octokit/request-error@5.1.1",
+        "@octokit/types@13.10.0",
+        "before-after-hook",
+        "universal-user-agent@6.0.1"
+      ]
+    },
+    "@octokit/endpoint@10.1.4": {
+      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
+      "dependencies": [
+        "@octokit/types@14.1.0",
+        "universal-user-agent@7.0.3"
+      ]
+    },
+    "@octokit/endpoint@9.0.6": {
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "dependencies": [
+        "@octokit/types@13.10.0",
+        "universal-user-agent@6.0.1"
+      ]
+    },
+    "@octokit/graphql@7.1.1": {
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "dependencies": [
+        "@octokit/request@8.4.1",
+        "@octokit/types@13.10.0",
+        "universal-user-agent@6.0.1"
+      ]
+    },
+    "@octokit/oauth-authorization-url@7.1.1": {
+      "integrity": "sha512-ooXV8GBSabSWyhLUowlMIVd9l1s2nsOGQdlP2SQ4LnkEsGXzeCvbSbCPdZThXhEFzleGPwbapT0Sb+YhXRyjCA=="
+    },
+    "@octokit/oauth-methods@5.1.5": {
+      "integrity": "sha512-Ev7K8bkYrYLhoOSZGVAGsLEscZQyq7XQONCBBAl2JdMg7IT3PQn/y8P0KjloPoYpI5UylqYrLeUcScaYWXwDvw==",
+      "dependencies": [
+        "@octokit/oauth-authorization-url",
+        "@octokit/request@9.2.4",
+        "@octokit/request-error@6.1.8",
+        "@octokit/types@14.1.0"
+      ]
+    },
+    "@octokit/openapi-types@24.2.0": {
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="
+    },
+    "@octokit/openapi-types@25.1.0": {
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA=="
+    },
+    "@octokit/request-error@5.1.1": {
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "dependencies": [
+        "@octokit/types@13.10.0",
+        "deprecation",
+        "once"
+      ]
+    },
+    "@octokit/request-error@6.1.8": {
+      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
+      "dependencies": [
+        "@octokit/types@14.1.0"
+      ]
+    },
+    "@octokit/request@8.4.1": {
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "dependencies": [
+        "@octokit/endpoint@9.0.6",
+        "@octokit/request-error@5.1.1",
+        "@octokit/types@13.10.0",
+        "universal-user-agent@6.0.1"
+      ]
+    },
+    "@octokit/request@9.2.4": {
+      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
+      "dependencies": [
+        "@octokit/endpoint@10.1.4",
+        "@octokit/request-error@6.1.8",
+        "@octokit/types@14.1.0",
+        "fast-content-type-parse",
+        "universal-user-agent@7.0.3"
+      ]
+    },
+    "@octokit/types@13.10.0": {
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dependencies": [
+        "@octokit/openapi-types@24.2.0"
+      ]
+    },
+    "@octokit/types@14.1.0": {
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "dependencies": [
+        "@octokit/openapi-types@25.1.0"
+      ]
+    },
     "@types/prop-types@15.7.15": {
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="
     },
@@ -45,6 +333,31 @@
       "dependencies": [
         "@types/prop-types",
         "csstype"
+      ]
+    },
+    "accepts@2.0.0": {
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dependencies": [
+        "mime-types",
+        "negotiator"
+      ]
+    },
+    "ajv-formats@3.0.1_ajv@8.20.0": {
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dependencies": [
+        "ajv"
+      ],
+      "optionalPeers": [
+        "ajv"
+      ]
+    },
+    "ajv@8.20.0": {
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dependencies": [
+        "fast-deep-equal",
+        "fast-uri",
+        "json-schema-traverse",
+        "require-from-string"
       ]
     },
     "ansi-escapes@7.3.0": {
@@ -61,6 +374,40 @@
     },
     "auto-bind@5.0.1": {
       "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="
+    },
+    "before-after-hook@2.2.3": {
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+    },
+    "body-parser@2.2.2": {
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dependencies": [
+        "bytes",
+        "content-type",
+        "debug",
+        "http-errors",
+        "iconv-lite",
+        "on-finished",
+        "qs",
+        "raw-body",
+        "type-is"
+      ]
+    },
+    "bytes@3.1.2": {
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+    },
+    "call-bind-apply-helpers@1.0.2": {
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": [
+        "es-errors",
+        "function-bind"
+      ]
+    },
+    "call-bound@1.0.4": {
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "get-intrinsic"
+      ]
     },
     "chalk@5.6.2": {
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
@@ -87,29 +434,234 @@
         "convert-to-spaces"
       ]
     },
+    "content-disposition@1.1.0": {
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="
+    },
+    "content-type@1.0.5": {
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
+    },
     "convert-to-spaces@2.0.1": {
       "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="
+    },
+    "cookie-signature@1.2.2": {
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
+    },
+    "cookie@0.7.2": {
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
+    },
+    "cors@2.8.6": {
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dependencies": [
+        "object-assign",
+        "vary"
+      ]
+    },
+    "cross-spawn@7.0.6": {
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dependencies": [
+        "path-key",
+        "shebang-command",
+        "which"
+      ]
     },
     "csstype@3.2.3": {
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
+    "debug@4.4.3": {
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "depd@2.0.0": {
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+    },
+    "deprecation@2.3.1": {
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "dunder-proto@1.0.1": {
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-errors",
+        "gopd"
+      ]
+    },
+    "ee-first@1.1.1": {
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
     "emoji-regex@10.6.0": {
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
+    },
+    "encodeurl@2.0.0": {
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
     },
     "environment@1.1.0": {
       "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="
     },
+    "es-define-property@1.0.1": {
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors@1.3.0": {
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms@1.1.1": {
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": [
+        "es-errors"
+      ]
+    },
     "es-toolkit@1.46.0": {
       "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA=="
+    },
+    "escape-html@1.0.3": {
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "escape-string-regexp@2.0.0": {
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
     },
+    "etag@1.8.1": {
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+    },
+    "eventsource-parser@3.0.8": {
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="
+    },
+    "eventsource@3.0.7": {
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dependencies": [
+        "eventsource-parser"
+      ]
+    },
+    "express-rate-limit@8.4.1_express@5.2.1": {
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "dependencies": [
+        "express",
+        "ip-address"
+      ]
+    },
+    "express@5.2.1": {
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dependencies": [
+        "accepts",
+        "body-parser",
+        "content-disposition",
+        "content-type",
+        "cookie",
+        "cookie-signature",
+        "debug",
+        "depd",
+        "encodeurl",
+        "escape-html",
+        "etag",
+        "finalhandler",
+        "fresh",
+        "http-errors",
+        "merge-descriptors",
+        "mime-types",
+        "on-finished",
+        "once",
+        "parseurl",
+        "proxy-addr",
+        "qs",
+        "range-parser",
+        "router",
+        "send",
+        "serve-static",
+        "statuses",
+        "type-is",
+        "vary"
+      ]
+    },
+    "fast-content-type-parse@2.0.1": {
+      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q=="
+    },
+    "fast-deep-equal@3.1.3": {
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-uri@3.1.0": {
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
+    },
+    "finalhandler@2.1.1": {
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dependencies": [
+        "debug",
+        "encodeurl",
+        "escape-html",
+        "on-finished",
+        "parseurl",
+        "statuses"
+      ]
+    },
+    "forwarded@0.2.0": {
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
+    "fresh@2.0.0": {
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="
+    },
+    "function-bind@1.1.2": {
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
     "get-east-asian-width@1.5.0": {
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="
     },
+    "get-intrinsic@1.3.0": {
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "es-errors",
+        "es-object-atoms",
+        "function-bind",
+        "get-proto",
+        "gopd",
+        "has-symbols",
+        "hasown",
+        "math-intrinsics"
+      ]
+    },
+    "get-proto@1.0.1": {
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": [
+        "dunder-proto",
+        "es-object-atoms"
+      ]
+    },
+    "gopd@1.2.0": {
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-symbols@1.1.0": {
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "hasown@2.0.3": {
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dependencies": [
+        "function-bind"
+      ]
+    },
+    "hono@4.12.15": {
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg=="
+    },
+    "http-errors@2.0.1": {
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dependencies": [
+        "depd",
+        "inherits",
+        "setprototypeof",
+        "statuses",
+        "toidentifier"
+      ]
+    },
+    "iconv-lite@0.7.2": {
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dependencies": [
+        "safer-buffer"
+      ]
+    },
     "indent-string@5.0.0": {
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
+    },
+    "inherits@2.0.4": {
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ink@5.2.1_@types+react@18.3.28_react@18.3.1": {
       "integrity": "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==",
@@ -145,6 +697,12 @@
         "@types/react"
       ]
     },
+    "ip-address@10.1.0": {
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="
+    },
+    "ipaddr.js@1.9.1": {
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
     "is-fullwidth-code-point@4.0.0": {
       "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="
     },
@@ -158,8 +716,30 @@
       "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
       "bin": true
     },
+    "is-promise@4.0.0": {
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+    },
+    "isexe@2.0.0": {
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "jose@6.2.2": {
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="
+    },
     "js-tokens@4.0.0": {
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "json-schema-to-ts@3.1.1": {
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dependencies": [
+        "@babel/runtime",
+        "ts-algebra"
+      ]
+    },
+    "json-schema-traverse@1.0.0": {
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "json-schema-typed@8.0.2": {
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
     },
     "loose-envify@1.4.0": {
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
@@ -168,8 +748,50 @@
       ],
       "bin": true
     },
+    "math-intrinsics@1.1.0": {
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "media-typer@1.1.0": {
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
+    },
+    "merge-descriptors@2.0.0": {
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="
+    },
+    "mime-db@1.54.0": {
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+    },
+    "mime-types@3.0.2": {
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dependencies": [
+        "mime-db"
+      ]
+    },
     "mimic-fn@2.1.0": {
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "negotiator@1.0.0": {
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
+    },
+    "object-assign@4.1.1": {
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
+    "object-inspect@1.13.4": {
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
+    },
+    "on-finished@2.4.1": {
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": [
+        "ee-first"
+      ]
+    },
+    "once@1.4.0": {
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": [
+        "wrappy"
+      ]
     },
     "onetime@5.1.2": {
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
@@ -177,8 +799,45 @@
         "mimic-fn"
       ]
     },
+    "parseurl@1.3.3": {
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
     "patch-console@2.0.0": {
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="
+    },
+    "path-key@3.1.1": {
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
+    "path-to-regexp@8.4.2": {
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="
+    },
+    "pkce-challenge@5.0.1": {
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="
+    },
+    "proxy-addr@2.0.7": {
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": [
+        "forwarded",
+        "ipaddr.js"
+      ]
+    },
+    "qs@6.15.1": {
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dependencies": [
+        "side-channel"
+      ]
+    },
+    "range-parser@1.2.1": {
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body@3.0.2": {
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dependencies": [
+        "bytes",
+        "http-errors",
+        "iconv-lite",
+        "unpipe"
+      ]
     },
     "react-reconciler@0.29.2_react@18.3.1": {
       "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
@@ -194,6 +853,9 @@
         "loose-envify"
       ]
     },
+    "require-from-string@2.0.2": {
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "restore-cursor@4.0.0": {
       "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
       "dependencies": [
@@ -201,10 +863,96 @@
         "signal-exit"
       ]
     },
+    "router@2.2.0": {
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dependencies": [
+        "debug",
+        "depd",
+        "is-promise",
+        "parseurl",
+        "path-to-regexp"
+      ]
+    },
+    "safer-buffer@2.1.2": {
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "scheduler@0.23.2": {
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dependencies": [
         "loose-envify"
+      ]
+    },
+    "send@1.2.1": {
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dependencies": [
+        "debug",
+        "encodeurl",
+        "escape-html",
+        "etag",
+        "fresh",
+        "http-errors",
+        "mime-types",
+        "ms",
+        "on-finished",
+        "range-parser",
+        "statuses"
+      ]
+    },
+    "serve-static@2.2.1": {
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dependencies": [
+        "encodeurl",
+        "escape-html",
+        "parseurl",
+        "send"
+      ]
+    },
+    "setprototypeof@1.2.0": {
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "shebang-command@2.0.0": {
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": [
+        "shebang-regex"
+      ]
+    },
+    "shebang-regex@3.0.0": {
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+    },
+    "side-channel-list@1.0.1": {
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dependencies": [
+        "es-errors",
+        "object-inspect"
+      ]
+    },
+    "side-channel-map@1.0.1": {
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "get-intrinsic",
+        "object-inspect"
+      ]
+    },
+    "side-channel-weakmap@1.0.2": {
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "get-intrinsic",
+        "object-inspect",
+        "side-channel-map"
+      ]
+    },
+    "side-channel@1.1.0": {
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dependencies": [
+        "es-errors",
+        "object-inspect",
+        "side-channel-list",
+        "side-channel-map",
+        "side-channel-weakmap"
       ]
     },
     "signal-exit@3.0.7": {
@@ -230,6 +978,9 @@
         "escape-string-regexp"
       ]
     },
+    "statuses@2.0.2": {
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
+    },
     "string-width@7.2.0": {
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dependencies": [
@@ -244,8 +995,47 @@
         "ansi-regex"
       ]
     },
+    "toad-cache@3.7.0": {
+      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="
+    },
+    "toidentifier@1.0.1": {
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+    },
+    "ts-algebra@2.0.0": {
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="
+    },
     "type-fest@4.41.0": {
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="
+    },
+    "type-is@2.0.1": {
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dependencies": [
+        "content-type",
+        "media-typer",
+        "mime-types"
+      ]
+    },
+    "universal-github-app-jwt@2.2.2": {
+      "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw=="
+    },
+    "universal-user-agent@6.0.1": {
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
+    },
+    "universal-user-agent@7.0.3": {
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="
+    },
+    "unpipe@1.0.0": {
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
+    },
+    "vary@1.1.2": {
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    },
+    "which@2.0.2": {
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": [
+        "isexe"
+      ],
+      "bin": true
     },
     "widest-line@5.0.0": {
       "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
@@ -261,11 +1051,20 @@
         "strip-ansi"
       ]
     },
+    "wrappy@1.0.2": {
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
     "ws@8.20.0": {
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="
     },
     "yoga-layout@3.2.1": {
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="
+    },
+    "zod-to-json-schema@3.25.2_zod@3.25.76": {
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dependencies": [
+        "zod"
+      ]
     },
     "zod@3.25.76": {
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="

--- a/deno.lock
+++ b/deno.lock
@@ -1,51 +1,21 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@std/assert@1": "1.0.19",
-    "jsr:@std/assert@^1.0.19": "1.0.19",
-    "jsr:@std/async@1": "1.3.0",
-    "jsr:@std/cli@1": "1.0.29",
     "jsr:@std/fmt@^1.0.5": "1.0.10",
     "jsr:@std/fs@^1.0.11": "1.0.23",
-    "jsr:@std/fs@^1.0.23": "1.0.23",
-    "jsr:@std/internal@^1.0.12": "1.0.13",
-    "jsr:@std/internal@^1.0.13": "1.0.13",
     "jsr:@std/io@~0.225.2": "0.225.3",
     "jsr:@std/log@0.224": "0.224.14",
-    "jsr:@std/path@^1.1.4": "1.1.4",
-    "jsr:@std/testing@1": "1.0.18",
-    "npm:@anthropic-ai/claude-agent-sdk@*": "0.2.119_zod@3.25.76",
-    "npm:@octokit/auth-app@7": "7.2.2",
-    "npm:@octokit/core@5": "5.2.2",
     "npm:@types/react@18": "18.3.28",
     "npm:ink@5": "5.2.1_@types+react@18.3.28_react@18.3.1",
     "npm:react@18": "18.3.1",
     "npm:zod@3": "3.25.76"
   },
   "jsr": {
-    "@std/assert@1.0.19": {
-      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
-      "dependencies": [
-        "jsr:@std/internal@^1.0.12"
-      ]
-    },
-    "@std/async@1.3.0": {
-      "integrity": "80485538a4f7baaa46bfe2246168069e02ed142b9f9079cd164f43bb060ad9e9"
-    },
-    "@std/cli@1.0.29": {
-      "integrity": "fa4ef29130baa834d8a13b7d138240c3a2fcfba740bfb7afa646a360a15ec84f"
-    },
     "@std/fmt@1.0.10": {
       "integrity": "90dfba288802ac6de82fb31d0917eb9e4450b9925b954d5e51fc29ac07419db5"
     },
     "@std/fs@1.0.23": {
-      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
-      "dependencies": [
-        "jsr:@std/path"
-      ]
-    },
-    "@std/internal@1.0.13": {
-      "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
+      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37"
     },
     "@std/io@0.225.3": {
       "integrity": "27b07b591384d12d7b568f39e61dff966b8230559122df1e9fd11cc068f7ddd1"
@@ -54,23 +24,8 @@
       "integrity": "257f7adceee3b53bb2bc86c7242e7d1bc59729e57d4981c4a7e5b876c808f05e",
       "dependencies": [
         "jsr:@std/fmt",
-        "jsr:@std/fs@^1.0.11",
+        "jsr:@std/fs",
         "jsr:@std/io"
-      ]
-    },
-    "@std/path@1.1.4": {
-      "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
-      "dependencies": [
-        "jsr:@std/internal@^1.0.12"
-      ]
-    },
-    "@std/testing@1.0.18": {
-      "integrity": "d3152f57b11666bf6358d0e127c7e3488e91178b0c2d8fbf0793e1c53cd13cb1",
-      "dependencies": [
-        "jsr:@std/assert@^1.0.19",
-        "jsr:@std/fs@^1.0.23",
-        "jsr:@std/internal@^1.0.13",
-        "jsr:@std/path"
       ]
     }
   },
@@ -82,248 +37,6 @@
         "is-fullwidth-code-point@4.0.0"
       ]
     },
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.119": {
-      "integrity": "sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw==",
-      "os": ["darwin"],
-      "cpu": ["arm64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.119": {
-      "integrity": "sha512-9Aj8g3ELsmZuOFg17TCkikeg/Wt2ucVT8hOOPQUatzLd7BKhydrHLA0RP42nBpWECO1B/n/mPdQ4iS/LS3s2Fg==",
-      "os": ["darwin"],
-      "cpu": ["x64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.119": {
-      "integrity": "sha512-IPGWgtz+gGnD7fxKAvSf913EUT/lYBTBE8EZ7lh3+x5ZP2859LWLmrCm053Lf3nMWo/CWikZsVPwkDVwpz6tIQ==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.119": {
-      "integrity": "sha512-v3o464XkiYehp/OKidQQirxdVb+aGSvdJvHF2zH9p33W8M/NC21zwwh4dhwDnKsyrtBIgkt2CcMwzIl30r0OtA==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.119": {
-      "integrity": "sha512-QYxFNAe4FFridPkKhGlNcNBJ0TaIygWYyvfI9g4kX0i+RVbresUWuZVkWY06ioJ0fXoixFJ+HNQBMB7dLrIp8Q==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-linux-x64@0.2.119": {
-      "integrity": "sha512-9ePt4ZN+hsqDw4AgS4KtcWIGKfL9Oq28kwkrTER/QAcSrVKxiLonp81cCLzg7Ok/IUJu4Cfd71GZbFv/WE54zw==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.119": {
-      "integrity": "sha512-p/TjcKQvkCYtXGPlR+mdyNwqCmvRcQL34Wtq0yUZ+iqmI/eyCe59IJ3AZrE0EZoqmiAevEYzatPIt9sncC9uxw==",
-      "os": ["win32"],
-      "cpu": ["arm64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-win32-x64@0.2.119": {
-      "integrity": "sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA==",
-      "os": ["win32"],
-      "cpu": ["x64"]
-    },
-    "@anthropic-ai/claude-agent-sdk@0.2.119_zod@3.25.76": {
-      "integrity": "sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA==",
-      "dependencies": [
-        "@anthropic-ai/sdk",
-        "@modelcontextprotocol/sdk",
-        "zod"
-      ],
-      "optionalDependencies": [
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl",
-        "@anthropic-ai/claude-agent-sdk-linux-x64",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64",
-        "@anthropic-ai/claude-agent-sdk-win32-x64"
-      ]
-    },
-    "@anthropic-ai/sdk@0.81.0_zod@3.25.76": {
-      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
-      "dependencies": [
-        "json-schema-to-ts",
-        "zod"
-      ],
-      "optionalPeers": [
-        "zod"
-      ],
-      "bin": true
-    },
-    "@babel/runtime@7.29.2": {
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
-    },
-    "@hono/node-server@1.19.14_hono@4.12.15": {
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
-      "dependencies": [
-        "hono"
-      ]
-    },
-    "@modelcontextprotocol/sdk@1.29.0_zod@3.25.76": {
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
-      "dependencies": [
-        "@hono/node-server",
-        "ajv",
-        "ajv-formats",
-        "content-type",
-        "cors",
-        "cross-spawn",
-        "eventsource",
-        "eventsource-parser",
-        "express",
-        "express-rate-limit",
-        "hono",
-        "jose",
-        "json-schema-typed",
-        "pkce-challenge",
-        "raw-body",
-        "zod",
-        "zod-to-json-schema"
-      ]
-    },
-    "@octokit/auth-app@7.2.2": {
-      "integrity": "sha512-p6hJtEyQDCJEPN9ijjhEC/kpFHMHN4Gca9r+8S0S8EJi7NaWftaEmexjxxpT1DFBeJpN4u/5RE22ArnyypupJw==",
-      "dependencies": [
-        "@octokit/auth-oauth-app",
-        "@octokit/auth-oauth-user",
-        "@octokit/request@9.2.4",
-        "@octokit/request-error@6.1.8",
-        "@octokit/types@14.1.0",
-        "toad-cache",
-        "universal-github-app-jwt",
-        "universal-user-agent@7.0.3"
-      ]
-    },
-    "@octokit/auth-oauth-app@8.1.4": {
-      "integrity": "sha512-71iBa5SflSXcclk/OL3lJzdt4iFs56OJdpBGEBl1wULp7C58uiswZLV6TdRaiAzHP1LT8ezpbHlKuxADb+4NkQ==",
-      "dependencies": [
-        "@octokit/auth-oauth-device",
-        "@octokit/auth-oauth-user",
-        "@octokit/request@9.2.4",
-        "@octokit/types@14.1.0",
-        "universal-user-agent@7.0.3"
-      ]
-    },
-    "@octokit/auth-oauth-device@7.1.5": {
-      "integrity": "sha512-lR00+k7+N6xeECj0JuXeULQ2TSBB/zjTAmNF2+vyGPDEFx1dgk1hTDmL13MjbSmzusuAmuJD8Pu39rjp9jH6yw==",
-      "dependencies": [
-        "@octokit/oauth-methods",
-        "@octokit/request@9.2.4",
-        "@octokit/types@14.1.0",
-        "universal-user-agent@7.0.3"
-      ]
-    },
-    "@octokit/auth-oauth-user@5.1.6": {
-      "integrity": "sha512-/R8vgeoulp7rJs+wfJ2LtXEVC7pjQTIqDab7wPKwVG6+2v/lUnCOub6vaHmysQBbb45FknM3tbHW8TOVqYHxCw==",
-      "dependencies": [
-        "@octokit/auth-oauth-device",
-        "@octokit/oauth-methods",
-        "@octokit/request@9.2.4",
-        "@octokit/types@14.1.0",
-        "universal-user-agent@7.0.3"
-      ]
-    },
-    "@octokit/auth-token@4.0.0": {
-      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="
-    },
-    "@octokit/core@5.2.2": {
-      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
-      "dependencies": [
-        "@octokit/auth-token",
-        "@octokit/graphql",
-        "@octokit/request@8.4.1",
-        "@octokit/request-error@5.1.1",
-        "@octokit/types@13.10.0",
-        "before-after-hook",
-        "universal-user-agent@6.0.1"
-      ]
-    },
-    "@octokit/endpoint@10.1.4": {
-      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
-      "dependencies": [
-        "@octokit/types@14.1.0",
-        "universal-user-agent@7.0.3"
-      ]
-    },
-    "@octokit/endpoint@9.0.6": {
-      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
-      "dependencies": [
-        "@octokit/types@13.10.0",
-        "universal-user-agent@6.0.1"
-      ]
-    },
-    "@octokit/graphql@7.1.1": {
-      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
-      "dependencies": [
-        "@octokit/request@8.4.1",
-        "@octokit/types@13.10.0",
-        "universal-user-agent@6.0.1"
-      ]
-    },
-    "@octokit/oauth-authorization-url@7.1.1": {
-      "integrity": "sha512-ooXV8GBSabSWyhLUowlMIVd9l1s2nsOGQdlP2SQ4LnkEsGXzeCvbSbCPdZThXhEFzleGPwbapT0Sb+YhXRyjCA=="
-    },
-    "@octokit/oauth-methods@5.1.5": {
-      "integrity": "sha512-Ev7K8bkYrYLhoOSZGVAGsLEscZQyq7XQONCBBAl2JdMg7IT3PQn/y8P0KjloPoYpI5UylqYrLeUcScaYWXwDvw==",
-      "dependencies": [
-        "@octokit/oauth-authorization-url",
-        "@octokit/request@9.2.4",
-        "@octokit/request-error@6.1.8",
-        "@octokit/types@14.1.0"
-      ]
-    },
-    "@octokit/openapi-types@24.2.0": {
-      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="
-    },
-    "@octokit/openapi-types@25.1.0": {
-      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA=="
-    },
-    "@octokit/request-error@5.1.1": {
-      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
-      "dependencies": [
-        "@octokit/types@13.10.0",
-        "deprecation",
-        "once"
-      ]
-    },
-    "@octokit/request-error@6.1.8": {
-      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
-      "dependencies": [
-        "@octokit/types@14.1.0"
-      ]
-    },
-    "@octokit/request@8.4.1": {
-      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
-      "dependencies": [
-        "@octokit/endpoint@9.0.6",
-        "@octokit/request-error@5.1.1",
-        "@octokit/types@13.10.0",
-        "universal-user-agent@6.0.1"
-      ]
-    },
-    "@octokit/request@9.2.4": {
-      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
-      "dependencies": [
-        "@octokit/endpoint@10.1.4",
-        "@octokit/request-error@6.1.8",
-        "@octokit/types@14.1.0",
-        "fast-content-type-parse",
-        "universal-user-agent@7.0.3"
-      ]
-    },
-    "@octokit/types@13.10.0": {
-      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
-      "dependencies": [
-        "@octokit/openapi-types@24.2.0"
-      ]
-    },
-    "@octokit/types@14.1.0": {
-      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
-      "dependencies": [
-        "@octokit/openapi-types@25.1.0"
-      ]
-    },
     "@types/prop-types@15.7.15": {
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="
     },
@@ -332,31 +45,6 @@
       "dependencies": [
         "@types/prop-types",
         "csstype"
-      ]
-    },
-    "accepts@2.0.0": {
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "dependencies": [
-        "mime-types",
-        "negotiator"
-      ]
-    },
-    "ajv-formats@3.0.1_ajv@8.20.0": {
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dependencies": [
-        "ajv"
-      ],
-      "optionalPeers": [
-        "ajv"
-      ]
-    },
-    "ajv@8.20.0": {
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dependencies": [
-        "fast-deep-equal",
-        "fast-uri",
-        "json-schema-traverse",
-        "require-from-string"
       ]
     },
     "ansi-escapes@7.3.0": {
@@ -373,40 +61,6 @@
     },
     "auto-bind@5.0.1": {
       "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="
-    },
-    "before-after-hook@2.2.3": {
-      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
-    },
-    "body-parser@2.2.2": {
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
-      "dependencies": [
-        "bytes",
-        "content-type",
-        "debug",
-        "http-errors",
-        "iconv-lite",
-        "on-finished",
-        "qs",
-        "raw-body",
-        "type-is"
-      ]
-    },
-    "bytes@3.1.2": {
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
-    },
-    "call-bind-apply-helpers@1.0.2": {
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dependencies": [
-        "es-errors",
-        "function-bind"
-      ]
-    },
-    "call-bound@1.0.4": {
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dependencies": [
-        "call-bind-apply-helpers",
-        "get-intrinsic"
-      ]
     },
     "chalk@5.6.2": {
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
@@ -433,234 +87,29 @@
         "convert-to-spaces"
       ]
     },
-    "content-disposition@1.1.0": {
-      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="
-    },
-    "content-type@1.0.5": {
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
-    },
     "convert-to-spaces@2.0.1": {
       "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="
-    },
-    "cookie-signature@1.2.2": {
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
-    },
-    "cookie@0.7.2": {
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
-    },
-    "cors@2.8.6": {
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "dependencies": [
-        "object-assign",
-        "vary"
-      ]
-    },
-    "cross-spawn@7.0.6": {
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dependencies": [
-        "path-key",
-        "shebang-command",
-        "which"
-      ]
     },
     "csstype@3.2.3": {
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
-    "debug@4.4.3": {
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dependencies": [
-        "ms"
-      ]
-    },
-    "depd@2.0.0": {
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-    },
-    "deprecation@2.3.1": {
-      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
-    },
-    "dunder-proto@1.0.1": {
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dependencies": [
-        "call-bind-apply-helpers",
-        "es-errors",
-        "gopd"
-      ]
-    },
-    "ee-first@1.1.1": {
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
-    },
     "emoji-regex@10.6.0": {
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
-    },
-    "encodeurl@2.0.0": {
-      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
     },
     "environment@1.1.0": {
       "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="
     },
-    "es-define-property@1.0.1": {
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
-    },
-    "es-errors@1.3.0": {
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-    },
-    "es-object-atoms@1.1.1": {
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dependencies": [
-        "es-errors"
-      ]
-    },
     "es-toolkit@1.46.0": {
       "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA=="
-    },
-    "escape-html@1.0.3": {
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "escape-string-regexp@2.0.0": {
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
     },
-    "etag@1.8.1": {
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
-    },
-    "eventsource-parser@3.0.8": {
-      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="
-    },
-    "eventsource@3.0.7": {
-      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-      "dependencies": [
-        "eventsource-parser"
-      ]
-    },
-    "express-rate-limit@8.4.1_express@5.2.1": {
-      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
-      "dependencies": [
-        "express",
-        "ip-address"
-      ]
-    },
-    "express@5.2.1": {
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "dependencies": [
-        "accepts",
-        "body-parser",
-        "content-disposition",
-        "content-type",
-        "cookie",
-        "cookie-signature",
-        "debug",
-        "depd",
-        "encodeurl",
-        "escape-html",
-        "etag",
-        "finalhandler",
-        "fresh",
-        "http-errors",
-        "merge-descriptors",
-        "mime-types",
-        "on-finished",
-        "once",
-        "parseurl",
-        "proxy-addr",
-        "qs",
-        "range-parser",
-        "router",
-        "send",
-        "serve-static",
-        "statuses",
-        "type-is",
-        "vary"
-      ]
-    },
-    "fast-content-type-parse@2.0.1": {
-      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q=="
-    },
-    "fast-deep-equal@3.1.3": {
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "fast-uri@3.1.0": {
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
-    },
-    "finalhandler@2.1.1": {
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "dependencies": [
-        "debug",
-        "encodeurl",
-        "escape-html",
-        "on-finished",
-        "parseurl",
-        "statuses"
-      ]
-    },
-    "forwarded@0.2.0": {
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
-    },
-    "fresh@2.0.0": {
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="
-    },
-    "function-bind@1.1.2": {
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-    },
     "get-east-asian-width@1.5.0": {
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="
     },
-    "get-intrinsic@1.3.0": {
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dependencies": [
-        "call-bind-apply-helpers",
-        "es-define-property",
-        "es-errors",
-        "es-object-atoms",
-        "function-bind",
-        "get-proto",
-        "gopd",
-        "has-symbols",
-        "hasown",
-        "math-intrinsics"
-      ]
-    },
-    "get-proto@1.0.1": {
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dependencies": [
-        "dunder-proto",
-        "es-object-atoms"
-      ]
-    },
-    "gopd@1.2.0": {
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
-    },
-    "has-symbols@1.1.0": {
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
-    },
-    "hasown@2.0.3": {
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "dependencies": [
-        "function-bind"
-      ]
-    },
-    "hono@4.12.15": {
-      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg=="
-    },
-    "http-errors@2.0.1": {
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "dependencies": [
-        "depd",
-        "inherits",
-        "setprototypeof",
-        "statuses",
-        "toidentifier"
-      ]
-    },
-    "iconv-lite@0.7.2": {
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "dependencies": [
-        "safer-buffer"
-      ]
-    },
     "indent-string@5.0.0": {
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
-    },
-    "inherits@2.0.4": {
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ink@5.2.1_@types+react@18.3.28_react@18.3.1": {
       "integrity": "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==",
@@ -696,12 +145,6 @@
         "@types/react"
       ]
     },
-    "ip-address@10.1.0": {
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="
-    },
-    "ipaddr.js@1.9.1": {
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
-    },
     "is-fullwidth-code-point@4.0.0": {
       "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="
     },
@@ -715,30 +158,8 @@
       "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
       "bin": true
     },
-    "is-promise@4.0.0": {
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
-    },
-    "isexe@2.0.0": {
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-    },
-    "jose@6.2.2": {
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="
-    },
     "js-tokens@4.0.0": {
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
-    "json-schema-to-ts@3.1.1": {
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "dependencies": [
-        "@babel/runtime",
-        "ts-algebra"
-      ]
-    },
-    "json-schema-traverse@1.0.0": {
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "json-schema-typed@8.0.2": {
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
     },
     "loose-envify@1.4.0": {
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
@@ -747,50 +168,8 @@
       ],
       "bin": true
     },
-    "math-intrinsics@1.1.0": {
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
-    },
-    "media-typer@1.1.0": {
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
-    },
-    "merge-descriptors@2.0.0": {
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="
-    },
-    "mime-db@1.54.0": {
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
-    },
-    "mime-types@3.0.2": {
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "dependencies": [
-        "mime-db"
-      ]
-    },
     "mimic-fn@2.1.0": {
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
-    },
-    "ms@2.1.3": {
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "negotiator@1.0.0": {
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
-    },
-    "object-assign@4.1.1": {
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
-    },
-    "object-inspect@1.13.4": {
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
-    },
-    "on-finished@2.4.1": {
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "dependencies": [
-        "ee-first"
-      ]
-    },
-    "once@1.4.0": {
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dependencies": [
-        "wrappy"
-      ]
     },
     "onetime@5.1.2": {
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
@@ -798,45 +177,8 @@
         "mimic-fn"
       ]
     },
-    "parseurl@1.3.3": {
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-    },
     "patch-console@2.0.0": {
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="
-    },
-    "path-key@3.1.1": {
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-    },
-    "path-to-regexp@8.4.2": {
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="
-    },
-    "pkce-challenge@5.0.1": {
-      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="
-    },
-    "proxy-addr@2.0.7": {
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "dependencies": [
-        "forwarded",
-        "ipaddr.js"
-      ]
-    },
-    "qs@6.15.1": {
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "dependencies": [
-        "side-channel"
-      ]
-    },
-    "range-parser@1.2.1": {
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-    },
-    "raw-body@3.0.2": {
-      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "dependencies": [
-        "bytes",
-        "http-errors",
-        "iconv-lite",
-        "unpipe"
-      ]
     },
     "react-reconciler@0.29.2_react@18.3.1": {
       "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
@@ -852,9 +194,6 @@
         "loose-envify"
       ]
     },
-    "require-from-string@2.0.2": {
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
-    },
     "restore-cursor@4.0.0": {
       "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
       "dependencies": [
@@ -862,96 +201,10 @@
         "signal-exit"
       ]
     },
-    "router@2.2.0": {
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "dependencies": [
-        "debug",
-        "depd",
-        "is-promise",
-        "parseurl",
-        "path-to-regexp"
-      ]
-    },
-    "safer-buffer@2.1.2": {
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "scheduler@0.23.2": {
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dependencies": [
         "loose-envify"
-      ]
-    },
-    "send@1.2.1": {
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "dependencies": [
-        "debug",
-        "encodeurl",
-        "escape-html",
-        "etag",
-        "fresh",
-        "http-errors",
-        "mime-types",
-        "ms",
-        "on-finished",
-        "range-parser",
-        "statuses"
-      ]
-    },
-    "serve-static@2.2.1": {
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "dependencies": [
-        "encodeurl",
-        "escape-html",
-        "parseurl",
-        "send"
-      ]
-    },
-    "setprototypeof@1.2.0": {
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
-    },
-    "shebang-command@2.0.0": {
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dependencies": [
-        "shebang-regex"
-      ]
-    },
-    "shebang-regex@3.0.0": {
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-    },
-    "side-channel-list@1.0.1": {
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "dependencies": [
-        "es-errors",
-        "object-inspect"
-      ]
-    },
-    "side-channel-map@1.0.1": {
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dependencies": [
-        "call-bound",
-        "es-errors",
-        "get-intrinsic",
-        "object-inspect"
-      ]
-    },
-    "side-channel-weakmap@1.0.2": {
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dependencies": [
-        "call-bound",
-        "es-errors",
-        "get-intrinsic",
-        "object-inspect",
-        "side-channel-map"
-      ]
-    },
-    "side-channel@1.1.0": {
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dependencies": [
-        "es-errors",
-        "object-inspect",
-        "side-channel-list",
-        "side-channel-map",
-        "side-channel-weakmap"
       ]
     },
     "signal-exit@3.0.7": {
@@ -977,9 +230,6 @@
         "escape-string-regexp"
       ]
     },
-    "statuses@2.0.2": {
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
-    },
     "string-width@7.2.0": {
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dependencies": [
@@ -994,47 +244,8 @@
         "ansi-regex"
       ]
     },
-    "toad-cache@3.7.0": {
-      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="
-    },
-    "toidentifier@1.0.1": {
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
-    },
-    "ts-algebra@2.0.0": {
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="
-    },
     "type-fest@4.41.0": {
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="
-    },
-    "type-is@2.0.1": {
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-      "dependencies": [
-        "content-type",
-        "media-typer",
-        "mime-types"
-      ]
-    },
-    "universal-github-app-jwt@2.2.2": {
-      "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw=="
-    },
-    "universal-user-agent@6.0.1": {
-      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
-    },
-    "universal-user-agent@7.0.3": {
-      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="
-    },
-    "unpipe@1.0.0": {
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
-    },
-    "vary@1.1.2": {
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
-    },
-    "which@2.0.2": {
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dependencies": [
-        "isexe"
-      ],
-      "bin": true
     },
     "widest-line@5.0.0": {
       "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
@@ -1050,20 +261,11 @@
         "strip-ansi"
       ]
     },
-    "wrappy@1.0.2": {
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
     "ws@8.20.0": {
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="
     },
     "yoga-layout@3.2.1": {
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="
-    },
-    "zod-to-json-schema@3.25.2_zod@3.25.76": {
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "dependencies": [
-        "zod"
-      ]
     },
     "zod@3.25.76": {
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="

--- a/src/daemon/worktree-manager.ts
+++ b/src/daemon/worktree-manager.ts
@@ -216,6 +216,14 @@ export function createWorktreeManager(
    * operation per bare clone is in flight at a time. Errors propagate
    * through the chain unchanged but do not poison subsequent calls — the
    * lock only awaits *settlement*, not success.
+   *
+   * Lock entries are removed from the map once the chain quiesces. We
+   * compare-and-swap on the stored sentinel: only the operation whose
+   * sentinel still occupies the slot at settlement time clears it. If a
+   * later caller chained on top, the slot belongs to that newer chain and
+   * must not be touched. This keeps `repoLocks` proportional to *active*
+   * repositories rather than the cumulative set ever seen — important for
+   * long-lived daemons that touch many repos.
    */
   function withRepoLock<T>(repoKey: string, work: () => Promise<T>): Promise<T> {
     const previous = repoLocks.get(repoKey) ?? Promise.resolve();
@@ -223,11 +231,20 @@ export function createWorktreeManager(
       .catch(() => undefined)
       .then(() => work());
     // Store the cleaned promise so a failure on one task doesn't leak
-    // into the next one's `await`.
-    repoLocks.set(
-      repoKey,
-      next.catch(() => undefined),
-    );
+    // into the next one's `await`. Capture the exact sentinel we install
+    // so the cleanup branch can verify nothing chained on top before it
+    // removes the entry.
+    const sentinel: Promise<unknown> = next.catch(() => undefined);
+    repoLocks.set(repoKey, sentinel);
+    sentinel.then(() => {
+      // Compare-and-swap: only delete if this chain is still the tail. A
+      // subsequent `withRepoLock(repoKey, …)` would have replaced the
+      // entry with its own sentinel, in which case ours is stale and
+      // there is nothing to clean up.
+      if (repoLocks.get(repoKey) === sentinel) {
+        repoLocks.delete(repoKey);
+      }
+    });
     return next;
   }
 
@@ -373,14 +390,30 @@ export function createWorktreeManager(
       // Idempotent: tearing down an already-removed task is a no-op.
       return;
     }
+    // Path-traversal guard. `removeWorktree` performs recursive deletes,
+    // and a registration whose path escapes the configured workspace
+    // would let a corrupt persistence layer (or a malicious task record)
+    // wipe arbitrary directories on disk. Any registration outside
+    // `worktreesRoot` is a programming error: refuse it loudly and leave
+    // the bookkeeping intact so the operator can investigate. The check
+    // is intentionally strict — we *only* delete inside `worktreesRoot`,
+    // never under `reposRoot`, never the workspace root itself, never
+    // anywhere else on the filesystem.
+    if (!isUnderWorktreesRoot(path)) {
+      throw new Error(
+        `refusing to remove worktree at ${path}: ` +
+          `path is not under the configured workspace (${worktreesRoot}). ` +
+          `This guards against path-traversal via corrupt task registrations.`,
+      );
+    }
     // Locate the bare clone for this worktree path so we can serialize
     // against other operations on the same repo.
     const repoKey = bareCloneForWorktreePath(path);
     // The bare clone may itself be gone (a user `rm -rf`'d the workspace,
-    // or this is a stray registration outside `worktreesRoot`). In both
-    // cases, talking to git is pointless: the metadata to prune lives
-    // *inside* the bare clone, so its absence already means there is
-    // nothing to reclaim. Fall back to a manual rm so the API stays
+    // or its bookkeeping was lost). Talking to git is pointless then: the
+    // metadata to prune lives *inside* the bare clone, so its absence
+    // already means there is nothing to reclaim. Fall back to a manual rm
+    // — still bounded by the prefix guard above — so the API stays
     // idempotent on corrupted state.
     const bareCloneUsable = repoKey !== null && (await pathExists(join(repoKey, "HEAD")));
     await withRepoLock(repoKey ?? path, async () => {
@@ -414,6 +447,19 @@ export function createWorktreeManager(
       }
       taskIdToPath.delete(taskId);
     });
+  }
+
+  /**
+   * True when `path` sits under `<worktreesRoot>/` (with a separator) and
+   * is not equal to `worktreesRoot` itself. The check runs against the
+   * raw string — it does not resolve symlinks, so a worktree path that
+   * traverses a symlink out of the workspace is treated as in-bounds (the
+   * supervisor never creates such paths). We *only* normalize the prefix
+   * with a trailing `/` so `<worktreesRoot>foo` (no separator) is rejected.
+   */
+  function isUnderWorktreesRoot(path: string): boolean {
+    const prefix = worktreesRoot + "/";
+    return path.startsWith(prefix);
   }
 
   /**
@@ -477,10 +523,15 @@ export function createWorktreeManager(
 }
 
 /**
- * Slugify a `<owner>/<name>` repo identifier into a single filesystem
- * segment. We use `<owner>__<name>` rather than `<owner>--<name>` because
- * GitHub names allow hyphens but not double-underscores, so the slug round-
- * trips losslessly.
+ * Convert a `<owner>/<name>` repo identifier into a single filesystem
+ * segment by replacing the `/` separator with `__`. We use `__` rather
+ * than `--` so hyphens in GitHub owner/repository names remain unchanged.
+ *
+ * The substitution is **best-effort**, not a reversible escape: a name
+ * that happens to embed `__` would alias another, and {@link makeRepoFullName}
+ * does not enforce a no-double-underscore invariant (W1 contract). The slug
+ * is purely for laying out files on disk; callers who need to recover the
+ * `<owner>/<name>` pair must keep it stored alongside, not parse it back.
  *
  * @param repo The repository name.
  * @returns A filesystem-safe slug.

--- a/src/daemon/worktree-manager.ts
+++ b/src/daemon/worktree-manager.ts
@@ -1,0 +1,475 @@
+/**
+ * daemon/worktree-manager.ts — per-repo bare clones and per-task git
+ * worktrees, the way ADR-007 spells them out.
+ *
+ * The supervisor (Wave 3) hands the manager a `<repo, issueNumber>` and
+ * receives back an isolated working directory on its own branch. Concurrent
+ * agents never share a working tree, but they *do* share the underlying
+ * object store via the bare clone — `git fetch` once per repo refreshes
+ * objects for every worktree.
+ *
+ * **Layout** (all paths beneath the configured `workspace`):
+ *
+ * ```text
+ * <workspace>/repos/<owner>__<name>.git/                  # bare clone, one per repo
+ * <workspace>/worktrees/<owner>__<name>/issue-<n>/        # worktree, one per task
+ * ```
+ *
+ * **Branch naming**: `makina/issue-<n>`. The branch is created at the
+ * remote `HEAD` of the bare clone the first time a worktree for that issue
+ * is requested, and reused if the worktree is recreated afterwards (so
+ * unmerged work survives a daemon restart).
+ *
+ * **Concurrency**. `git worktree add` mutates the bare clone's `worktrees/`
+ * metadata directory; running two of them in parallel for the same repo can
+ * race. The manager serializes `git` invocations *per repository* with a
+ * tiny per-repo promise chain, so the supervisor can spin off many tasks
+ * across repos in parallel without coordinating.
+ *
+ * **Startup hygiene**. `pruneAll()` runs `git worktree prune` against every
+ * existing bare clone so an interrupted daemon doesn't leak metadata
+ * (entries pointing at directories that were `rm -rf`'d while the daemon
+ * was down).
+ *
+ * **TaskId bookkeeping**. The W1 `WorktreeManager` interface gives
+ * `createWorktreeForIssue(repo, issueNumber)` no `taskId` to associate
+ * with the resulting worktree, but `removeWorktree(taskId)` needs one. The
+ * manager keeps its own `taskId → path` map; the supervisor calls
+ * {@link WorktreeManagerImpl.registerTaskId} after minting the task id.
+ * Until a task id is registered, only the path-based teardown works (the
+ * supervisor isn't expected to use that — it goes through the registered
+ * id so logs read consistently).
+ *
+ * @module
+ */
+
+import { dirname, join } from "@std/path";
+
+import {
+  type IssueNumber,
+  type RepoFullName,
+  type TaskId,
+  type WorktreeManager,
+} from "../types.ts";
+
+/** Constructor options for {@link createWorktreeManager}. */
+export interface WorktreeManagerOptions {
+  /**
+   * Absolute path to the makina workspace directory. The manager creates
+   * `repos/` and `worktrees/` subdirectories beneath this path on first
+   * use. The directory must already exist (the loader created it).
+   */
+  readonly workspace: string;
+  /**
+   * Override the `git` executable. Defaults to the unqualified name `git`
+   * which Deno resolves on `PATH`. Useful for tests that bind to a
+   * specific binary.
+   */
+  readonly gitBinary?: string;
+}
+
+/**
+ * One git invocation's outcome, surfaced when something goes wrong.
+ *
+ * Carries the command, exit code, and captured stderr so the supervisor
+ * can render a precise error message rather than a bare exception. The
+ * class is exported so callers can `instanceof`-check.
+ */
+export class GitCommandError extends Error {
+  /**
+   * Build a git-command error.
+   *
+   * @param message Human-readable description.
+   * @param command The full argv that was invoked, including the binary.
+   * @param exitCode Process exit code reported by Deno.
+   * @param stderr Captured stderr text.
+   */
+  constructor(
+    message: string,
+    /** Full argv that was invoked, including the `git` binary. */
+    public readonly command: readonly string[],
+    /** Exit code reported by Deno. */
+    public readonly exitCode: number,
+    /** Captured stderr text. */
+    public readonly stderr: string,
+  ) {
+    super(message);
+    this.name = "GitCommandError";
+  }
+}
+
+/**
+ * Concrete return type of {@link createWorktreeManager}. Widens the W1
+ * {@link WorktreeManager} contract with:
+ *
+ *  - a `remoteUrl` argument on {@link WorktreeManagerImpl.ensureBareClone}
+ *    (the W3 supervisor injects the GitHub-App-authenticated URL there);
+ *  - the bookkeeping calls the supervisor uses to map task ids to paths;
+ *  - {@link WorktreeManagerImpl.pruneAll} for startup hygiene.
+ *
+ * The wider surface stays out of the cross-wave contract file so consumer
+ * waves not in the supervisor (TUI, persistence) are not coupled to it.
+ */
+export interface WorktreeManagerImpl extends Omit<WorktreeManager, "ensureBareClone"> {
+  /**
+   * Ensure a bare clone of `repo` exists on disk, cloning from `remoteUrl`
+   * if it does not. Idempotent: subsequent calls observe the existing
+   * directory and short-circuit without invoking `git clone`.
+   *
+   * @param repo Repository identifier.
+   * @param remoteUrl Fully-qualified clone URL. The supervisor builds this
+   *   with a GitHub App installation token embedded in the userinfo so the
+   *   bare clone can be created without a separate credential helper.
+   * @returns Absolute filesystem path of the bare clone.
+   */
+  ensureBareClone(repo: RepoFullName, remoteUrl: string): Promise<string>;
+
+  /**
+   * Run `git worktree prune` against every bare clone present in the
+   * workspace. Idempotent; safe to call many times. The supervisor calls
+   * this once during boot, after the workspace is loaded but before any
+   * worktree creation.
+   *
+   * @returns Resolves when every prune finishes.
+   */
+  pruneAll(): Promise<void>;
+
+  /**
+   * Associate `taskId` with a worktree path so a later
+   * {@link WorktreeManager.removeWorktree} call can find it. The
+   * supervisor calls this immediately after
+   * {@link WorktreeManager.createWorktreeForIssue} returns.
+   *
+   * Re-registering the same id with a different path overwrites the prior
+   * binding (handy when the supervisor re-creates a worktree after
+   * resuming from persistence).
+   *
+   * @param taskId The task identifier to bind.
+   * @param worktreePath Absolute filesystem path of the worktree.
+   */
+  registerTaskId(taskId: TaskId, worktreePath: string): void;
+
+  /**
+   * Look up the worktree path bound to `taskId`, or `undefined` if the
+   * supervisor has not yet registered (or has already removed) it.
+   *
+   * @param taskId The task identifier to look up.
+   * @returns The bound worktree path, if any.
+   */
+  worktreePathFor(taskId: TaskId): string | undefined;
+}
+
+/**
+ * Construct a {@link WorktreeManagerImpl}.
+ *
+ * The factory does not perform any IO; it returns an object whose methods
+ * lazily create the `repos/` and `worktrees/` subdirectories of `workspace`
+ * the first time they are needed. This keeps construction cheap and makes
+ * the manager easy to instantiate inside tests.
+ *
+ * @param opts Configuration.
+ * @returns A {@link WorktreeManagerImpl} bound to `opts.workspace`.
+ *
+ * @example
+ * ```ts
+ * import { createWorktreeManager } from "./worktree-manager.ts";
+ *
+ * const manager = createWorktreeManager({ workspace: "/var/lib/makina" });
+ * await manager.pruneAll();
+ * await manager.ensureBareClone(repo, "https://github.com/owner/name.git");
+ * const path = await manager.createWorktreeForIssue(repo, makeIssueNumber(42));
+ * manager.registerTaskId(taskId, path);
+ * ```
+ */
+export function createWorktreeManager(
+  opts: WorktreeManagerOptions,
+): WorktreeManagerImpl {
+  if (opts.workspace.length === 0) {
+    throw new RangeError("workspace path cannot be empty");
+  }
+  const workspace = opts.workspace;
+  const gitBinary = opts.gitBinary ?? "git";
+
+  const reposRoot = join(workspace, "repos");
+  const worktreesRoot = join(workspace, "worktrees");
+
+  /**
+   * Per-repository serialization queue. `git worktree add` and `git
+   * worktree remove` mutate the bare clone's `worktrees/` metadata
+   * directory; running two of them in parallel for the same repo can
+   * race. We serialize *per repo*, not globally, so unrelated repos run
+   * in parallel.
+   */
+  const repoLocks = new Map<string, Promise<unknown>>();
+
+  /**
+   * Bookkeeping for {@link WorktreeManagerImpl.removeWorktree}. The
+   * supervisor calls {@link WorktreeManagerImpl.registerTaskId} after
+   * minting the task id and stashing the path on the persistent task
+   * record. Re-registering with a different path is allowed (recovery
+   * after a daemon crash recreates the binding from disk).
+   */
+  const taskIdToPath = new Map<TaskId, string>();
+
+  /**
+   * Acquire the per-repo lock around `work`, so that only one mutating
+   * operation per bare clone is in flight at a time. Errors propagate
+   * through the chain unchanged but do not poison subsequent calls — the
+   * lock only awaits *settlement*, not success.
+   */
+  function withRepoLock<T>(repoKey: string, work: () => Promise<T>): Promise<T> {
+    const previous = repoLocks.get(repoKey) ?? Promise.resolve();
+    const next = previous
+      .catch(() => undefined)
+      .then(() => work());
+    // Store the cleaned promise so a failure on one task doesn't leak
+    // into the next one's `await`.
+    repoLocks.set(
+      repoKey,
+      next.catch(() => undefined),
+    );
+    return next;
+  }
+
+  function bareClonePath(repo: RepoFullName): string {
+    return join(reposRoot, `${repoSlug(repo)}.git`);
+  }
+
+  function worktreePath(repo: RepoFullName, issueNumber: IssueNumber): string {
+    return join(worktreesRoot, repoSlug(repo), `issue-${issueNumber}`);
+  }
+
+  function branchName(issueNumber: IssueNumber): string {
+    return `makina/issue-${issueNumber}`;
+  }
+
+  async function runGit(
+    args: readonly string[],
+    cwd?: string,
+  ): Promise<{ stdout: string; stderr: string }> {
+    const options: Deno.CommandOptions = {
+      args: [...args],
+      stdout: "piped",
+      stderr: "piped",
+    };
+    if (cwd !== undefined) {
+      options.cwd = cwd;
+    }
+    const command = new Deno.Command(gitBinary, options);
+    const result = await command.output();
+    const stdout = new TextDecoder().decode(result.stdout);
+    const stderr = new TextDecoder().decode(result.stderr);
+    if (!result.success) {
+      throw new GitCommandError(
+        `git ${args.join(" ")} failed (exit ${result.code})`,
+        [gitBinary, ...args],
+        result.code,
+        stderr,
+      );
+    }
+    return { stdout, stderr };
+  }
+
+  async function pathExists(path: string): Promise<boolean> {
+    try {
+      await Deno.lstat(path);
+      return true;
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async function ensureBareClone(
+    repo: RepoFullName,
+    remoteUrl: string,
+  ): Promise<string> {
+    if (remoteUrl.length === 0) {
+      throw new RangeError("remoteUrl cannot be empty");
+    }
+    const target = bareClonePath(repo);
+    return await withRepoLock(target, async () => {
+      if (await pathExists(target)) {
+        // Sanity-check that what's there is actually a git directory; a
+        // half-cloned leftover from a crashed run shouldn't be silently
+        // treated as success.
+        if (!(await pathExists(join(target, "HEAD")))) {
+          throw new Error(
+            `bare clone at ${target} exists but has no HEAD; remove it manually`,
+          );
+        }
+        return target;
+      }
+      await Deno.mkdir(reposRoot, { recursive: true });
+      await runGit(["clone", "--bare", "--quiet", remoteUrl, target]);
+      return target;
+    });
+  }
+
+  async function createWorktreeForIssue(
+    repo: RepoFullName,
+    issueNumber: IssueNumber,
+  ): Promise<string> {
+    const bareDir = bareClonePath(repo);
+    if (!(await pathExists(bareDir))) {
+      throw new Error(
+        `bare clone for ${repo} not found at ${bareDir}; ` +
+          `call ensureBareClone first`,
+      );
+    }
+    const target = worktreePath(repo, issueNumber);
+    const branch = branchName(issueNumber);
+    return await withRepoLock(bareDir, async () => {
+      if (await pathExists(target)) {
+        // Someone (probably us, after a daemon restart) already has the
+        // worktree on disk. Trust it: the supervisor preserves worktrees
+        // across NEEDS_HUMAN/FAILED, and recreating it would clobber any
+        // in-flight edits.
+        return target;
+      }
+      await Deno.mkdir(dirname(target), { recursive: true });
+      // If the branch already exists in the bare clone, reuse it; else
+      // create it pointing at `HEAD`. The two-step is needed because
+      // `git worktree add -b` fails if the branch is already there.
+      const existing = await branchExists(bareDir, branch);
+      const args = existing
+        ? ["worktree", "add", "--quiet", target, branch]
+        : ["worktree", "add", "--quiet", "-b", branch, target, "HEAD"];
+      await runGit(args, bareDir);
+      return target;
+    });
+  }
+
+  async function branchExists(bareDir: string, branch: string): Promise<boolean> {
+    try {
+      await runGit(
+        ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`],
+        bareDir,
+      );
+      return true;
+    } catch (error) {
+      // `git show-ref --verify --quiet` exits 1 when the ref does not
+      // exist. Any other non-zero exit is a real error worth surfacing.
+      if (error instanceof GitCommandError && error.exitCode === 1) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async function removeWorktree(taskId: TaskId): Promise<void> {
+    const path = taskIdToPath.get(taskId);
+    if (path === undefined) {
+      // Idempotent: tearing down an already-removed task is a no-op.
+      return;
+    }
+    // Locate the bare clone for this worktree path so we can serialize
+    // against other operations on the same repo.
+    const repoKey = bareCloneForWorktreePath(path);
+    await withRepoLock(repoKey ?? path, async () => {
+      if (repoKey === null) {
+        // No bare clone we can talk to — fall back to a manual rm. This
+        // keeps the API idempotent even in the face of corrupted state.
+        if (await pathExists(path)) {
+          await Deno.remove(path, { recursive: true });
+        }
+        taskIdToPath.delete(taskId);
+        return;
+      }
+      if (await pathExists(path)) {
+        try {
+          await runGit(["worktree", "remove", "--force", path], repoKey);
+        } catch (error) {
+          // If `git worktree remove` failed (e.g. because the worktree
+          // metadata is corrupt), fall back to a manual rm followed by
+          // `git worktree prune` so bookkeeping stays consistent.
+          if (await pathExists(path)) {
+            await Deno.remove(path, { recursive: true });
+          }
+          await runGit(["worktree", "prune"], repoKey);
+          if (!(error instanceof GitCommandError)) {
+            throw error;
+          }
+        }
+      } else {
+        // The directory is gone but git may still hold metadata for it.
+        await runGit(["worktree", "prune"], repoKey);
+      }
+      taskIdToPath.delete(taskId);
+    });
+  }
+
+  /**
+   * Recover the bare-clone path that a worktree path lives under. Returns
+   * `null` if the worktree path doesn't sit under our `worktrees/` root —
+   * that shouldn't happen via the manager's own APIs, but we tolerate it
+   * to keep `removeWorktree` idempotent on weird state.
+   */
+  function bareCloneForWorktreePath(path: string): string | null {
+    const prefix = worktreesRoot + "/";
+    if (!path.startsWith(prefix)) {
+      return null;
+    }
+    const remainder = path.slice(prefix.length);
+    const slash = remainder.indexOf("/");
+    if (slash <= 0) {
+      return null;
+    }
+    const slug = remainder.slice(0, slash);
+    return join(reposRoot, `${slug}.git`);
+  }
+
+  async function pruneAll(): Promise<void> {
+    if (!(await pathExists(reposRoot))) {
+      return;
+    }
+    const tasks: Promise<void>[] = [];
+    for await (const entry of Deno.readDir(reposRoot)) {
+      if (!entry.isDirectory || !entry.name.endsWith(".git")) {
+        continue;
+      }
+      const bareDir = join(reposRoot, entry.name);
+      tasks.push(
+        withRepoLock(bareDir, async () => {
+          await runGit(["worktree", "prune"], bareDir);
+        }),
+      );
+    }
+    await Promise.all(tasks);
+  }
+
+  function registerTaskId(taskId: TaskId, path: string): void {
+    if (path.length === 0) {
+      throw new RangeError("worktree path cannot be empty");
+    }
+    taskIdToPath.set(taskId, path);
+  }
+
+  function worktreePathFor(taskId: TaskId): string | undefined {
+    return taskIdToPath.get(taskId);
+  }
+
+  return {
+    ensureBareClone,
+    createWorktreeForIssue,
+    removeWorktree,
+    pruneAll,
+    registerTaskId,
+    worktreePathFor,
+  };
+}
+
+/**
+ * Slugify a `<owner>/<name>` repo identifier into a single filesystem
+ * segment. We use `<owner>__<name>` rather than `<owner>--<name>` because
+ * GitHub names allow hyphens but not double-underscores, so the slug round-
+ * trips losslessly.
+ *
+ * @param repo The repository name.
+ * @returns A filesystem-safe slug.
+ */
+function repoSlug(repo: RepoFullName): string {
+  return repo.replace("/", "__");
+}

--- a/src/daemon/worktree-manager.ts
+++ b/src/daemon/worktree-manager.ts
@@ -43,7 +43,7 @@
  * @module
  */
 
-import { dirname, join } from "@std/path";
+import { dirname, join, resolve } from "@std/path";
 
 import {
   type IssueNumber,
@@ -409,14 +409,20 @@ export function createWorktreeManager(
     // Locate the bare clone for this worktree path so we can serialize
     // against other operations on the same repo.
     const repoKey = bareCloneForWorktreePath(path);
-    // The bare clone may itself be gone (a user `rm -rf`'d the workspace,
-    // or its bookkeeping was lost). Talking to git is pointless then: the
-    // metadata to prune lives *inside* the bare clone, so its absence
-    // already means there is nothing to reclaim. Fall back to a manual rm
-    // — still bounded by the prefix guard above — so the API stays
-    // idempotent on corrupted state.
-    const bareCloneUsable = repoKey !== null && (await pathExists(join(repoKey, "HEAD")));
     await withRepoLock(repoKey ?? path, async () => {
+      // Re-check bare-clone usability *inside* the lock. A check before
+      // the lock would race against a concurrent `removeWorktree` (or an
+      // out-of-band `rm -rf`) that wipes the bare clone between the
+      // check and the locked section: we'd then take the git path and
+      // throw, breaking the idempotency guarantee. The bare clone may be
+      // gone (a user `rm -rf`'d the workspace, or its bookkeeping was
+      // lost). Talking to git is pointless then: the metadata to prune
+      // lives *inside* the bare clone, so its absence already means
+      // there is nothing to reclaim. Fall back to a manual rm — still
+      // bounded by the prefix guard above — so the API stays idempotent
+      // on corrupted state.
+      const bareCloneUsable = repoKey !== null &&
+        (await pathExists(join(repoKey, "HEAD")));
       if (!bareCloneUsable) {
         if (await pathExists(path)) {
           await Deno.remove(path, { recursive: true });
@@ -432,48 +438,74 @@ export function createWorktreeManager(
         } catch (error) {
           // If `git worktree remove` failed (e.g. because the worktree
           // metadata is corrupt), fall back to a manual rm followed by
-          // `git worktree prune` so bookkeeping stays consistent.
+          // `git worktree prune` so bookkeeping stays consistent. The
+          // prune itself is best-effort: if the bare clone vanished
+          // mid-flight we treat that as "nothing to reclaim" rather than
+          // re-throwing past the idempotency guarantee.
           if (await pathExists(path)) {
             await Deno.remove(path, { recursive: true });
           }
-          await runGit(["worktree", "prune"], bareDir);
+          if (await pathExists(join(bareDir, "HEAD"))) {
+            await runGit(["worktree", "prune"], bareDir);
+          }
           if (!(error instanceof GitCommandError)) {
             throw error;
           }
         }
       } else {
         // The directory is gone but git may still hold metadata for it.
-        await runGit(["worktree", "prune"], bareDir);
+        // Bare clone may have vanished concurrently — only prune if it's
+        // still there to be pruned.
+        if (await pathExists(join(bareDir, "HEAD"))) {
+          await runGit(["worktree", "prune"], bareDir);
+        }
       }
       taskIdToPath.delete(taskId);
     });
   }
 
   /**
-   * True when `path` sits under `<worktreesRoot>/` (with a separator) and
-   * is not equal to `worktreesRoot` itself. The check runs against the
-   * raw string — it does not resolve symlinks, so a worktree path that
-   * traverses a symlink out of the workspace is treated as in-bounds (the
-   * supervisor never creates such paths). We *only* normalize the prefix
-   * with a trailing `/` so `<worktreesRoot>foo` (no separator) is rejected.
+   * True when `path` sits strictly under `<worktreesRoot>/` after lexical
+   * normalization. We *resolve* `path` before checking — a corrupt
+   * registration like `<worktreesRoot>/repo/../../../outside` passes a raw
+   * `startsWith` test but `Deno.remove()` would happily traverse the `..`
+   * segments and wipe directories outside the workspace. Resolving first
+   * collapses the `..` so the prefix check sees the real target.
+   *
+   * The check is purely lexical (no symlink resolution): the supervisor
+   * never creates symlinked worktree paths, and a real-filesystem
+   * `realpath` would fail for paths whose leaf doesn't exist yet. The
+   * trailing-separator prefix (`<worktreesRoot>/`) keeps siblings like
+   * `<worktreesRoot>-suffix` out of bounds, and the explicit equality
+   * check rejects the root itself.
    */
   function isUnderWorktreesRoot(path: string): boolean {
-    const prefix = worktreesRoot + "/";
-    return path.startsWith(prefix);
+    const normalizedRoot = resolve(worktreesRoot);
+    const normalized = resolve(path);
+    if (normalized === normalizedRoot) {
+      return false;
+    }
+    const prefix = normalizedRoot + "/";
+    return normalized.startsWith(prefix);
   }
 
   /**
    * Recover the bare-clone path that a worktree path lives under. Returns
    * `null` if the worktree path doesn't sit under our `worktrees/` root —
-   * that shouldn't happen via the manager's own APIs, but we tolerate it
-   * to keep `removeWorktree` idempotent on weird state.
+   * that shouldn't happen via the manager's own APIs (the prefix guard in
+   * {@link isUnderWorktreesRoot} runs first), but we tolerate it to keep
+   * `removeWorktree` idempotent on weird state. We resolve `path` first
+   * for the same reason `isUnderWorktreesRoot` does: a stored path that
+   * embeds `..` segments must be normalized before we slice the slug.
    */
   function bareCloneForWorktreePath(path: string): string | null {
-    const prefix = worktreesRoot + "/";
-    if (!path.startsWith(prefix)) {
+    const normalizedRoot = resolve(worktreesRoot);
+    const normalized = resolve(path);
+    const prefix = normalizedRoot + "/";
+    if (!normalized.startsWith(prefix)) {
       return null;
     }
-    const remainder = path.slice(prefix.length);
+    const remainder = normalized.slice(prefix.length);
     const slash = remainder.indexOf("/");
     if (slash <= 0) {
       return null;

--- a/src/daemon/worktree-manager.ts
+++ b/src/daemon/worktree-manager.ts
@@ -43,6 +43,7 @@
  * @module
  */
 
+import { getLogger } from "@std/log";
 import { dirname, join, resolve } from "@std/path";
 
 import {
@@ -51,6 +52,17 @@ import {
   type TaskId,
   type WorktreeManager,
 } from "../types.ts";
+
+/**
+ * Narrow logger surface used by the worktree manager. The `@std/log`
+ * `Logger` class satisfies this shape (its `warn` accepts a string), but
+ * the narrower interface lets tests inject a recording double without
+ * matching the SDK's full overload signature.
+ */
+export interface WorktreeManagerLogger {
+  /** Emit a warning. */
+  warn(message: string): void;
+}
 
 /** Constructor options for {@link createWorktreeManager}. */
 export interface WorktreeManagerOptions {
@@ -66,6 +78,16 @@ export interface WorktreeManagerOptions {
    * specific binary.
    */
   readonly gitBinary?: string;
+  /**
+   * Logger used for non-fatal warnings — currently only
+   * {@link WorktreeManagerImpl.pruneAll} skipping a corrupt bare directory.
+   * Defaults to `getLogger()` from `@std/log` (the default-namespace
+   * logger), adapted to the {@link WorktreeManagerLogger} surface.
+   *
+   * Tests inject a recording logger to assert warning behavior without
+   * touching the global logger registry.
+   */
+  readonly logger?: WorktreeManagerLogger;
 }
 
 /**
@@ -189,6 +211,7 @@ export function createWorktreeManager(
   }
   const workspace = opts.workspace;
   const gitBinary = opts.gitBinary ?? "git";
+  const logger = opts.logger ?? defaultLogger();
 
   const reposRoot = join(workspace, "repos");
   const worktreesRoot = join(workspace, "worktrees");
@@ -524,9 +547,26 @@ export function createWorktreeManager(
         continue;
       }
       const bareDir = join(reposRoot, entry.name);
+      // `pruneAll` is startup hygiene, called once before any worktree
+      // creation. A single corrupt entry (a partial clone that never
+      // wrote `HEAD`, or a manually-dropped `*.git` folder) must not
+      // abort pruning the rest — that would prevent the daemon from
+      // starting on an otherwise-recoverable workspace. Catch the
+      // per-directory `GitCommandError`, warn, and move on. Errors
+      // outside `runGit` (filesystem, lock primitive) still propagate.
       tasks.push(
         withRepoLock(bareDir, async () => {
-          await runGit(["worktree", "prune"], bareDir);
+          try {
+            await runGit(["worktree", "prune"], bareDir);
+          } catch (error) {
+            if (!(error instanceof GitCommandError)) {
+              throw error;
+            }
+            logger.warn(
+              `worktree-manager: skipping prune of ${bareDir} ` +
+                `(git exited ${error.exitCode}: ${error.stderr.trim()})`,
+            );
+          }
         }),
       );
     }
@@ -551,6 +591,21 @@ export function createWorktreeManager(
     pruneAll,
     registerTaskId,
     worktreePathFor,
+  };
+}
+
+/**
+ * Adapt the default-namespace `@std/log` logger to the narrow
+ * {@link WorktreeManagerLogger} surface. `getLogger()` returns a `Logger`
+ * whose `warn` overload accepts a plain string, but TypeScript needs a
+ * thin adapter to project the SDK's shape onto our interface.
+ */
+function defaultLogger(): WorktreeManagerLogger {
+  const inner = getLogger();
+  return {
+    warn(message: string): void {
+      inner.warn(message);
+    },
   };
 }
 

--- a/src/daemon/worktree-manager.ts
+++ b/src/daemon/worktree-manager.ts
@@ -260,11 +260,19 @@ export function createWorktreeManager(
     const stdout = new TextDecoder().decode(result.stdout);
     const stderr = new TextDecoder().decode(result.stderr);
     if (!result.success) {
+      // Redact credentials from any URL-shaped argv positions before the
+      // error escapes — the supervisor injects GitHub App installation
+      // tokens into clone URLs (`https://x-access-token:<token>@github.com/...`)
+      // and a bare exception would otherwise route them straight into logs
+      // and telemetry. We keep the host + path so the failure is still
+      // diagnosable.
+      const sanitizedArgs = args.map(redactUrlCredentials);
+      const sanitizedStderr = redactUrlCredentials(stderr);
       throw new GitCommandError(
-        `git ${args.join(" ")} failed (exit ${result.code})`,
-        [gitBinary, ...args],
+        `git ${sanitizedArgs.join(" ")} failed (exit ${result.code})`,
+        [gitBinary, ...sanitizedArgs],
         result.code,
-        stderr,
+        sanitizedStderr,
       );
     }
     return { stdout, stderr };
@@ -368,19 +376,26 @@ export function createWorktreeManager(
     // Locate the bare clone for this worktree path so we can serialize
     // against other operations on the same repo.
     const repoKey = bareCloneForWorktreePath(path);
+    // The bare clone may itself be gone (a user `rm -rf`'d the workspace,
+    // or this is a stray registration outside `worktreesRoot`). In both
+    // cases, talking to git is pointless: the metadata to prune lives
+    // *inside* the bare clone, so its absence already means there is
+    // nothing to reclaim. Fall back to a manual rm so the API stays
+    // idempotent on corrupted state.
+    const bareCloneUsable = repoKey !== null && (await pathExists(join(repoKey, "HEAD")));
     await withRepoLock(repoKey ?? path, async () => {
-      if (repoKey === null) {
-        // No bare clone we can talk to — fall back to a manual rm. This
-        // keeps the API idempotent even in the face of corrupted state.
+      if (!bareCloneUsable) {
         if (await pathExists(path)) {
           await Deno.remove(path, { recursive: true });
         }
         taskIdToPath.delete(taskId);
         return;
       }
+      // `repoKey` is non-null because `bareCloneUsable` requires it.
+      const bareDir = repoKey as string;
       if (await pathExists(path)) {
         try {
-          await runGit(["worktree", "remove", "--force", path], repoKey);
+          await runGit(["worktree", "remove", "--force", path], bareDir);
         } catch (error) {
           // If `git worktree remove` failed (e.g. because the worktree
           // metadata is corrupt), fall back to a manual rm followed by
@@ -388,14 +403,14 @@ export function createWorktreeManager(
           if (await pathExists(path)) {
             await Deno.remove(path, { recursive: true });
           }
-          await runGit(["worktree", "prune"], repoKey);
+          await runGit(["worktree", "prune"], bareDir);
           if (!(error instanceof GitCommandError)) {
             throw error;
           }
         }
       } else {
         // The directory is gone but git may still hold metadata for it.
-        await runGit(["worktree", "prune"], repoKey);
+        await runGit(["worktree", "prune"], bareDir);
       }
       taskIdToPath.delete(taskId);
     });
@@ -472,4 +487,29 @@ export function createWorktreeManager(
  */
 function repoSlug(repo: RepoFullName): string {
   return repo.replace("/", "__");
+}
+
+/**
+ * Strip `userinfo` (`user`, `user:password`, or a bare token) from any
+ * URL-shaped substring inside `text`, replacing it with the literal
+ * `REDACTED` so the host + path remain debuggable. Used by `runGit` to
+ * sanitize argv and stderr before they enter a {@link GitCommandError}:
+ * the W3 supervisor injects GitHub App installation tokens as the
+ * userinfo part of the clone URL (`https://x-access-token:<token>@…`),
+ * and we must not leak those into logs/telemetry on a `git clone`
+ * failure.
+ *
+ * The regex is intentionally conservative: it matches `scheme://user[:pw]@`
+ * sequences. URLs without userinfo, SSH-style `git@host:` strings (no
+ * credential to redact), and arbitrary non-URL text pass through unchanged.
+ *
+ * @param text Argv element or stderr buffer that may contain a URL.
+ * @returns `text` with any `userinfo` segments rewritten to `REDACTED`.
+ */
+function redactUrlCredentials(text: string): string {
+  // Match `scheme://userinfo@`. The userinfo grammar in RFC 3986 allows
+  // unreserved chars + a few sub-delims + `:` + percent-encodings; we use
+  // a permissive `[^@\s/]+` to avoid pulling in URL parsing for what is
+  // ultimately a redaction routine.
+  return text.replace(/([a-zA-Z][a-zA-Z0-9+.\-]*:\/\/)[^@\s/]+@/g, "$1REDACTED@");
 }

--- a/tests/integration/worktree_manager_test.ts
+++ b/tests/integration/worktree_manager_test.ts
@@ -1,0 +1,520 @@
+/**
+ * Integration tests for `src/daemon/worktree-manager.ts`.
+ *
+ * Each test stands up a `Deno.makeTempDir`-backed bare-source repository
+ * with a couple of real commits, then exercises the manager against a
+ * second `Deno.makeTempDir`-backed workspace. The tests run actual `git`
+ * subprocesses — they require `git` on `PATH` — so the assertions reflect
+ * how the bare clone, the worktrees, and `git worktree prune` *really*
+ * behave on disk, not against a mock.
+ *
+ * Coverage targets called out in the W2 brief:
+ *
+ *  - idempotent `ensureBareClone` (a second call observes the existing
+ *    directory and is a no-op);
+ *  - concurrent `createWorktreeForIssue` for distinct issues against the
+ *    same repo (no shared-state corruption from `git worktree add`);
+ *  - `removeWorktree` (idempotent, reclaims directory and metadata);
+ *  - `pruneAll` on startup reclaims metadata after an interrupted run.
+ */
+
+import { assert, assertEquals, assertNotEquals, assertRejects } from "@std/assert";
+import { join } from "@std/path";
+
+import { makeIssueNumber, makeRepoFullName, makeTaskId } from "../../src/types.ts";
+import {
+  createWorktreeManager,
+  GitCommandError,
+  type WorktreeManagerImpl,
+} from "../../src/daemon/worktree-manager.ts";
+
+// ---------------------------------------------------------------------------
+// Test scaffolding
+// ---------------------------------------------------------------------------
+
+interface TestRig {
+  readonly workspace: string;
+  readonly remoteUrl: string;
+  readonly remoteDir: string;
+  readonly manager: WorktreeManagerImpl;
+  cleanup(): Promise<void>;
+}
+
+/** Run `git` with the given args and cwd; throw with stderr on failure. */
+async function git(args: readonly string[], cwd: string): Promise<string> {
+  const command = new Deno.Command("git", {
+    args: [...args],
+    cwd,
+    stdout: "piped",
+    stderr: "piped",
+    env: {
+      // Tests run inside CI environments that may not have a global git
+      // identity. Setting these as env vars keeps the test self-contained.
+      GIT_AUTHOR_NAME: "makina-test",
+      GIT_AUTHOR_EMAIL: "makina-test@example.com",
+      GIT_COMMITTER_NAME: "makina-test",
+      GIT_COMMITTER_EMAIL: "makina-test@example.com",
+    },
+  });
+  const result = await command.output();
+  if (!result.success) {
+    const stderr = new TextDecoder().decode(result.stderr);
+    throw new Error(
+      `git ${args.join(" ")} failed (exit ${result.code}): ${stderr}`,
+    );
+  }
+  return new TextDecoder().decode(result.stdout);
+}
+
+/**
+ * Build a self-contained source repo with two commits on `main` plus a
+ * second branch, then return a `file://` URL the manager can clone from.
+ */
+async function makeSourceRepo(): Promise<{ dir: string; url: string }> {
+  const dir = await Deno.makeTempDir({ prefix: "makina-src-" });
+  await git(["init", "--quiet", "--initial-branch=main", dir], dir);
+  // First commit.
+  await Deno.writeTextFile(join(dir, "README.md"), "# fixture\n");
+  await git(["add", "."], dir);
+  await git(["commit", "--quiet", "-m", "feat: initial commit"], dir);
+  // Second commit on main.
+  await Deno.writeTextFile(join(dir, "VERSION"), "0.0.1\n");
+  await git(["add", "."], dir);
+  await git(["commit", "--quiet", "-m", "chore: bump version"], dir);
+  return { dir, url: `file://${dir}` };
+}
+
+/** Build a temporary workspace and a manager bound to it. */
+async function makeRig(): Promise<TestRig> {
+  const workspace = await Deno.makeTempDir({ prefix: "makina-ws-" });
+  const source = await makeSourceRepo();
+  const manager = createWorktreeManager({ workspace });
+  return {
+    workspace,
+    remoteUrl: source.url,
+    remoteDir: source.dir,
+    manager,
+    async cleanup() {
+      await Deno.remove(workspace, { recursive: true });
+      await Deno.remove(source.dir, { recursive: true });
+    },
+  };
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await Deno.lstat(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ensureBareClone
+// ---------------------------------------------------------------------------
+
+Deno.test("ensureBareClone: clones into <workspace>/repos/<owner>__<name>.git", async () => {
+  const rig = await makeRig();
+  try {
+    const repo = makeRepoFullName("octo/widgets");
+    const path = await rig.manager.ensureBareClone(repo, rig.remoteUrl);
+    assertEquals(path, join(rig.workspace, "repos", "octo__widgets.git"));
+    assert(await pathExists(join(path, "HEAD")), "bare clone has HEAD");
+    // `--bare` clones don't create a working tree; sanity-check that.
+    assert(!(await pathExists(join(path, ".git"))), "no nested .git in a bare clone");
+  } finally {
+    await rig.cleanup();
+  }
+});
+
+Deno.test("ensureBareClone: is idempotent across repeated calls", async () => {
+  const rig = await makeRig();
+  try {
+    const repo = makeRepoFullName("octo/widgets");
+    const first = await rig.manager.ensureBareClone(repo, rig.remoteUrl);
+    const headPath = join(first, "HEAD");
+    const before = (await Deno.lstat(headPath)).mtime;
+
+    // Second and third calls observe the existing clone and short-circuit.
+    const second = await rig.manager.ensureBareClone(repo, rig.remoteUrl);
+    const third = await rig.manager.ensureBareClone(repo, rig.remoteUrl);
+    assertEquals(second, first);
+    assertEquals(third, first);
+
+    // mtime on HEAD shouldn't have moved — proof we didn't re-clone.
+    const after = (await Deno.lstat(headPath)).mtime;
+    assertEquals(after?.getTime(), before?.getTime());
+  } finally {
+    await rig.cleanup();
+  }
+});
+
+Deno.test("ensureBareClone: rejects an empty remoteUrl", async () => {
+  const rig = await makeRig();
+  try {
+    await assertRejects(
+      () => rig.manager.ensureBareClone(makeRepoFullName("a/b"), ""),
+      RangeError,
+      "remoteUrl",
+    );
+  } finally {
+    await rig.cleanup();
+  }
+});
+
+Deno.test("ensureBareClone: refuses to reuse a half-cloned directory", async () => {
+  const rig = await makeRig();
+  try {
+    const repo = makeRepoFullName("octo/widgets");
+    // Pre-create the bare clone directory but without a HEAD file —
+    // simulating a clone that crashed mid-flight.
+    const target = join(rig.workspace, "repos", "octo__widgets.git");
+    await Deno.mkdir(target, { recursive: true });
+
+    await assertRejects(
+      () => rig.manager.ensureBareClone(repo, rig.remoteUrl),
+      Error,
+      "no HEAD",
+    );
+  } finally {
+    await rig.cleanup();
+  }
+});
+
+Deno.test("ensureBareClone: surfaces git failures as GitCommandError", async () => {
+  const rig = await makeRig();
+  try {
+    await assertRejects(
+      () =>
+        rig.manager.ensureBareClone(
+          makeRepoFullName("octo/widgets"),
+          "file:///definitely/does/not/exist.git",
+        ),
+      GitCommandError,
+    );
+  } finally {
+    await rig.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// createWorktreeForIssue
+// ---------------------------------------------------------------------------
+
+Deno.test("createWorktreeForIssue: lands at the documented path on a fresh branch", async () => {
+  const rig = await makeRig();
+  try {
+    const repo = makeRepoFullName("octo/widgets");
+    await rig.manager.ensureBareClone(repo, rig.remoteUrl);
+    const path = await rig.manager.createWorktreeForIssue(repo, makeIssueNumber(42));
+
+    assertEquals(
+      path,
+      join(rig.workspace, "worktrees", "octo__widgets", "issue-42"),
+    );
+    // Files from the source commit should be checked out in the worktree.
+    assert(await pathExists(join(path, "README.md")));
+    assert(await pathExists(join(path, "VERSION")));
+
+    // `git rev-parse --abbrev-ref HEAD` inside the worktree confirms the
+    // branch name matches the makina/issue-<n> convention.
+    const branch = (await git(["rev-parse", "--abbrev-ref", "HEAD"], path)).trim();
+    assertEquals(branch, "makina/issue-42");
+  } finally {
+    await rig.cleanup();
+  }
+});
+
+Deno.test("createWorktreeForIssue: fails if ensureBareClone has not run", async () => {
+  const rig = await makeRig();
+  try {
+    await assertRejects(
+      () => rig.manager.createWorktreeForIssue(makeRepoFullName("a/b"), makeIssueNumber(1)),
+      Error,
+      "bare clone",
+    );
+  } finally {
+    await rig.cleanup();
+  }
+});
+
+Deno.test("createWorktreeForIssue: returns the existing path if the worktree is already on disk", async () => {
+  const rig = await makeRig();
+  try {
+    const repo = makeRepoFullName("octo/widgets");
+    await rig.manager.ensureBareClone(repo, rig.remoteUrl);
+    const path = await rig.manager.createWorktreeForIssue(repo, makeIssueNumber(7));
+
+    // Pretend the agent left a file in the worktree; a second call must
+    // **not** clobber it.
+    const sentinel = join(path, "in-flight-edit.txt");
+    await Deno.writeTextFile(sentinel, "user work in progress");
+
+    const again = await rig.manager.createWorktreeForIssue(repo, makeIssueNumber(7));
+    assertEquals(again, path);
+    assertEquals(await Deno.readTextFile(sentinel), "user work in progress");
+  } finally {
+    await rig.cleanup();
+  }
+});
+
+Deno.test(
+  "createWorktreeForIssue: concurrent calls for distinct issues against one repo all succeed",
+  async () => {
+    const rig = await makeRig();
+    try {
+      const repo = makeRepoFullName("octo/widgets");
+      await rig.manager.ensureBareClone(repo, rig.remoteUrl);
+
+      const issues = [101, 102, 103, 104, 105].map(makeIssueNumber);
+      const paths = await Promise.all(
+        issues.map((issue) => rig.manager.createWorktreeForIssue(repo, issue)),
+      );
+
+      // Every worktree exists, and the paths match the documented layout.
+      for (const [i, issue] of issues.entries()) {
+        const expected = join(
+          rig.workspace,
+          "worktrees",
+          "octo__widgets",
+          `issue-${issue}`,
+        );
+        assertEquals(paths[i], expected);
+        assert(await pathExists(expected), `worktree ${i} on disk`);
+      }
+
+      // Every branch was created exactly once. `git worktree list` from
+      // the bare clone should report (1 bare + 5 worktrees) = 6 entries.
+      const bareDir = join(rig.workspace, "repos", "octo__widgets.git");
+      const list = await git(["worktree", "list", "--porcelain"], bareDir);
+      const matches = list.match(/^worktree /gm) ?? [];
+      assertEquals(matches.length, 6);
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "createWorktreeForIssue: concurrent calls for distinct repos run in parallel",
+  async () => {
+    const wsA = await makeRig();
+    const wsB = await makeRig();
+    try {
+      // Use the same workspace to expose the per-repo locking. Re-bind
+      // the second rig's manager to the first rig's workspace so both
+      // managers point at the same physical paths but represent
+      // different repos.
+      const manager = createWorktreeManager({ workspace: wsA.workspace });
+      const repoA = makeRepoFullName("octo/alpha");
+      const repoB = makeRepoFullName("octo/beta");
+      await manager.ensureBareClone(repoA, wsA.remoteUrl);
+      await manager.ensureBareClone(repoB, wsB.remoteUrl);
+
+      const [pa, pb] = await Promise.all([
+        manager.createWorktreeForIssue(repoA, makeIssueNumber(1)),
+        manager.createWorktreeForIssue(repoB, makeIssueNumber(1)),
+      ]);
+      assertNotEquals(pa, pb);
+      assert(await pathExists(pa));
+      assert(await pathExists(pb));
+    } finally {
+      await wsA.cleanup();
+      await wsB.cleanup();
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// removeWorktree
+// ---------------------------------------------------------------------------
+
+Deno.test("removeWorktree: removes the directory and the git metadata entry", async () => {
+  const rig = await makeRig();
+  try {
+    const repo = makeRepoFullName("octo/widgets");
+    await rig.manager.ensureBareClone(repo, rig.remoteUrl);
+    const path = await rig.manager.createWorktreeForIssue(repo, makeIssueNumber(9));
+    const taskId = makeTaskId("task-9");
+    rig.manager.registerTaskId(taskId, path);
+
+    assertEquals(rig.manager.worktreePathFor(taskId), path);
+    await rig.manager.removeWorktree(taskId);
+
+    assert(!(await pathExists(path)), "worktree directory is gone");
+    assertEquals(rig.manager.worktreePathFor(taskId), undefined);
+
+    const bareDir = join(rig.workspace, "repos", "octo__widgets.git");
+    const list = await git(["worktree", "list", "--porcelain"], bareDir);
+    // Only the bare clone itself remains.
+    const matches = list.match(/^worktree /gm) ?? [];
+    assertEquals(matches.length, 1);
+  } finally {
+    await rig.cleanup();
+  }
+});
+
+Deno.test("removeWorktree: is idempotent for unknown task ids", async () => {
+  const rig = await makeRig();
+  try {
+    await rig.manager.removeWorktree(makeTaskId("never-registered"));
+    // No throw, no observable side effect.
+  } finally {
+    await rig.cleanup();
+  }
+});
+
+Deno.test("removeWorktree: recovers when the directory was rm'd out from under git", async () => {
+  const rig = await makeRig();
+  try {
+    const repo = makeRepoFullName("octo/widgets");
+    await rig.manager.ensureBareClone(repo, rig.remoteUrl);
+    const path = await rig.manager.createWorktreeForIssue(repo, makeIssueNumber(5));
+    const taskId = makeTaskId("task-5");
+    rig.manager.registerTaskId(taskId, path);
+
+    // Simulate an out-of-band rm — common when a user nukes the
+    // workspace by hand. The manager should still tear down cleanly.
+    await Deno.remove(path, { recursive: true });
+    await rig.manager.removeWorktree(taskId);
+
+    const bareDir = join(rig.workspace, "repos", "octo__widgets.git");
+    const list = await git(["worktree", "list", "--porcelain"], bareDir);
+    const matches = list.match(/^worktree /gm) ?? [];
+    assertEquals(matches.length, 1);
+    assertEquals(rig.manager.worktreePathFor(taskId), undefined);
+  } finally {
+    await rig.cleanup();
+  }
+});
+
+Deno.test("removeWorktree: tolerates registrations outside the workspace root", async () => {
+  const rig = await makeRig();
+  const stray = await Deno.makeTempDir({ prefix: "makina-stray-" });
+  try {
+    // Pretend a previous run registered a worktree path that doesn't sit
+    // under our `worktrees/` root (e.g. a future relocation feature).
+    const taskId = makeTaskId("stray-task");
+    rig.manager.registerTaskId(taskId, stray);
+    await rig.manager.removeWorktree(taskId);
+    assert(!(await pathExists(stray)), "stray path removed");
+    assertEquals(rig.manager.worktreePathFor(taskId), undefined);
+  } finally {
+    // The stray path is already gone; only the workspace cleanup remains.
+    await rig.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// pruneAll
+// ---------------------------------------------------------------------------
+
+Deno.test("pruneAll: reclaims metadata for worktrees deleted between runs", async () => {
+  const rig = await makeRig();
+  try {
+    const repo = makeRepoFullName("octo/widgets");
+    await rig.manager.ensureBareClone(repo, rig.remoteUrl);
+    const path = await rig.manager.createWorktreeForIssue(repo, makeIssueNumber(3));
+
+    // Simulate an interrupted daemon: the directory is wiped without git
+    // ever being told.
+    await Deno.remove(path, { recursive: true });
+
+    // Right after deletion the metadata entry is still there (git only
+    // notices on the next prune) — confirm that, then run pruneAll.
+    const bareDir = join(rig.workspace, "repos", "octo__widgets.git");
+    const before = await git(["worktree", "list", "--porcelain"], bareDir);
+    assert(before.includes("issue-3"), "metadata still present pre-prune");
+
+    await rig.manager.pruneAll();
+
+    const after = await git(["worktree", "list", "--porcelain"], bareDir);
+    assert(!after.includes("issue-3"), "metadata cleared after prune");
+  } finally {
+    await rig.cleanup();
+  }
+});
+
+Deno.test("pruneAll: is a no-op when the workspace has no bare clones yet", async () => {
+  const workspace = await Deno.makeTempDir({ prefix: "makina-empty-" });
+  try {
+    const manager = createWorktreeManager({ workspace });
+    await manager.pruneAll();
+    // Reposroot was not created by pruneAll; it stays absent.
+    assert(!(await pathExists(join(workspace, "repos"))));
+  } finally {
+    await Deno.remove(workspace, { recursive: true });
+  }
+});
+
+Deno.test("pruneAll: ignores non-bare entries beneath repos/", async () => {
+  const rig = await makeRig();
+  try {
+    // Create a stray non-.git file and a non-.git directory; pruneAll
+    // must skip both rather than try to invoke git against them.
+    await Deno.mkdir(join(rig.workspace, "repos"), { recursive: true });
+    await Deno.writeTextFile(join(rig.workspace, "repos", "stray.txt"), "hi");
+    await Deno.mkdir(join(rig.workspace, "repos", "not-a-clone"));
+
+    await rig.manager.pruneAll();
+  } finally {
+    await rig.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// registerTaskId / worktreePathFor
+// ---------------------------------------------------------------------------
+
+Deno.test("registerTaskId: rejects an empty path", () => {
+  const manager = createWorktreeManager({ workspace: "/tmp" });
+  let threw = false;
+  try {
+    manager.registerTaskId(makeTaskId("t"), "");
+  } catch (error) {
+    threw = error instanceof RangeError;
+  }
+  assert(threw, "expected RangeError");
+});
+
+Deno.test("registerTaskId: re-registering the same id overwrites the binding", () => {
+  const manager = createWorktreeManager({ workspace: "/tmp" });
+  const taskId = makeTaskId("t");
+  manager.registerTaskId(taskId, "/path/one");
+  manager.registerTaskId(taskId, "/path/two");
+  assertEquals(manager.worktreePathFor(taskId), "/path/two");
+});
+
+Deno.test("createWorktreeManager: rejects an empty workspace path", () => {
+  let threw = false;
+  try {
+    createWorktreeManager({ workspace: "" });
+  } catch (error) {
+    threw = error instanceof RangeError;
+  }
+  assert(threw, "expected RangeError");
+});
+
+// ---------------------------------------------------------------------------
+// gitBinary override
+// ---------------------------------------------------------------------------
+
+Deno.test("createWorktreeManager: surfaces a missing gitBinary as a clear error", async () => {
+  const workspace = await Deno.makeTempDir({ prefix: "makina-bad-git-" });
+  try {
+    const manager = createWorktreeManager({
+      workspace,
+      gitBinary: "/definitely/not/a/real/binary",
+    });
+    await assertRejects(
+      () => manager.ensureBareClone(makeRepoFullName("a/b"), "file:///nope"),
+      Error,
+    );
+  } finally {
+    await Deno.remove(workspace, { recursive: true });
+  }
+});

--- a/tests/integration/worktree_manager_test.ts
+++ b/tests/integration/worktree_manager_test.ts
@@ -419,22 +419,117 @@ Deno.test("removeWorktree: recovers when the directory was rm'd out from under g
   }
 });
 
-Deno.test("removeWorktree: tolerates registrations outside the workspace root", async () => {
-  const rig = await makeRig();
-  const stray = await Deno.makeTempDir({ prefix: "makina-stray-" });
-  try {
-    // Pretend a previous run registered a worktree path that doesn't sit
-    // under our `worktrees/` root (e.g. a future relocation feature).
-    const taskId = makeTaskId("stray-task");
-    rig.manager.registerTaskId(taskId, stray);
-    await rig.manager.removeWorktree(taskId);
-    assert(!(await pathExists(stray)), "stray path removed");
-    assertEquals(rig.manager.worktreePathFor(taskId), undefined);
-  } finally {
-    // The stray path is already gone; only the workspace cleanup remains.
-    await rig.cleanup();
-  }
-});
+Deno.test(
+  "removeWorktree: refuses to delete registrations outside the worktrees root (path-traversal guard)",
+  async () => {
+    const rig = await makeRig();
+    const stray = await Deno.makeTempDir({ prefix: "makina-stray-" });
+    const sentinel = join(stray, "MUST_NOT_BE_DELETED");
+    await Deno.writeTextFile(sentinel, "evidence");
+    try {
+      // A corrupt persistence layer (or a malicious task record) hands us
+      // a path that escapes the configured workspace. The manager must
+      // refuse the recursive delete loudly and leave the registration in
+      // place so the operator can investigate, rather than silently wipe
+      // an arbitrary directory on disk.
+      const taskId = makeTaskId("stray-task");
+      rig.manager.registerTaskId(taskId, stray);
+      await assertRejects(
+        () => rig.manager.removeWorktree(taskId),
+        Error,
+        "not under the configured workspace",
+      );
+      // Critically, neither the stray dir nor its contents were touched.
+      assert(await pathExists(stray), "stray dir untouched");
+      assert(await pathExists(sentinel), "sentinel file untouched");
+      // The registration is preserved so a follow-up audit can find it.
+      assertEquals(rig.manager.worktreePathFor(taskId), stray);
+    } finally {
+      await Deno.remove(stray, { recursive: true });
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "removeWorktree: path-traversal guard blocks `..` segments and parent-dir registrations",
+  async () => {
+    // Regression coverage for the path-traversal vector flagged by review:
+    // `removeWorktree` previously did `Deno.remove(path, { recursive: true })`
+    // for *any* registered path when the bare clone was missing/unusable.
+    // A corrupt registration containing `..` (or simply pointing at the
+    // workspace itself) must not let the manager rm-rf its way out of the
+    // configured worktrees root.
+    const rig = await makeRig();
+    const outside = await Deno.makeTempDir({ prefix: "makina-outside-" });
+    const sentinel = join(outside, "DO_NOT_TOUCH");
+    await Deno.writeTextFile(sentinel, "evidence");
+    try {
+      // Case 1: a `..`-laced path that starts under worktreesRoot but
+      // climbs out via segment traversal.
+      const traversal = join(
+        rig.workspace,
+        "worktrees",
+        "octo__widgets",
+        "..",
+        "..",
+        "..",
+        // Attempt to land inside the temp-dir hierarchy alongside the workspace.
+        "outside-target",
+      );
+      const tA = makeTaskId("traversal-task");
+      rig.manager.registerTaskId(tA, traversal);
+      await assertRejects(
+        () => rig.manager.removeWorktree(tA),
+        Error,
+        "not under the configured workspace",
+      );
+
+      // Case 2: registration pointing at the workspace itself — a single
+      // `removeWorktree(taskId)` call would otherwise wipe everything
+      // makina is tracking.
+      const tB = makeTaskId("workspace-root");
+      rig.manager.registerTaskId(tB, rig.workspace);
+      await assertRejects(
+        () => rig.manager.removeWorktree(tB),
+        Error,
+        "not under the configured workspace",
+      );
+
+      // Case 3: registration pointing at the worktrees root *prefix* with
+      // no trailing separator (`<worktreesRoot>foo` rather than
+      // `<worktreesRoot>/foo`) — must not satisfy the prefix check.
+      const tC = makeTaskId("prefix-collision");
+      rig.manager.registerTaskId(
+        tC,
+        join(rig.workspace, "worktrees") + "-suffix",
+      );
+      await assertRejects(
+        () => rig.manager.removeWorktree(tC),
+        Error,
+        "not under the configured workspace",
+      );
+
+      // Case 4: an entirely arbitrary outside path.
+      const tD = makeTaskId("absolute-outside");
+      rig.manager.registerTaskId(tD, outside);
+      await assertRejects(
+        () => rig.manager.removeWorktree(tD),
+        Error,
+        "not under the configured workspace",
+      );
+
+      // None of the four attempts touched the outside hierarchy.
+      assert(await pathExists(outside), "outside dir untouched");
+      assert(await pathExists(sentinel), "sentinel untouched");
+      // Workspace itself is intact.
+      assert(await pathExists(rig.workspace), "workspace untouched");
+    } finally {
+      await Deno.remove(outside, { recursive: true });
+      await rig.cleanup();
+    }
+  },
+);
 
 Deno.test(
   "removeWorktree: cleans up when the bare clone has been deleted out from under us",

--- a/tests/integration/worktree_manager_test.ts
+++ b/tests/integration/worktree_manager_test.ts
@@ -26,6 +26,7 @@ import {
   createWorktreeManager,
   GitCommandError,
   type WorktreeManagerImpl,
+  type WorktreeManagerLogger,
 } from "../../src/daemon/worktree-manager.ts";
 
 // ---------------------------------------------------------------------------
@@ -67,8 +68,8 @@ async function git(args: readonly string[], cwd: string): Promise<string> {
 }
 
 /**
- * Build a self-contained source repo with two commits on `main` plus a
- * second branch, then return a `file://` URL the manager can clone from.
+ * Build a self-contained source repo with two commits on `main`, then
+ * return a `file://` URL the manager can clone from.
  */
 async function makeSourceRepo(): Promise<{ dir: string; url: string }> {
   const dir = await Deno.makeTempDir({ prefix: "makina-src-" });
@@ -611,6 +612,59 @@ Deno.test("pruneAll: ignores non-bare entries beneath repos/", async () => {
     await rig.cleanup();
   }
 });
+
+Deno.test(
+  "pruneAll: tolerates a corrupt *.git directory and prunes the rest",
+  async () => {
+    // Regression: previously a single bare directory missing `HEAD` (a
+    // crashed/partial clone, or a manually-dropped folder with the `.git`
+    // suffix) made `git worktree prune` exit non-zero, the
+    // `Promise.all` fan-out rejected, and `pruneAll()` threw — which the
+    // supervisor calls during boot, so a single corrupt entry would
+    // prevent the whole daemon from starting. The fix swallows
+    // `GitCommandError` per-bare-dir, warns, and keeps going.
+    const warnings: string[] = [];
+    const recorder: WorktreeManagerLogger = {
+      warn(message) {
+        warnings.push(message);
+      },
+    };
+    const workspace = await Deno.makeTempDir({ prefix: "makina-ws-" });
+    const source = await makeSourceRepo();
+    const manager = createWorktreeManager({ workspace, logger: recorder });
+    try {
+      // Healthy repo so we can prove the loop didn't bail early.
+      const repo = makeRepoFullName("octo/widgets");
+      await manager.ensureBareClone(repo, source.url);
+      const path = await manager.createWorktreeForIssue(repo, makeIssueNumber(7));
+      await Deno.remove(path, { recursive: true });
+
+      // Sibling corrupt entry: empty `*.git/` directory with no `HEAD`,
+      // exactly what a partial clone leaves behind.
+      const brokenDir = join(workspace, "repos", "broken.git");
+      await Deno.mkdir(brokenDir, { recursive: true });
+
+      // Must not throw.
+      await manager.pruneAll();
+
+      // Healthy repo's stale metadata was still pruned.
+      const healthyBare = join(workspace, "repos", "octo__widgets.git");
+      const after = await git(["worktree", "list", "--porcelain"], healthyBare);
+      assert(!after.includes("issue-7"), "metadata cleared after prune");
+
+      // Corrupt entry produced one warning that mentions the path.
+      assertEquals(warnings.length, 1, `expected 1 warning, got ${warnings.length}`);
+      const warning = warnings[0] ?? "";
+      assert(
+        warning.includes("broken.git"),
+        `warning should mention broken.git, got: ${warning}`,
+      );
+    } finally {
+      await Deno.remove(workspace, { recursive: true });
+      await Deno.remove(source.dir, { recursive: true });
+    }
+  },
+);
 
 // ---------------------------------------------------------------------------
 // registerTaskId / worktreePathFor

--- a/tests/integration/worktree_manager_test.ts
+++ b/tests/integration/worktree_manager_test.ts
@@ -465,18 +465,15 @@ Deno.test(
     const sentinel = join(outside, "DO_NOT_TOUCH");
     await Deno.writeTextFile(sentinel, "evidence");
     try {
-      // Case 1: a `..`-laced path that starts under worktreesRoot but
-      // climbs out via segment traversal.
-      const traversal = join(
-        rig.workspace,
-        "worktrees",
-        "octo__widgets",
-        "..",
-        "..",
-        "..",
-        // Attempt to land inside the temp-dir hierarchy alongside the workspace.
-        "outside-target",
-      );
+      // Case 1: a raw `..`-laced path that starts under worktreesRoot
+      // but climbs out via segment traversal. Build this with string
+      // concatenation rather than `join(...)` so the literal `..`
+      // segments survive into `registerTaskId()` — `join` would
+      // normalize them away here, hiding the very bug the guard exists
+      // to catch (a corrupt persisted registration containing literal
+      // `..` segments).
+      const worktreesRoot = join(rig.workspace, "worktrees");
+      const traversal = `${worktreesRoot}/octo__widgets/../../../outside-target`;
       const tA = makeTaskId("traversal-task");
       rig.manager.registerTaskId(tA, traversal);
       await assertRejects(

--- a/tests/integration/worktree_manager_test.ts
+++ b/tests/integration/worktree_manager_test.ts
@@ -201,6 +201,33 @@ Deno.test("ensureBareClone: surfaces git failures as GitCommandError", async () 
   }
 });
 
+Deno.test(
+  "ensureBareClone: redacts userinfo credentials from GitCommandError on failure",
+  async () => {
+    const rig = await makeRig();
+    try {
+      // Simulate the W3 supervisor injecting a GitHub App installation
+      // token into the clone URL. The host (`example.invalid`) does not
+      // resolve, so `git clone` fails — and the resulting GitCommandError
+      // must NOT echo the token back to the caller.
+      const token = "ghs_supersecret_token_value";
+      const url = `https://x-access-token:${token}@example.invalid/octo/widgets.git`;
+
+      const error = await assertRejects(
+        () => rig.manager.ensureBareClone(makeRepoFullName("octo/widgets"), url),
+        GitCommandError,
+      );
+      const haystack = `${error.message} ${error.command.join(" ")} ${error.stderr}`;
+      assert(!haystack.includes(token), "token leaked into GitCommandError");
+      assert(!haystack.includes("x-access-token"), "userinfo leaked into GitCommandError");
+      assert(haystack.includes("REDACTED"), "redaction marker present");
+      assert(haystack.includes("example.invalid"), "host kept for debuggability");
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
 // ---------------------------------------------------------------------------
 // createWorktreeForIssue
 // ---------------------------------------------------------------------------
@@ -408,6 +435,33 @@ Deno.test("removeWorktree: tolerates registrations outside the workspace root", 
     await rig.cleanup();
   }
 });
+
+Deno.test(
+  "removeWorktree: cleans up when the bare clone has been deleted out from under us",
+  async () => {
+    const rig = await makeRig();
+    try {
+      const repo = makeRepoFullName("octo/widgets");
+      await rig.manager.ensureBareClone(repo, rig.remoteUrl);
+      const path = await rig.manager.createWorktreeForIssue(repo, makeIssueNumber(11));
+      const taskId = makeTaskId("task-11");
+      rig.manager.registerTaskId(taskId, path);
+
+      // User nukes the bare clone directory — the worktree path still
+      // computes a `repoKey` under `worktreesRoot`, but the bare repo
+      // no longer exists. `git worktree remove`/`prune` would throw
+      // against a non-repo; the manager must fall back to a manual rm.
+      const bareDir = join(rig.workspace, "repos", "octo__widgets.git");
+      await Deno.remove(bareDir, { recursive: true });
+
+      await rig.manager.removeWorktree(taskId);
+      assert(!(await pathExists(path)), "worktree directory cleaned up");
+      assertEquals(rig.manager.worktreePathFor(taskId), undefined);
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
 
 // ---------------------------------------------------------------------------
 // pruneAll


### PR DESCRIPTION
## Summary

Implements [#6](https://github.com/koraytaylan/makina/issues/6) — WorktreeManager that owns the bare clone per repo and per-task worktrees on their own branches.

## Linked issue

Closes #6

## Definition of Done

- [x] JSDoc on every exported symbol; `deno doc --lint` green.
- [x] Integration tests against `Deno.makeTempDir`-backed repos.
- [x] Concurrent worktree creation, removal, and prune-on-startup all covered.
- [x] `deno task ci` is green.

## References

- Plan §Architecture (WorktreeManager); ADR-007.
