### PR TITLE
feat(#4): GitHub App auth with installation token cache

### DIFF
--- a/docs/adrs/010-bypass-octokit-auth-app-cache.md
+++ b/docs/adrs/010-bypass-octokit-auth-app-cache.md
@@ -1,0 +1,77 @@
+# ADR-010: Bypass `@octokit/auth-app`'s built-in token cache
+
+## Status
+
+Accepted (2026-04-26). Refines [ADR-005](005-no-jose-using-octokit-auth-app.md).
+
+## Context
+
+`@octokit/auth-app@7` ships an internal LRU token cache (`dist-src/cache.js`):
+
+- Capacity 15 000 entries.
+- TTL = 1 minute less than the GitHub-issued installation-token lifetime (~59 of 60 minutes).
+- Cache key derived from `installationId` plus optional repository/permission scoping.
+
+By default, `auth({ type: "installation", installationId })` returns the cached token until it falls
+inside the library's own ~1-minute lead window.
+
+The Wave 2 GitHub App auth implementation in `src/github/app-auth.ts` maintains its own cache, keyed
+by the branded `InstallationId`, with refresh lead time
+`INSTALLATION_TOKEN_REFRESH_LEAD_MILLISECONDS` (currently 60 s). The point of _our_ cache is:
+
+1. The branded type means the daemon, not a string-typed Octokit-internal key, owns identity.
+2. The lead time is configurable in one place and unit-testable with an injected clock.
+3. The same cache layer naturally handles in-flight request deduplication for concurrent callers.
+
+If the library's cache is left enabled, those guarantees do not hold:
+
+- The library may serve a token that is still inside its 1-minute window even though our cache
+  considers it expired (or the other way around — clock-granularity drift between the two layers).
+- A future tightening of `INSTALLATION_TOKEN_REFRESH_LEAD_MILLISECONDS` (e.g. to react to a slow
+  network or to widen safety margin) silently does nothing because the library still hands back the
+  pre-existing cached token.
+- Two layers of cache means two places where a stale token can hide — bad for the audit trail on a
+  security boundary that is the actual GitHub auth credential.
+
+## Decision
+
+Pass `refresh: true` on every `@octokit/auth-app` `auth({ type: "installation" })` call from
+`src/github/app-auth.ts`. This bypasses the library's LRU cache and forces a fresh
+`POST /app/installations/{id}/access_tokens` exchange every time _our_ cache decides a refresh is
+needed. Caching is then governed end-to-end by the daemon's logic, never by the library's.
+
+The `refresh: true` flag is encoded as a `readonly refresh: true` field on the
+`InstallationAuthHook` interface so a missed forward (e.g. a future strategy implementation) is a
+TypeScript compile error rather than a silent regression.
+
+A regression-guard test
+(`createGitHubAppAuth: forwards refresh:true to bypass the library's LRU cache`) asserts the flag is
+set on every hook invocation.
+
+## Consequences
+
+**Positive:**
+
+- One cache, one source of truth, one audit point. The daemon's `InstallationId`-keyed cache is the
+  only place a token lives.
+- `INSTALLATION_TOKEN_REFRESH_LEAD_MILLISECONDS` actually controls the refresh boundary. Tuning this
+  constant has the documented effect.
+- The TypeScript signature makes the bypass mandatory; future contributors cannot quietly drop it.
+
+**Negative:**
+
+- We give up the library cache's "free" deduplication and 15 000-entry headroom. Mitigated:
+  - The daemon already deduplicates concurrent requests through its own `inFlight` map.
+  - Realistic deployment has a small constant number of installations, well under any LRU cap.
+- Each refresh always pays the network cost of the install-token exchange. That is the correct
+  trade-off for a security credential — caching past our chosen lead time is exactly what we want to
+  forbid.
+
+## Alternatives considered
+
+- **Match our lead time to the library's** (~60 s) and hope the two caches stay in lockstep.
+  Rejected: relies on a private library implementation detail that the library is free to change in
+  a patch release, and does not solve the dual-source-of-truth problem.
+- **Supply a no-op cache adapter via `createAppAuth`'s undocumented `cache` slot.** Rejected:
+  undocumented surface, no compile-time guarantee, and the per-call `refresh: true` flag is the
+  library's documented escape hatch for exactly this case.

--- a/src/github/app-auth.ts
+++ b/src/github/app-auth.ts
@@ -146,6 +146,8 @@ export class GitHubAppAuthError extends Error {
   readonly operation: string;
 
   /**
+   * Construct a new {@link GitHubAppAuthError}.
+   *
    * @param operation A short identifier for the failing operation.
    * @param cause The original error thrown by `@octokit/auth-app`.
    */

--- a/src/github/app-auth.ts
+++ b/src/github/app-auth.ts
@@ -16,11 +16,14 @@
  * Steps 1 and 2 are delegated to `@octokit/auth-app` per
  * {@link "../../docs/adrs/005-no-jose-using-octokit-auth-app.md" | ADR-005} —
  * we do not reimplement the JOSE/JWT primitives, the install-token
- * exchange, or its retry/clock-skew handling. The cache is **ours**: we
- * intentionally bypass `@octokit/auth-app`'s built-in cache so the lead
- * time matches {@link INSTALLATION_TOKEN_REFRESH_LEAD_MILLISECONDS} exactly
- * and so the cache key is the branded {@link InstallationId} rather than a
- * Octokit-internal string.
+ * exchange, or its retry/clock-skew handling. The cache is **ours**: every
+ * call into `@octokit/auth-app` passes `refresh: true` so its built-in LRU
+ * cache is bypassed and the lead time matches
+ * {@link INSTALLATION_TOKEN_REFRESH_LEAD_MILLISECONDS} exactly. The cache
+ * key is the branded {@link InstallationId} rather than an Octokit-internal
+ * string, which keeps the surface area auditable. See
+ * {@link "../../docs/adrs/010-bypass-octokit-auth-app-cache.md" | ADR-010}
+ * for the trade-off.
  *
  * **Errors.** Anything thrown by `@octokit/auth-app` (private-key parse
  * failure, `403 Bad credentials`, network outage) is rewrapped as a
@@ -60,6 +63,11 @@ export interface CreateAppAuthStrategy {
  * that this module actually uses: ask for an installation token, get back
  * `{ token, expiresAt }`.
  *
+ * The `refresh: true` flag is mandatory and bypasses the library's own
+ * LRU cache (see {@link defaultCreateAppAuthStrategy} for why). Test stubs
+ * may ignore the flag because they have no internal cache, but production
+ * callers MUST forward it to `@octokit/auth-app`.
+ *
  * Modeled as an interface so a test stub can implement it without pulling
  * in the full Octokit `AuthInterface` (which mostly covers OAuth flows we
  * do not exercise).
@@ -68,6 +76,7 @@ export interface InstallationAuthHook {
   (options: {
     readonly type: "installation";
     readonly installationId: number;
+    readonly refresh: true;
   }): Promise<InstallationAuthResult>;
 }
 
@@ -95,14 +104,14 @@ export interface CreateGitHubAppAuthOptions {
    */
   readonly privateKey: string;
   /**
-   * Default installation id passed through to `createAppAuth`. Callers
-   * that target a single installation can omit `installationId` from each
-   * `getInstallationToken` call; the default is used.
+   * Installation id passed through to `createAppAuth`.
    *
-   * Note: every call to {@link GitHubAuth.getInstallationToken} still
-   * receives an explicit {@link InstallationId} per the W1 contract; this
-   * default lets us reuse the same auth strategy for any installation
-   * instead of constructing a fresh one per token request.
+   * This value configures the underlying `@octokit/auth-app` strategy, but
+   * it is **not** a default for the {@link GitHubAuth.getInstallationToken}
+   * parameter: callers still pass an explicit {@link InstallationId} to
+   * each token request per the W1 contract. The single auth strategy is
+   * reused across installations rather than constructed afresh per token
+   * request.
    */
   readonly installationId: number;
   /**
@@ -213,6 +222,12 @@ export function createGitHubAppAuth(opts: CreateGitHubAppAuthOptions): GitHubAut
       result = await authHook({
         type: "installation",
         installationId,
+        // Force `@octokit/auth-app` to bypass its built-in LRU cache so the
+        // refresh decision lives entirely in *our* lead-time logic. Without
+        // this, the library could hand back a stale cached token whose
+        // expiry is closer than INSTALLATION_TOKEN_REFRESH_LEAD_MILLISECONDS
+        // away — defeating the whole point of our cache.
+        refresh: true,
       });
     } catch (error) {
       throw new GitHubAppAuthError("getInstallationToken", error);
@@ -268,6 +283,15 @@ interface CachedToken {
  * Default strategy: real `@octokit/auth-app`. The Octokit `auth()`
  * function returns an `InstallationAccessTokenAuthentication`; we narrow
  * it to the {@link InstallationAuthResult} surface this module needs.
+ *
+ * `@octokit/auth-app` ships with its own LRU cache that holds installation
+ * tokens for ~59 of the GitHub-issued 60 minutes. Forwarding the
+ * `refresh: true` flag from the request bypasses that cache entirely so
+ * cache lifetime is governed *only* by this module's
+ * {@link INSTALLATION_TOKEN_REFRESH_LEAD_MILLISECONDS} lead-time logic.
+ * Without this, near-expiry refreshes initiated by our cache could still
+ * receive the library's stale token and the lead-time guarantee in the
+ * module header would not hold.
  */
 function defaultCreateAppAuthStrategy(options: {
   readonly appId: number;
@@ -279,7 +303,12 @@ function defaultCreateAppAuthStrategy(options: {
     privateKey: options.privateKey,
     ...(options.installationId === undefined ? {} : { installationId: options.installationId }),
   });
-  return (request) => auth({ type: "installation", installationId: request.installationId });
+  return (request) =>
+    auth({
+      type: "installation",
+      installationId: request.installationId,
+      refresh: request.refresh,
+    });
 }
 
 /**

--- a/src/github/app-auth.ts
+++ b/src/github/app-auth.ts
@@ -1,0 +1,322 @@
+/**
+ * github/app-auth.ts — GitHub App authentication backed by
+ * `@octokit/auth-app`.
+ *
+ * Wave 1 froze the {@link GitHubAuth} contract; this module is the real
+ * implementation. The supervisor and the high-level GitHub client both
+ * obtain installation tokens through {@link GitHubAuth.getInstallationToken},
+ * which here is wired to:
+ *
+ * 1. Sign a short-lived (10-minute) JWT with the App's private key.
+ * 2. Exchange the JWT for an installation access token via
+ *    `POST /app/installations/{id}/access_tokens`.
+ * 3. Return the cached token for subsequent calls until
+ *    `expiresAt - INSTALLATION_TOKEN_REFRESH_LEAD_MILLISECONDS`.
+ *
+ * Steps 1 and 2 are delegated to `@octokit/auth-app` per
+ * {@link "../../docs/adrs/005-no-jose-using-octokit-auth-app.md" | ADR-005} —
+ * we do not reimplement the JOSE/JWT primitives, the install-token
+ * exchange, or its retry/clock-skew handling. The cache is **ours**: we
+ * intentionally bypass `@octokit/auth-app`'s built-in cache so the lead
+ * time matches {@link INSTALLATION_TOKEN_REFRESH_LEAD_MILLISECONDS} exactly
+ * and so the cache key is the branded {@link InstallationId} rather than a
+ * Octokit-internal string.
+ *
+ * **Errors.** Anything thrown by `@octokit/auth-app` (private-key parse
+ * failure, `403 Bad credentials`, network outage) is rewrapped as a
+ * {@link GitHubAppAuthError} that names the failing operation. The
+ * original error is preserved on `cause` so call-site tracebacks are not
+ * lost.
+ *
+ * @module
+ */
+
+import { createAppAuth } from "@octokit/auth-app";
+
+import { INSTALLATION_TOKEN_REFRESH_LEAD_MILLISECONDS } from "../constants.ts";
+import { type GitHubAuth, type InstallationId } from "../types.ts";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Strategy function compatible with `@octokit/auth-app`'s `createAppAuth`.
+ *
+ * Tests inject a stub strategy so no JWT signing or HTTPS round-trip
+ * happens; production code uses the default that delegates to the real
+ * `@octokit/auth-app`.
+ */
+export interface CreateAppAuthStrategy {
+  (options: {
+    readonly appId: number;
+    readonly privateKey: string;
+    readonly installationId?: number;
+  }): InstallationAuthHook;
+}
+
+/**
+ * The narrow surface of `@octokit/auth-app`'s returned `auth()` function
+ * that this module actually uses: ask for an installation token, get back
+ * `{ token, expiresAt }`.
+ *
+ * Modeled as an interface so a test stub can implement it without pulling
+ * in the full Octokit `AuthInterface` (which mostly covers OAuth flows we
+ * do not exercise).
+ */
+export interface InstallationAuthHook {
+  (options: {
+    readonly type: "installation";
+    readonly installationId: number;
+  }): Promise<InstallationAuthResult>;
+}
+
+/**
+ * Subset of `@octokit/auth-app`'s `InstallationAccessTokenAuthentication`
+ * we read. `expiresAt` is an ISO-8601 timestamp; the cache compares it
+ * (parsed via `Date.parse`) against the injected clock.
+ */
+export interface InstallationAuthResult {
+  /** The minted installation access token. */
+  readonly token: string;
+  /** ISO-8601 timestamp at which the token stops being valid. */
+  readonly expiresAt: string;
+}
+
+/**
+ * Options accepted by {@link createGitHubAppAuth}.
+ */
+export interface CreateGitHubAppAuthOptions {
+  /** GitHub App id (the integer printed on the App settings page). */
+  readonly appId: number;
+  /**
+   * PEM-encoded private key as a string. Reading the key from disk is the
+   * caller's responsibility (the config loader handles `~/` expansion).
+   */
+  readonly privateKey: string;
+  /**
+   * Default installation id passed through to `createAppAuth`. Callers
+   * that target a single installation can omit `installationId` from each
+   * `getInstallationToken` call; the default is used.
+   *
+   * Note: every call to {@link GitHubAuth.getInstallationToken} still
+   * receives an explicit {@link InstallationId} per the W1 contract; this
+   * default lets us reuse the same auth strategy for any installation
+   * instead of constructing a fresh one per token request.
+   */
+  readonly installationId: number;
+  /**
+   * Optional injection point for the auth strategy factory. Tests pass a
+   * stub; production callers omit this and the real `@octokit/auth-app`
+   * is used.
+   *
+   * @internal
+   */
+  readonly createAppAuthStrategy?: CreateAppAuthStrategy;
+  /**
+   * Optional injection point for the wall-clock used by the cache. Tests
+   * pass a deterministic clock so expiry behavior is reproducible;
+   * production callers omit this and `Date.now()` is used.
+   *
+   * @internal
+   */
+  readonly nowMilliseconds?: () => number;
+}
+
+/**
+ * Error thrown when an underlying `@octokit/auth-app` call fails.
+ *
+ * The message starts with `GitHub App auth failed during <operation>:` so
+ * logs are scannable. The original error (private-key parse error, HTTP
+ * `RequestError`, etc.) is preserved on `cause`.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await auth.getInstallationToken(installationId);
+ * } catch (error) {
+ *   if (error instanceof GitHubAppAuthError) {
+ *     console.error(error.operation, error.cause);
+ *   }
+ * }
+ * ```
+ */
+export class GitHubAppAuthError extends Error {
+  /** The operation that failed (e.g. `"getInstallationToken"`). */
+  readonly operation: string;
+
+  /**
+   * @param operation A short identifier for the failing operation.
+   * @param cause The original error thrown by `@octokit/auth-app`.
+   */
+  constructor(operation: string, cause: unknown) {
+    super(
+      `GitHub App auth failed during ${operation}: ${describeError(cause)}`,
+      { cause },
+    );
+    this.name = "GitHubAppAuthError";
+    this.operation = operation;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a {@link GitHubAuth} backed by `@octokit/auth-app`.
+ *
+ * The returned object holds an in-memory cache keyed by
+ * {@link InstallationId}. A cache entry is reused until it is within
+ * {@link INSTALLATION_TOKEN_REFRESH_LEAD_MILLISECONDS} of its `expiresAt`,
+ * at which point a fresh token is minted.
+ *
+ * Concurrent requests for the same installation share the in-flight
+ * promise so the App is not hit twice for one expiry boundary.
+ *
+ * @param opts See {@link CreateGitHubAppAuthOptions}.
+ * @returns A {@link GitHubAuth} implementation.
+ *
+ * @example
+ * ```ts
+ * const auth = createGitHubAppAuth({
+ *   appId: 1234,
+ *   privateKey: await Deno.readTextFile("private-key.pem"),
+ *   installationId: 9876543,
+ * });
+ * const token = await auth.getInstallationToken(makeInstallationId(9876543));
+ * ```
+ */
+export function createGitHubAppAuth(opts: CreateGitHubAppAuthOptions): GitHubAuth {
+  const strategy = opts.createAppAuthStrategy ?? defaultCreateAppAuthStrategy;
+  const nowMilliseconds = opts.nowMilliseconds ?? defaultNowMilliseconds;
+
+  let authHook: InstallationAuthHook;
+  try {
+    authHook = strategy({
+      appId: opts.appId,
+      privateKey: opts.privateKey,
+      installationId: opts.installationId,
+    });
+  } catch (error) {
+    throw new GitHubAppAuthError("createAppAuth", error);
+  }
+
+  const cache = new Map<InstallationId, CachedToken>();
+  const inFlight = new Map<InstallationId, Promise<string>>();
+
+  async function refresh(installationId: InstallationId): Promise<string> {
+    let result: InstallationAuthResult;
+    try {
+      result = await authHook({
+        type: "installation",
+        installationId,
+      });
+    } catch (error) {
+      throw new GitHubAppAuthError("getInstallationToken", error);
+    }
+    const expiresAtMilliseconds = parseExpiresAt(result.expiresAt);
+    cache.set(installationId, {
+      token: result.token,
+      expiresAtMilliseconds,
+    });
+    return result.token;
+  }
+
+  return {
+    async getInstallationToken(installationId: InstallationId): Promise<string> {
+      const cached = cache.get(installationId);
+      const refreshThreshold = nowMilliseconds() +
+        INSTALLATION_TOKEN_REFRESH_LEAD_MILLISECONDS;
+      if (cached !== undefined && cached.expiresAtMilliseconds > refreshThreshold) {
+        return cached.token;
+      }
+
+      const pending = inFlight.get(installationId);
+      if (pending !== undefined) {
+        return await pending;
+      }
+
+      const promise = refresh(installationId);
+      inFlight.set(installationId, promise);
+      try {
+        return await promise;
+      } finally {
+        inFlight.delete(installationId);
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/**
+ * Cache entry written when a fresh token is minted.
+ */
+interface CachedToken {
+  /** The cached installation access token. */
+  readonly token: string;
+  /** Wall-clock expiry, in milliseconds since the Unix epoch. */
+  readonly expiresAtMilliseconds: number;
+}
+
+/**
+ * Default strategy: real `@octokit/auth-app`. The Octokit `auth()`
+ * function returns an `InstallationAccessTokenAuthentication`; we narrow
+ * it to the {@link InstallationAuthResult} surface this module needs.
+ */
+function defaultCreateAppAuthStrategy(options: {
+  readonly appId: number;
+  readonly privateKey: string;
+  readonly installationId?: number;
+}): InstallationAuthHook {
+  const auth = createAppAuth({
+    appId: options.appId,
+    privateKey: options.privateKey,
+    ...(options.installationId === undefined ? {} : { installationId: options.installationId }),
+  });
+  return (request) => auth({ type: "installation", installationId: request.installationId });
+}
+
+/**
+ * Default clock: `Date.now()` wall-clock in milliseconds since the Unix
+ * epoch.
+ */
+function defaultNowMilliseconds(): number {
+  return Date.now();
+}
+
+/**
+ * Parse the `expiresAt` ISO-8601 string into a millisecond timestamp.
+ * Throws a {@link GitHubAppAuthError} if the string is unparseable —
+ * `@octokit/auth-app` should never produce one, but defensive parsing
+ * keeps a malformed third-party response from poisoning the cache with
+ * `NaN`.
+ */
+function parseExpiresAt(expiresAt: string): number {
+  const milliseconds = Date.parse(expiresAt);
+  if (Number.isNaN(milliseconds)) {
+    throw new GitHubAppAuthError(
+      "parseExpiresAt",
+      new Error(`Could not parse expiresAt timestamp: ${JSON.stringify(expiresAt)}`),
+    );
+  }
+  return milliseconds;
+}
+
+/**
+ * Coerce an unknown thrown value to a printable message. `Error.message`
+ * for true Errors, JSON for everything else.
+ */
+function describeError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}

--- a/src/github/app-auth.ts
+++ b/src/github/app-auth.ts
@@ -104,16 +104,20 @@ export interface CreateGitHubAppAuthOptions {
    */
   readonly privateKey: string;
   /**
-   * Installation id passed through to `createAppAuth`.
+   * Optional installation id forwarded to `createAppAuth` as a seed.
    *
-   * This value configures the underlying `@octokit/auth-app` strategy, but
-   * it is **not** a default for the {@link GitHubAuth.getInstallationToken}
-   * parameter: callers still pass an explicit {@link InstallationId} to
-   * each token request per the W1 contract. The single auth strategy is
-   * reused across installations rather than constructed afresh per token
-   * request.
+   * The authoritative {@link InstallationId} for every token request comes
+   * from the per-call argument to {@link GitHubAuth.getInstallationToken},
+   * not this option. The same `createGitHubAppAuth` instance is reused
+   * across all installations the daemon manages, so this seed is not
+   * required and is only kept for callers that wired a single-installation
+   * auth in early experiments. Prefer omitting it.
+   *
+   * If you do supply this value, it is passed through to `createAppAuth`
+   * but is **not** a fallback default for the
+   * {@link GitHubAuth.getInstallationToken} parameter.
    */
-  readonly installationId: number;
+  readonly installationId?: number;
   /**
    * Optional injection point for the auth strategy factory. Tests pass a
    * stub; production callers omit this and the real `@octokit/auth-app`
@@ -193,7 +197,6 @@ export class GitHubAppAuthError extends Error {
  * const auth = createGitHubAppAuth({
  *   appId: 1234,
  *   privateKey: await Deno.readTextFile("private-key.pem"),
- *   installationId: 9876543,
  * });
  * const token = await auth.getInstallationToken(makeInstallationId(9876543));
  * ```
@@ -207,7 +210,7 @@ export function createGitHubAppAuth(opts: CreateGitHubAppAuthOptions): GitHubAut
     authHook = strategy({
       appId: opts.appId,
       privateKey: opts.privateKey,
-      installationId: opts.installationId,
+      ...(opts.installationId === undefined ? {} : { installationId: opts.installationId }),
     });
   } catch (error) {
     throw new GitHubAppAuthError("createAppAuth", error);

--- a/tests/unit/app_auth_test.ts
+++ b/tests/unit/app_auth_test.ts
@@ -1,0 +1,486 @@
+/**
+ * Unit tests for `src/github/app-auth.ts`. Covers the cache lifecycle
+ * (hit, miss, refresh on near-expiry), error propagation from the
+ * underlying `@octokit/auth-app` strategy, distinct-installation
+ * isolation, and concurrent access.
+ *
+ * Tests inject a stub `createAppAuthStrategy` and an injected clock so
+ * that no real network or `Date.now()` reads happen — every expiry path
+ * is deterministic.
+ */
+
+import { assertEquals, assertNotEquals, assertRejects, assertStrictEquals } from "@std/assert";
+
+import {
+  type CreateAppAuthStrategy,
+  createGitHubAppAuth,
+  GitHubAppAuthError,
+  type InstallationAuthHook,
+  type InstallationAuthResult,
+} from "../../src/github/app-auth.ts";
+import { INSTALLATION_TOKEN_REFRESH_LEAD_MILLISECONDS } from "../../src/constants.ts";
+import { type InstallationId, makeInstallationId } from "../../src/types.ts";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const ONE_HOUR_MILLISECONDS = 60 * 60 * 1_000;
+
+/**
+ * Adjustable clock used by every test that exercises expiry behavior.
+ *
+ * The setter lets a test "advance" virtual time between cache reads.
+ */
+function createClock(initialMilliseconds: number): {
+  now: () => number;
+  set: (milliseconds: number) => void;
+  advance: (deltaMilliseconds: number) => void;
+} {
+  let current = initialMilliseconds;
+  return {
+    now: () => current,
+    set: (milliseconds: number) => {
+      current = milliseconds;
+    },
+    advance: (deltaMilliseconds: number) => {
+      current += deltaMilliseconds;
+    },
+  };
+}
+
+/**
+ * Build a stub strategy that mints deterministic tokens whose `expiresAt`
+ * is `nowMilliseconds + ttl` at mint time. Returns the hook plus a counter
+ * tracking how many times the auth strategy was *invoked* for tokens.
+ */
+function createStubStrategy(args: {
+  /** The synthetic clock used to compute `expiresAt`. */
+  readonly clock: { now: () => number };
+  /**
+   * TTL applied to each minted token (mirrors GitHub's one-hour install
+   * tokens unless overridden).
+   */
+  readonly tokenTtlMilliseconds?: number;
+  /**
+   * Optional pre-baked replies. If supplied, the strategy serves these in
+   * order until exhausted, then falls back to deterministic minting. Each
+   * entry is either a value to return or an error to throw.
+   */
+  readonly scriptedReplies?: Array<
+    | { readonly kind: "value"; readonly value: InstallationAuthResult }
+    | { readonly kind: "error"; readonly error: unknown }
+  >;
+  /** Throw from the strategy *factory* itself (private-key parse failure). */
+  readonly factoryError?: unknown;
+}): {
+  strategy: CreateAppAuthStrategy;
+  authCalls: Array<{ installationId: number }>;
+  factoryCalls: Array<{ appId: number; privateKey: string; installationId?: number }>;
+} {
+  const ttl = args.tokenTtlMilliseconds ?? ONE_HOUR_MILLISECONDS;
+  const scripted = args.scriptedReplies ? [...args.scriptedReplies] : [];
+  const authCalls: Array<{ installationId: number }> = [];
+  const factoryCalls: Array<{ appId: number; privateKey: string; installationId?: number }> = [];
+  let mintCounter = 0;
+
+  const strategy: CreateAppAuthStrategy = (factoryOpts) => {
+    if (factoryOpts.installationId === undefined) {
+      factoryCalls.push({
+        appId: factoryOpts.appId,
+        privateKey: factoryOpts.privateKey,
+      });
+    } else {
+      factoryCalls.push({
+        appId: factoryOpts.appId,
+        privateKey: factoryOpts.privateKey,
+        installationId: factoryOpts.installationId,
+      });
+    }
+    if (args.factoryError !== undefined) {
+      throw args.factoryError;
+    }
+
+    const hook: InstallationAuthHook = (request) => {
+      authCalls.push({ installationId: request.installationId });
+      const next = scripted.shift();
+      if (next !== undefined) {
+        if (next.kind === "error") {
+          return Promise.reject(next.error);
+        }
+        return Promise.resolve(next.value);
+      }
+      mintCounter += 1;
+      const expiresAtMs = args.clock.now() + ttl;
+      return Promise.resolve({
+        token: `stub-token-${request.installationId}-${mintCounter}`,
+        expiresAt: new Date(expiresAtMs).toISOString(),
+      });
+    };
+    return hook;
+  };
+
+  return { strategy, authCalls, factoryCalls };
+}
+
+const COMMON_OPTS = {
+  appId: 1234,
+  privateKey: "-----BEGIN RSA PRIVATE KEY-----\nstub\n-----END RSA PRIVATE KEY-----",
+  installationId: 9876543,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Cache hit / miss / refresh
+// ---------------------------------------------------------------------------
+
+Deno.test("createGitHubAppAuth: returns the cached token on consecutive hits", async () => {
+  const clock = createClock(1_700_000_000_000);
+  const { strategy, authCalls } = createStubStrategy({ clock });
+
+  const auth = createGitHubAppAuth({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    nowMilliseconds: clock.now,
+  });
+
+  const installation = makeInstallationId(9876543);
+  const first = await auth.getInstallationToken(installation);
+  const second = await auth.getInstallationToken(installation);
+  const third = await auth.getInstallationToken(installation);
+
+  assertEquals(first, second);
+  assertEquals(second, third);
+  assertEquals(authCalls.length, 1, "underlying strategy should mint once");
+});
+
+Deno.test("createGitHubAppAuth: cache miss mints a fresh token on first call", async () => {
+  const clock = createClock(0);
+  const { strategy, authCalls } = createStubStrategy({ clock });
+
+  const auth = createGitHubAppAuth({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    nowMilliseconds: clock.now,
+  });
+
+  const token = await auth.getInstallationToken(makeInstallationId(9876543));
+  assertEquals(token.startsWith("stub-token-9876543-"), true);
+  assertEquals(authCalls.length, 1);
+  assertEquals(authCalls[0]?.installationId, 9876543);
+});
+
+Deno.test("createGitHubAppAuth: refreshes when within the lead-time window", async () => {
+  const clock = createClock(1_700_000_000_000);
+  const { strategy, authCalls } = createStubStrategy({ clock });
+
+  const auth = createGitHubAppAuth({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    nowMilliseconds: clock.now,
+  });
+
+  const installation = makeInstallationId(9876543);
+  const first = await auth.getInstallationToken(installation);
+  // Advance past TTL minus the refresh lead time. The cache should
+  // consider the token expired and mint a new one.
+  clock.advance(ONE_HOUR_MILLISECONDS - INSTALLATION_TOKEN_REFRESH_LEAD_MILLISECONDS);
+  const second = await auth.getInstallationToken(installation);
+
+  assertNotEquals(first, second);
+  assertEquals(authCalls.length, 2);
+});
+
+Deno.test("createGitHubAppAuth: keeps the cached token just before the lead-time boundary", async () => {
+  const clock = createClock(1_700_000_000_000);
+  const { strategy, authCalls } = createStubStrategy({ clock });
+
+  const auth = createGitHubAppAuth({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    nowMilliseconds: clock.now,
+  });
+
+  const installation = makeInstallationId(9876543);
+  const first = await auth.getInstallationToken(installation);
+  // Advance to *one millisecond before* the refresh boundary. The cached
+  // token's `expiresAt` is `t0 + ONE_HOUR`; the refresh threshold under
+  // strict-greater semantics is `t0 + ONE_HOUR - LEAD - 1` ms.
+  clock.advance(ONE_HOUR_MILLISECONDS - INSTALLATION_TOKEN_REFRESH_LEAD_MILLISECONDS - 1);
+  const second = await auth.getInstallationToken(installation);
+
+  assertEquals(first, second);
+  assertEquals(authCalls.length, 1);
+});
+
+Deno.test("createGitHubAppAuth: refreshes once the token has fully expired", async () => {
+  const clock = createClock(1_700_000_000_000);
+  const { strategy, authCalls } = createStubStrategy({ clock });
+
+  const auth = createGitHubAppAuth({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    nowMilliseconds: clock.now,
+  });
+
+  const installation = makeInstallationId(9876543);
+  await auth.getInstallationToken(installation);
+  clock.advance(ONE_HOUR_MILLISECONDS * 2);
+  const second = await auth.getInstallationToken(installation);
+
+  assertEquals(second.endsWith("-2"), true);
+  assertEquals(authCalls.length, 2);
+});
+
+// ---------------------------------------------------------------------------
+// Per-installation isolation
+// ---------------------------------------------------------------------------
+
+Deno.test("createGitHubAppAuth: distinct installations get distinct cache entries", async () => {
+  const clock = createClock(1_700_000_000_000);
+  const { strategy, authCalls } = createStubStrategy({ clock });
+
+  const auth = createGitHubAppAuth({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    nowMilliseconds: clock.now,
+  });
+
+  const a = await auth.getInstallationToken(makeInstallationId(1));
+  const b = await auth.getInstallationToken(makeInstallationId(2));
+  const aAgain = await auth.getInstallationToken(makeInstallationId(1));
+
+  assertNotEquals(a, b);
+  assertEquals(a, aAgain);
+  assertEquals(authCalls.length, 2);
+  assertEquals(authCalls[0]?.installationId, 1);
+  assertEquals(authCalls[1]?.installationId, 2);
+});
+
+// ---------------------------------------------------------------------------
+// Concurrency
+// ---------------------------------------------------------------------------
+
+Deno.test("createGitHubAppAuth: concurrent first calls share one in-flight refresh", async () => {
+  const clock = createClock(1_700_000_000_000);
+  let resolveAuth: ((value: InstallationAuthResult) => void) | undefined;
+  let invocations = 0;
+  const strategy: CreateAppAuthStrategy = () => {
+    return () => {
+      invocations += 1;
+      return new Promise((resolve) => {
+        resolveAuth = resolve;
+      });
+    };
+  };
+
+  const auth = createGitHubAppAuth({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    nowMilliseconds: clock.now,
+  });
+
+  const installation = makeInstallationId(9876543);
+  const pendingA = auth.getInstallationToken(installation);
+  const pendingB = auth.getInstallationToken(installation);
+  // Both calls should be waiting on the same single underlying request.
+  if (resolveAuth === undefined) {
+    throw new Error("strategy should have been invoked exactly once before resolving");
+  }
+  resolveAuth({
+    token: "concurrent-token",
+    expiresAt: new Date(clock.now() + ONE_HOUR_MILLISECONDS).toISOString(),
+  });
+  const [a, b] = await Promise.all([pendingA, pendingB]);
+  assertEquals(a, b);
+  assertEquals(a, "concurrent-token");
+  assertEquals(invocations, 1);
+});
+
+Deno.test("createGitHubAppAuth: in-flight refresh failure does not leak across calls", async () => {
+  const clock = createClock(1_700_000_000_000);
+  const { strategy } = createStubStrategy({
+    clock,
+    scriptedReplies: [
+      { kind: "error", error: new Error("transient 503") },
+      {
+        kind: "value",
+        value: {
+          token: "recovered",
+          expiresAt: new Date(clock.now() + ONE_HOUR_MILLISECONDS).toISOString(),
+        },
+      },
+    ],
+  });
+
+  const auth = createGitHubAppAuth({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    nowMilliseconds: clock.now,
+  });
+
+  const installation = makeInstallationId(9876543);
+  await assertRejects(
+    () => auth.getInstallationToken(installation),
+    GitHubAppAuthError,
+    "transient 503",
+  );
+  // Second call should re-attempt rather than serve a poisoned cache entry.
+  const second = await auth.getInstallationToken(installation);
+  assertEquals(second, "recovered");
+});
+
+// ---------------------------------------------------------------------------
+// Error propagation
+// ---------------------------------------------------------------------------
+
+Deno.test("createGitHubAppAuth: wraps install-token errors as GitHubAppAuthError", async () => {
+  const clock = createClock(0);
+  const { strategy } = createStubStrategy({
+    clock,
+    scriptedReplies: [{
+      kind: "error",
+      error: new Error("Bad credentials"),
+    }],
+  });
+
+  const auth = createGitHubAppAuth({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    nowMilliseconds: clock.now,
+  });
+
+  const error = await assertRejects(
+    () => auth.getInstallationToken(makeInstallationId(9876543)),
+    GitHubAppAuthError,
+  );
+  assertEquals(error.operation, "getInstallationToken");
+  assertEquals(
+    error.message.startsWith("GitHub App auth failed during getInstallationToken:"),
+    true,
+  );
+  assertEquals(error.message.includes("Bad credentials"), true);
+  // Cause is preserved.
+  assertStrictEquals((error.cause as Error).message, "Bad credentials");
+});
+
+Deno.test("createGitHubAppAuth: rethrows strategy-factory errors as GitHubAppAuthError", () => {
+  const { strategy } = createStubStrategy({
+    clock: { now: () => 0 },
+    factoryError: new Error("invalid PEM"),
+  });
+
+  let caught: unknown;
+  try {
+    createGitHubAppAuth({
+      ...COMMON_OPTS,
+      createAppAuthStrategy: strategy,
+      nowMilliseconds: () => 0,
+    });
+  } catch (error) {
+    caught = error;
+  }
+  if (!(caught instanceof GitHubAppAuthError)) {
+    throw new Error("expected GitHubAppAuthError");
+  }
+  assertEquals(caught.operation, "createAppAuth");
+  assertEquals(caught.message.includes("invalid PEM"), true);
+  assertStrictEquals((caught.cause as Error).message, "invalid PEM");
+});
+
+Deno.test("createGitHubAppAuth: surfaces non-Error rejection values via stringification", async () => {
+  const clock = createClock(0);
+  const { strategy } = createStubStrategy({
+    clock,
+    scriptedReplies: [{ kind: "error", error: { code: "ENETUNREACH" } }],
+  });
+
+  const auth = createGitHubAppAuth({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    nowMilliseconds: clock.now,
+  });
+
+  const error = await assertRejects(
+    () => auth.getInstallationToken(makeInstallationId(9876543)),
+    GitHubAppAuthError,
+  );
+  assertEquals(error.message.includes("ENETUNREACH"), true);
+});
+
+Deno.test("createGitHubAppAuth: rejects an unparseable expiresAt timestamp", async () => {
+  const clock = createClock(0);
+  const { strategy } = createStubStrategy({
+    clock,
+    scriptedReplies: [{
+      kind: "value",
+      value: { token: "garbled", expiresAt: "not-a-date" },
+    }],
+  });
+
+  const auth = createGitHubAppAuth({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    nowMilliseconds: clock.now,
+  });
+
+  const error = await assertRejects(
+    () => auth.getInstallationToken(makeInstallationId(9876543)),
+    GitHubAppAuthError,
+  );
+  assertEquals(error.operation, "parseExpiresAt");
+});
+
+// ---------------------------------------------------------------------------
+// Strategy wiring
+// ---------------------------------------------------------------------------
+
+Deno.test("createGitHubAppAuth: forwards appId/privateKey/installationId to the strategy", () => {
+  const clock = createClock(0);
+  const { strategy, factoryCalls } = createStubStrategy({ clock });
+
+  createGitHubAppAuth({
+    appId: 4321,
+    privateKey: "PEM",
+    installationId: 99,
+    createAppAuthStrategy: strategy,
+    nowMilliseconds: clock.now,
+  });
+
+  assertEquals(factoryCalls.length, 1);
+  assertEquals(factoryCalls[0]?.appId, 4321);
+  assertEquals(factoryCalls[0]?.privateKey, "PEM");
+  assertEquals(factoryCalls[0]?.installationId, 99);
+});
+
+Deno.test("createGitHubAppAuth: passes the requested installationId on each token call", async () => {
+  const clock = createClock(0);
+  const { strategy, authCalls } = createStubStrategy({ clock });
+
+  const auth = createGitHubAppAuth({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    nowMilliseconds: clock.now,
+  });
+
+  await auth.getInstallationToken(makeInstallationId(11));
+  await auth.getInstallationToken(makeInstallationId(22));
+
+  assertEquals(authCalls.map((c) => c.installationId), [11, 22]);
+});
+
+// ---------------------------------------------------------------------------
+// Type sanity
+// ---------------------------------------------------------------------------
+
+Deno.test("createGitHubAppAuth: returned object satisfies the W1 GitHubAuth interface", async () => {
+  const clock = createClock(0);
+  const { strategy } = createStubStrategy({ clock });
+  const auth = createGitHubAppAuth({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    nowMilliseconds: clock.now,
+  });
+  const installation: InstallationId = makeInstallationId(9876543);
+  const result: string = await auth.getInstallationToken(installation);
+  assertEquals(typeof result, "string");
+});

--- a/tests/unit/app_auth_test.ts
+++ b/tests/unit/app_auth_test.ts
@@ -484,3 +484,83 @@ Deno.test("createGitHubAppAuth: returned object satisfies the W1 GitHubAuth inte
   const result: string = await auth.getInstallationToken(installation);
   assertEquals(typeof result, "string");
 });
+
+// ---------------------------------------------------------------------------
+// Default-injection paths
+// ---------------------------------------------------------------------------
+//
+// The two paths below exercise the production default factories so the
+// `?? defaultCreateAppAuthStrategy` and `?? defaultNowMilliseconds`
+// branches do not stay dead code in coverage. We do not let the real
+// `@octokit/auth-app` perform any HTTP request — we cancel before the
+// install-token exchange ever fires.
+
+Deno.test("createGitHubAppAuth: default factory hooks the real @octokit/auth-app", async () => {
+  // Real @octokit/auth-app requires a parseable PEM at construction. A
+  // deliberately-malformed key proves the default factory was actually
+  // invoked: the call must throw a GitHubAppAuthError tagged
+  // `getInstallationToken` (the install-token call delegates JWT signing
+  // to the lazy auth() invocation, so the error surfaces there).
+  const auth = createGitHubAppAuth({
+    appId: 1234,
+    privateKey: "-----BEGIN RSA PRIVATE KEY-----\nnot-a-real-key\n-----END RSA PRIVATE KEY-----",
+    installationId: 9876543,
+  });
+  await assertRejects(
+    () => auth.getInstallationToken(makeInstallationId(9876543)),
+    GitHubAppAuthError,
+  );
+});
+
+Deno.test("createGitHubAppAuth: default clock falls back to Date.now()", async () => {
+  // Provide a stub strategy but omit `nowMilliseconds` so the production
+  // default (`Date.now`) is exercised. The token mints with a TTL much
+  // larger than any real clock skew, so a single hit/refresh cycle is
+  // deterministic against wall-clock time.
+  const farFutureExpiry = new Date(Date.now() + ONE_HOUR_MILLISECONDS).toISOString();
+  let invocations = 0;
+  const strategy: CreateAppAuthStrategy = () => {
+    return () => {
+      invocations += 1;
+      return Promise.resolve({
+        token: `default-clock-token-${invocations}`,
+        expiresAt: farFutureExpiry,
+      });
+    };
+  };
+
+  const auth = createGitHubAppAuth({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+  });
+
+  const first = await auth.getInstallationToken(makeInstallationId(9876543));
+  const second = await auth.getInstallationToken(makeInstallationId(9876543));
+  assertEquals(first, second);
+  assertEquals(invocations, 1);
+});
+
+Deno.test("createGitHubAppAuth: surfaces unprintable thrown values as String(error)", async () => {
+  // Build a circular structure so JSON.stringify throws inside
+  // describeError; the fallback is `String(error)`.
+  const circular: Record<string, unknown> = {};
+  circular.self = circular;
+
+  const clock = createClock(0);
+  const { strategy } = createStubStrategy({
+    clock,
+    scriptedReplies: [{ kind: "error", error: circular }],
+  });
+  const auth = createGitHubAppAuth({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    nowMilliseconds: clock.now,
+  });
+
+  const error = await assertRejects(
+    () => auth.getInstallationToken(makeInstallationId(9876543)),
+    GitHubAppAuthError,
+  );
+  // Default `String({})` formats as "[object Object]".
+  assertEquals(error.message.endsWith("[object Object]"), true);
+});

--- a/tests/unit/app_auth_test.ts
+++ b/tests/unit/app_auth_test.ts
@@ -75,12 +75,12 @@ function createStubStrategy(args: {
   readonly factoryError?: unknown;
 }): {
   strategy: CreateAppAuthStrategy;
-  authCalls: Array<{ installationId: number }>;
+  authCalls: Array<{ installationId: number; refresh: true }>;
   factoryCalls: Array<{ appId: number; privateKey: string; installationId?: number }>;
 } {
   const ttl = args.tokenTtlMilliseconds ?? ONE_HOUR_MILLISECONDS;
   const scripted = args.scriptedReplies ? [...args.scriptedReplies] : [];
-  const authCalls: Array<{ installationId: number }> = [];
+  const authCalls: Array<{ installationId: number; refresh: true }> = [];
   const factoryCalls: Array<{ appId: number; privateKey: string; installationId?: number }> = [];
   let mintCounter = 0;
 
@@ -102,7 +102,7 @@ function createStubStrategy(args: {
     }
 
     const hook: InstallationAuthHook = (request) => {
-      authCalls.push({ installationId: request.installationId });
+      authCalls.push({ installationId: request.installationId, refresh: request.refresh });
       const next = scripted.shift();
       if (next !== undefined) {
         if (next.kind === "error") {
@@ -468,6 +468,32 @@ Deno.test("createGitHubAppAuth: passes the requested installationId on each toke
   assertEquals(authCalls.map((c) => c.installationId), [11, 22]);
 });
 
+Deno.test("createGitHubAppAuth: forwards refresh:true to bypass the library's LRU cache", async () => {
+  // Regression guard for the security boundary documented in the module
+  // header: every authHook invocation must set `refresh: true` so the
+  // library does not serve a stale token from its own LRU cache and
+  // defeat our INSTALLATION_TOKEN_REFRESH_LEAD_MILLISECONDS lead time.
+  const clock = createClock(1_700_000_000_000);
+  const { strategy, authCalls } = createStubStrategy({ clock });
+
+  const auth = createGitHubAppAuth({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    nowMilliseconds: clock.now,
+  });
+
+  const installation = makeInstallationId(9876543);
+  await auth.getInstallationToken(installation);
+  // Force a refresh by advancing past the lead-time window.
+  clock.advance(ONE_HOUR_MILLISECONDS - INSTALLATION_TOKEN_REFRESH_LEAD_MILLISECONDS);
+  await auth.getInstallationToken(installation);
+
+  assertEquals(authCalls.length, 2);
+  for (const call of authCalls) {
+    assertEquals(call.refresh, true);
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Type sanity
 // ---------------------------------------------------------------------------
@@ -501,15 +527,35 @@ Deno.test("createGitHubAppAuth: default factory hooks the real @octokit/auth-app
   // invoked: the call must throw a GitHubAppAuthError tagged
   // `getInstallationToken` (the install-token call delegates JWT signing
   // to the lazy auth() invocation, so the error surfaces there).
-  const auth = createGitHubAppAuth({
-    appId: 1234,
-    privateKey: "-----BEGIN RSA PRIVATE KEY-----\nnot-a-real-key\n-----END RSA PRIVATE KEY-----",
-    installationId: 9876543,
-  });
-  await assertRejects(
-    () => auth.getInstallationToken(makeInstallationId(9876543)),
-    GitHubAppAuthError,
-  );
+  //
+  // Explicitly forbid outbound HTTP in this unit test. If library behavior
+  // changes and reaches the install-token exchange, the fetch stub will
+  // make that visible — the assertion below verifies the failure was a
+  // local JWT/private-key parse error, not a network call.
+  const originalFetch = globalThis.fetch;
+  const unexpectedNetworkMessage = "unexpected network call in unit test";
+  globalThis.fetch = (() => {
+    throw new Error(unexpectedNetworkMessage);
+  }) as typeof fetch;
+
+  try {
+    const auth = createGitHubAppAuth({
+      appId: 1234,
+      privateKey: "-----BEGIN RSA PRIVATE KEY-----\nnot-a-real-key\n-----END RSA PRIVATE KEY-----",
+      installationId: 9876543,
+    });
+    const error = await assertRejects(
+      () => auth.getInstallationToken(makeInstallationId(9876543)),
+      GitHubAppAuthError,
+    );
+    assertNotEquals(
+      error.message.includes(unexpectedNetworkMessage),
+      true,
+      "expected the failure to be a local JWT/PEM parse error, not an outbound HTTP call",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 Deno.test("createGitHubAppAuth: default clock falls back to Date.now()", async () => {

--- a/tests/unit/app_auth_test.ts
+++ b/tests/unit/app_auth_test.ts
@@ -521,41 +521,39 @@ Deno.test("createGitHubAppAuth: returned object satisfies the W1 GitHubAuth inte
 // `@octokit/auth-app` perform any HTTP request — we cancel before the
 // install-token exchange ever fires.
 
-Deno.test("createGitHubAppAuth: default factory hooks the real @octokit/auth-app", async () => {
-  // Real @octokit/auth-app requires a parseable PEM at construction. A
-  // deliberately-malformed key proves the default factory was actually
-  // invoked: the call must throw a GitHubAppAuthError tagged
-  // `getInstallationToken` (the install-token call delegates JWT signing
-  // to the lazy auth() invocation, so the error surfaces there).
-  //
-  // Explicitly forbid outbound HTTP in this unit test. If library behavior
-  // changes and reaches the install-token exchange, the fetch stub will
-  // make that visible — the assertion below verifies the failure was a
-  // local JWT/private-key parse error, not a network call.
-  const originalFetch = globalThis.fetch;
-  const unexpectedNetworkMessage = "unexpected network call in unit test";
-  globalThis.fetch = (() => {
-    throw new Error(unexpectedNetworkMessage);
-  }) as typeof fetch;
-
-  try {
+Deno.test({
+  name: "createGitHubAppAuth: default factory hooks the real @octokit/auth-app",
+  // Sandbox this test so it cannot make a real network call even by
+  // accident. Per-test permissions are scoped to this test only — they do
+  // not affect other tests running in `--parallel` mode (no globals
+  // mutated). If `@octokit/auth-app` ever changes behavior and reaches the
+  // install-token exchange, Deno raises `PermissionDenied` and the
+  // assertion below catches that distinct failure mode.
+  permissions: { net: false },
+  async fn() {
+    // Real @octokit/auth-app requires a parseable PEM. A deliberately
+    // malformed key proves the default factory was actually wired up: the
+    // first `getInstallationToken` call must throw a GitHubAppAuthError
+    // tagged `getInstallationToken` because the install-token path
+    // delegates JWT signing to the lazy `auth()` invocation, and JWT
+    // signing fails on the bad PEM before any HTTP request is built.
     const auth = createGitHubAppAuth({
       appId: 1234,
       privateKey: "-----BEGIN RSA PRIVATE KEY-----\nnot-a-real-key\n-----END RSA PRIVATE KEY-----",
-      installationId: 9876543,
     });
     const error = await assertRejects(
       () => auth.getInstallationToken(makeInstallationId(9876543)),
       GitHubAppAuthError,
     );
+    // PermissionDenied carries the literal phrase "Requires net access" in
+    // Deno 2.x — assert it is NOT present so a future library change that
+    // reaches `fetch` cannot silently pass this regression guard.
     assertNotEquals(
-      error.message.includes(unexpectedNetworkMessage),
+      error.message.includes("Requires net access"),
       true,
-      "expected the failure to be a local JWT/PEM parse error, not an outbound HTTP call",
+      "expected a local JWT/PEM parse error, not a network permission denial",
     );
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
+  },
 });
 
 Deno.test("createGitHubAppAuth: default clock falls back to Date.now()", async () => {


### PR DESCRIPTION
## Summary

Implements [#4](https://github.com/koraytaylan/makina/issues/4) — GitHub App JWT signing + installation token exchange + expiry-aware cache.

## Linked issue

Closes #4

## Definition of Done

- [x] JSDoc on every exported symbol; `deno doc --lint` green.
- [x] Tests cover cache hit, miss, near-expiry refresh, error propagation.
- [x] Commits follow Conventional Commits.
- [x] `deno task ci` is green.

## References

- Plan §Architecture (GitHubClient); ADR-005.
