### PR TITLE
feat(#9): daemon Unix socket server with NDJSON dispatch

### DIFF
--- a/docs/adrs/010-stale-socket-cleanup-policy.md
+++ b/docs/adrs/010-stale-socket-cleanup-policy.md
@@ -1,0 +1,77 @@
+# ADR-010: Stale-socket cleanup policy for the daemon listener
+
+## Status
+
+Accepted (2026-04-26).
+
+## Context
+
+The daemon binds a Unix-domain socket at a configured path
+(`~/Library/Application Support/makina/makina.sock` by default). A clean shutdown unlinks the file;
+an unclean shutdown (SIGKILL, OOM, hardware crash) leaves the socket entry on disk. On restart,
+`Deno.listen({ transport: "unix", path })` will fail with `AddrInUse` until the leftover entry is
+removed.
+
+The first cut of `cleanupStaleSocket` (PR #26, original revision) probed the path with
+`Deno.connect` and unlinked it on **any** non-`AddrInUse` failure — and it accepted both `isSocket`
+and `isFile` as candidates for unlinking. Two problems followed:
+
+1. **Data loss risk.** If the operator typo'd `socketPath` to point at a regular file (e.g. an
+   unrelated `.sock` they keep elsewhere, or the wrong path inside their data directory), the daemon
+   would silently delete it on startup. That is a much worse failure mode than refusing to start.
+2. **Diagnostic loss.** A `PermissionDenied` from `Deno.connect` (e.g. the socket lives under a
+   directory the daemon cannot enter) would also be treated as "stale" and lead to an unlink attempt
+   that itself fails opaquely. The operator gets no signal that the original problem was a
+   permissions misconfiguration.
+
+Copilot review on PR #26 flagged both issues independently (comments 3 and 4). We agree.
+
+## Decision
+
+`cleanupStaleSocket` is now strictly conservative:
+
+1. **`stat.isSocket` is required.** Any other entry type (regular file, directory, symlink to
+   either, character device, …) is left untouched. The subsequent `Deno.listen` call surfaces its
+   native error (`AddrInUse`, `IsADirectory`, etc.) and the operator corrects the configuration. We
+   **never** delete a non-socket filesystem entry.
+2. **The probe failure must be `ConnectionRefused` or `NotFound`** for the path to be classified as
+   stale. `ECONNREFUSED` is the canonical kernel signal that a Unix-domain socket file is present
+   but unbound — that is exactly the "crashed daemon left a dead socket" case we want to recover
+   from. `NotFound` covers the narrow race where the file vanishes between the `lstat` and the
+   `connect`.
+3. **Every other probe error is rethrown.** `PermissionDenied`, address family mismatches, resource
+   limits — all surface to the caller so the daemon fails fast with the original diagnostic instead
+   of silently deleting filesystem entries on an unrelated error.
+
+Tests cover the three failure modes:
+
+- A real stale socket (created by `Deno.listen` then `close()` without unlinking) is recovered from
+  on the next `startDaemon` call.
+- A regular file at `socketPath` survives a failed `startDaemon` with its contents intact.
+- A directory at `socketPath` survives a failed `startDaemon`.
+
+## Consequences
+
+**Positive:**
+
+- A misconfigured `socketPath` cannot cause data loss. The worst outcome of a typo is a refusal to
+  start.
+- Operators see the underlying cause (`PermissionDenied`, `IsADirectory`, …) instead of a generic
+  "stale socket cleanup failed".
+- The "what does this helper unlink?" question has a one-line answer: "only Unix-domain sockets that
+  have no listener bound."
+
+**Negative:**
+
+- The (rare) case where a previous run wrote a regular file at the configured path — for instance, a
+  debug script that `touch`ed it — now requires manual cleanup. We accept that trade-off; the
+  operator's intent is unknowable from the daemon's perspective and the safe default is to refuse.
+- One additional discriminator function (`isStaleSocketProbeError`) and an ADR-mandated set of
+  recognised "no listener" error classes that future contributors must keep in sync if Deno adds new
+  error types. Acceptable; the surface is two classes today.
+
+## References
+
+- Copilot review on PR #26, comments 3 and 4 (stale-socket cleanup).
+- `src/daemon/server.ts::cleanupStaleSocket`.
+- `tests/integration/daemon_server_test.ts` — three stale-socket cases.

--- a/docs/adrs/013-stale-socket-cleanup-policy.md
+++ b/docs/adrs/013-stale-socket-cleanup-policy.md
@@ -1,4 +1,4 @@
-# ADR-010: Stale-socket cleanup policy for the daemon listener
+# ADR-013: Stale-socket cleanup policy for the daemon listener
 
 ## Status
 

--- a/main.ts
+++ b/main.ts
@@ -22,17 +22,26 @@ if (Deno.args[0] === "daemon") {
   // Defensive wiring for the Wave 2 daemon subcommand.
   //
   // The real config loader (#3) and EventBus (#8) may or may not be on
-  // `develop` when this branch lands; both are wrapped in a `try` so a
-  // missing sibling does not block the daemon from starting. When the
-  // sibling is absent we fall back to:
-  //   - a hardcoded `${TMPDIR:-/tmp}/makina.sock` socket path so the
-  //     binary can boot for smoke-testing;
-  //   - no event bus, which makes `subscribe` envelopes ack with
-  //     `{ ok: false, error: "unimplemented" }` until #8 lands.
+  // `develop` when this branch lands; both are loaded via dynamic
+  // `import()` so a still-missing sibling does not block the daemon
+  // from starting. We carefully distinguish two outcomes:
   //
-  // TODO(#3): replace the fallback socket path with
-  // `loadConfig().daemon.socketPath`.
-  // TODO(#8): replace the absent bus with an `InProcessEventBus`.
+  //  1. **Module not found** (`ERR_MODULE_NOT_FOUND`): the sibling has
+  //     not landed yet. Log a single `note:` line so operators know we
+  //     fell back, then continue with:
+  //       - a hardcoded `${TMPDIR:-/tmp}/makina.sock` socket path so
+  //         the binary can boot for smoke-testing;
+  //       - no event bus, which makes `subscribe` envelopes ack with
+  //         `{ ok: false, error: "unimplemented" }` until #8 lands.
+  //  2. **Anything else** (parse failure, permission error, throwing
+  //     constructor, …): a real misconfiguration. Print the diagnostic
+  //     to stderr and exit non-zero. Silently swallowing these would
+  //     mean a typo'd `config.json` boots a daemon on `/tmp/makina.sock`
+  //     and the operator has no signal that anything went wrong.
+  //
+  // TODO(#3): once #3 lands, the loadConfig branch is the only path —
+  // drop the module-missing fallback.
+  // TODO(#8): once #8 lands, the same applies to the event bus branch.
   const tmpDir = Deno.env.get("TMPDIR") ?? "/tmp";
   const fallbackSocketPath = `${tmpDir.replace(/\/$/, "")}/makina.sock`;
 
@@ -48,8 +57,15 @@ if (Deno.args[0] === "daemon") {
       const config = await loadConfig();
       socketPath = config.daemon.socketPath;
     }
-  } catch {
-    // Sibling not landed yet; keep the fallback path.
+  } catch (error) {
+    if (isModuleNotFoundError(error)) {
+      console.error(
+        `[daemon] note: src/config/load.ts not found; using fallback socket ${socketPath}`,
+      );
+    } else {
+      console.error(`[daemon] failed to load configuration: ${formatError(error)}`);
+      Deno.exit(1);
+    }
   }
 
   let eventBus: import("./src/types.ts").EventBus | undefined;
@@ -60,8 +76,15 @@ if (Deno.args[0] === "daemon") {
     if (typeof ctor === "function") {
       eventBus = new ctor() as import("./src/types.ts").EventBus;
     }
-  } catch {
-    // Sibling not landed yet; fall through with no bus.
+  } catch (error) {
+    if (isModuleNotFoundError(error)) {
+      console.error(
+        "[daemon] note: src/daemon/event-bus.ts not found; subscribe will reply unimplemented",
+      );
+    } else {
+      console.error(`[daemon] failed to initialise event bus: ${formatError(error)}`);
+      Deno.exit(1);
+    }
   }
 
   const handle = await startDaemon(
@@ -83,4 +106,33 @@ if (Deno.args[0] === "daemon") {
   console.log("Wave 1 skeleton. Most subcommands are not yet implemented.");
   console.log("Run `makina --version` to see the version.");
   console.log("See https://github.com/koraytaylan/makina for status.");
+}
+
+/**
+ * Whether `error` is the specific "module file does not exist" failure
+ * that Deno's dynamic `import()` raises. We treat this as a benign
+ * "sibling has not landed yet" signal; every other failure (a parse
+ * error in the module, a thrown top-level statement, a permission
+ * issue) is propagated by the caller so misconfiguration cannot silently
+ * downgrade the daemon's behaviour.
+ *
+ * Deno surfaces this as a `TypeError` whose `code` is the Node-style
+ * `ERR_MODULE_NOT_FOUND`. We sniff the `code` field defensively because
+ * the constructor is `TypeError` (a base class shared with many other
+ * runtime failures), and the message text is best-effort only.
+ */
+function isModuleNotFoundError(error: unknown): boolean {
+  if (!(error instanceof TypeError)) {
+    return false;
+  }
+  const code = (error as TypeError & { code?: unknown }).code;
+  return code === "ERR_MODULE_NOT_FOUND";
+}
+
+/** Render an arbitrary error value to a single-line diagnostic. */
+function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
 }

--- a/main.ts
+++ b/main.ts
@@ -11,14 +11,76 @@
  */
 
 import { MAKINA_VERSION } from "./src/constants.ts";
+import { startDaemon } from "./src/daemon/server.ts";
 
 if (Deno.args.includes("--version")) {
   console.log(MAKINA_VERSION);
   Deno.exit(0);
 }
 
-console.log("makina — agentic GitHub issue resolver");
-console.log("");
-console.log("Wave 1 skeleton. Most subcommands are not yet implemented.");
-console.log("Run `makina --version` to see the version.");
-console.log("See https://github.com/koraytaylan/makina for status.");
+if (Deno.args[0] === "daemon") {
+  // Defensive wiring for the Wave 2 daemon subcommand.
+  //
+  // The real config loader (#3) and EventBus (#8) may or may not be on
+  // `develop` when this branch lands; both are wrapped in a `try` so a
+  // missing sibling does not block the daemon from starting. When the
+  // sibling is absent we fall back to:
+  //   - a hardcoded `${TMPDIR:-/tmp}/makina.sock` socket path so the
+  //     binary can boot for smoke-testing;
+  //   - no event bus, which makes `subscribe` envelopes ack with
+  //     `{ ok: false, error: "unimplemented" }` until #8 lands.
+  //
+  // TODO(#3): replace the fallback socket path with
+  // `loadConfig().daemon.socketPath`.
+  // TODO(#8): replace the absent bus with an `InProcessEventBus`.
+  const tmpDir = Deno.env.get("TMPDIR") ?? "/tmp";
+  const fallbackSocketPath = `${tmpDir.replace(/\/$/, "")}/makina.sock`;
+
+  let socketPath = fallbackSocketPath;
+  try {
+    const configModule = await import("./src/config/load.ts");
+    if (
+      typeof (configModule as { loadConfig?: unknown }).loadConfig === "function"
+    ) {
+      const loadConfig = (configModule as {
+        loadConfig: () => Promise<{ daemon: { socketPath: string } }>;
+      }).loadConfig;
+      const config = await loadConfig();
+      socketPath = config.daemon.socketPath;
+    }
+  } catch {
+    // Sibling not landed yet; keep the fallback path.
+  }
+
+  let eventBus: import("./src/types.ts").EventBus | undefined;
+  try {
+    const busModule = await import("./src/daemon/event-bus.ts");
+    const ctor = (busModule as { InProcessEventBus?: new () => unknown })
+      .InProcessEventBus;
+    if (typeof ctor === "function") {
+      eventBus = new ctor() as import("./src/types.ts").EventBus;
+    }
+  } catch {
+    // Sibling not landed yet; fall through with no bus.
+  }
+
+  const handle = await startDaemon(
+    eventBus === undefined ? { socketPath } : { socketPath, eventBus },
+  );
+  console.error(`[daemon] listening on ${handle.socketPath}`);
+
+  // Translate SIGINT/SIGTERM into a clean shutdown so a crashed daemon
+  // does not leave a stale socket file behind.
+  const shutdown = async () => {
+    await handle.stop();
+    Deno.exit(0);
+  };
+  Deno.addSignalListener("SIGINT", shutdown);
+  Deno.addSignalListener("SIGTERM", shutdown);
+} else {
+  console.log("makina — agentic GitHub issue resolver");
+  console.log("");
+  console.log("Wave 1 skeleton. Most subcommands are not yet implemented.");
+  console.log("Run `makina --version` to see the version.");
+  console.log("See https://github.com/koraytaylan/makina for status.");
+}

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -1,0 +1,631 @@
+/**
+ * daemon/server.ts — Unix-domain socket listener and IPC dispatch loop.
+ *
+ * Wave 2 owns the wire side of the daemon: this module accepts TUI
+ * connections over `Deno.listen({ transport: "unix", path })`, decodes the
+ * NDJSON-style framed envelopes defined by `src/ipc/codec.ts`, and routes
+ * each one to a pluggable handler. Two message types are handled
+ * intrinsically:
+ *
+ *  - `ping` is replied to with a `pong` carrying {@link MAKINA_VERSION};
+ *  - `subscribe { target }` registers a fan-out from a passed-in
+ *    {@link EventBus} so the supervisor's events flow to the connected
+ *    client without the client having to poll.
+ *
+ * Anything else (`command`, `prompt`, `unsubscribe`) is forwarded to the
+ * `handlers` map on {@link DaemonServerOptions}; if no handler is
+ * registered the daemon replies with `ack { ok: false, error:
+ * "unimplemented" }` so the TUI gets a deterministic answer instead of a
+ * silent timeout. Wave 3 wires the supervisor's command surface here; this
+ * module's contract is the dispatch loop, not the commands.
+ *
+ * **Resilience.** A TUI that exits while the daemon is mid-write produces
+ * a `BrokenPipe` (or `Interrupted` / `ConnectionReset` on macOS); these
+ * are swallowed per-connection so a single misbehaving client cannot kill
+ * the daemon. Stale socket files left behind by an unclean shutdown are
+ * cleaned up before binding: the daemon first probes the path with
+ * `Deno.connect`; if the file exists but no peer answers, it is unlinked
+ * and the listener takes over.
+ *
+ * @module
+ */
+
+import { decode, encode, IpcCodecError } from "../ipc/codec.ts";
+import {
+  type AckPayload,
+  type EventPayload,
+  type MessageEnvelope,
+  type PongPayload,
+  type SubscribePayload,
+} from "../ipc/protocol.ts";
+import { MAKINA_VERSION } from "../constants.ts";
+import {
+  type EventBus,
+  type EventSubscription,
+  makeTaskId,
+  type TaskEvent,
+  type TaskId,
+} from "../types.ts";
+
+/**
+ * Per-message handler signature. The handler receives the parsed envelope
+ * and returns the {@link AckPayload} the daemon should reply with.
+ *
+ * Returning a rejected promise (or throwing synchronously) is treated as
+ * an internal handler bug: the daemon converts the failure into
+ * `ack { ok: false, error: <string> }` so the client never sees a
+ * dropped frame.
+ *
+ * @template TEnvelope The narrowed envelope variant the handler accepts.
+ */
+export type DaemonHandler<TEnvelope extends MessageEnvelope = MessageEnvelope> = (
+  envelope: TEnvelope,
+) => Promise<AckPayload> | AckPayload;
+
+/**
+ * Map of message type → handler. Only the message types the daemon does
+ * not handle intrinsically are looked up here (`command`, `prompt`,
+ * `unsubscribe`). Missing entries fall back to `ack { ok: false, error:
+ * "unimplemented" }`.
+ *
+ * Each entry is typed against the discriminated union in
+ * `src/ipc/protocol.ts` so a wave-3 handler that wires `command` cannot
+ * accidentally accept a `subscribe`.
+ */
+export interface DaemonHandlers {
+  /** Optional override for `command` envelopes. */
+  readonly command?: DaemonHandler<Extract<MessageEnvelope, { type: "command" }>>;
+  /** Optional override for `prompt` envelopes. */
+  readonly prompt?: DaemonHandler<Extract<MessageEnvelope, { type: "prompt" }>>;
+  /** Optional override for `unsubscribe` envelopes. */
+  readonly unsubscribe?: DaemonHandler<Extract<MessageEnvelope, { type: "unsubscribe" }>>;
+}
+
+/**
+ * Construction-time configuration for {@link startDaemon}.
+ */
+export interface DaemonServerOptions {
+  /** Filesystem path of the Unix-domain socket the daemon should bind. */
+  readonly socketPath: string;
+  /**
+   * Optional dispatch overrides for non-intrinsic message types. Wave 3
+   * wires the supervisor's command surface here; Wave 2 leaves it empty
+   * and the daemon answers with `unimplemented`.
+   */
+  readonly handlers?: DaemonHandlers;
+  /**
+   * Optional event bus. When set, `subscribe` envelopes register a
+   * fan-out from the bus to the connected client; when omitted, the
+   * daemon replies with `ack { ok: false, error: "unimplemented" }` to
+   * any `subscribe`.
+   */
+  readonly eventBus?: EventBus;
+  /**
+   * Optional version string surfaced in `pong`. Defaults to
+   * {@link MAKINA_VERSION}; tests pin a fixed value to assert against.
+   */
+  readonly daemonVersion?: string;
+  /**
+   * Optional logger invoked once per non-fatal error (broken pipes,
+   * malformed frames, handler throws). The default writes to
+   * `console.error`; tests pass a recorder.
+   */
+  readonly onError?: (error: unknown, context: string) => void;
+}
+
+/**
+ * Handle returned by {@link startDaemon}. Closing the handle stops
+ * accepting new connections, drains the active ones, unsubscribes every
+ * fan-out, and unlinks the socket file.
+ */
+export interface DaemonHandle {
+  /** Filesystem path the daemon is bound to. */
+  readonly socketPath: string;
+  /**
+   * Stop the listener and tear down active connections.
+   *
+   * Idempotent: a second call resolves immediately. Resolves once every
+   * accept-loop iteration has unwound and the socket file has been
+   * unlinked.
+   */
+  stop(): Promise<void>;
+}
+
+const UNIMPLEMENTED_ACK: AckPayload = { ok: false, error: "unimplemented" };
+
+/**
+ * Start a daemon listener on `opts.socketPath`.
+ *
+ * The function returns once the listener is bound; the accept loop runs
+ * in the background until {@link DaemonHandle.stop} is called.
+ *
+ * @param opts Server configuration. See {@link DaemonServerOptions}.
+ * @returns A {@link DaemonHandle} the caller uses to stop the server.
+ * @throws Deno.errors.AddrInUse if another live process is already bound
+ *   to `opts.socketPath`. Stale-socket cleanup runs first so a leftover
+ *   file from a previous unclean shutdown does not surface as this error.
+ *
+ * @example
+ * ```ts
+ * const handle = await startDaemon({ socketPath: "/tmp/makina.sock" });
+ * // ...
+ * await handle.stop();
+ * ```
+ */
+export async function startDaemon(opts: DaemonServerOptions): Promise<DaemonHandle> {
+  const onError = opts.onError ?? defaultOnError;
+  const daemonVersion = opts.daemonVersion ?? MAKINA_VERSION;
+
+  await cleanupStaleSocket(opts.socketPath);
+
+  const listener = Deno.listen({ transport: "unix", path: opts.socketPath });
+
+  const activeConnections = new Set<Promise<void>>();
+  let stopped = false;
+  let stopPromise: Promise<void> | undefined;
+
+  const acceptLoop = (async () => {
+    while (!stopped) {
+      let conn: Deno.Conn;
+      try {
+        conn = await listener.accept();
+      } catch (error) {
+        if (stopped) {
+          return;
+        }
+        // BadResource is what Deno emits when `listener.close()` races the
+        // accept; treat it as a normal shutdown signal.
+        if (error instanceof Deno.errors.BadResource) {
+          return;
+        }
+        onError(error, "accept");
+        return;
+      }
+      const handled = handleConnection({
+        conn,
+        opts,
+        daemonVersion,
+        onError,
+      })
+        .catch((error) => onError(error, "connection"))
+        .finally(() => {
+          activeConnections.delete(handled);
+        });
+      activeConnections.add(handled);
+    }
+  })();
+
+  const stop = (): Promise<void> => {
+    if (stopPromise !== undefined) {
+      return stopPromise;
+    }
+    stopPromise = (async () => {
+      stopped = true;
+      try {
+        listener.close();
+      } catch (error) {
+        if (!(error instanceof Deno.errors.BadResource)) {
+          onError(error, "listener-close");
+        }
+      }
+      await acceptLoop;
+      // Drain in-flight connections; each handler closes its own conn so
+      // we just await every recorded promise.
+      await Promise.allSettled(Array.from(activeConnections));
+      try {
+        await Deno.remove(opts.socketPath);
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          onError(error, "socket-unlink");
+        }
+      }
+    })();
+    return stopPromise;
+  };
+
+  return { socketPath: opts.socketPath, stop };
+}
+
+/**
+ * Probe `socketPath` to detect a stale socket left behind by a previous
+ * unclean shutdown and unlink it so {@link Deno.listen} can rebind.
+ *
+ * The probe order is important:
+ *  1. If the file does not exist, do nothing (the listener will create
+ *     it).
+ *  2. If `Deno.connect` succeeds, a live peer owns the socket — surface
+ *     `Deno.errors.AddrInUse` so the caller sees a deterministic error.
+ *  3. If `Deno.connect` fails (no listener answered), treat the file as
+ *     stale and `Deno.remove` it.
+ *
+ * @param socketPath The candidate socket file to probe.
+ */
+async function cleanupStaleSocket(socketPath: string): Promise<void> {
+  let stat: Deno.FileInfo;
+  try {
+    stat = await Deno.lstat(socketPath);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return;
+    }
+    throw error;
+  }
+  // Only probe regular sockets; refuse to remove a real file that happens
+  // to share the path so we cannot be tricked into deleting unrelated
+  // data.
+  if (!stat.isSocket && !stat.isFile) {
+    return;
+  }
+  try {
+    const probe = await Deno.connect({ transport: "unix", path: socketPath });
+    probe.close();
+    throw new Deno.errors.AddrInUse(`socket already in use: ${socketPath}`);
+  } catch (error) {
+    if (error instanceof Deno.errors.AddrInUse) {
+      throw error;
+    }
+    // No peer answered — the file is stale; remove it.
+    try {
+      await Deno.remove(socketPath);
+    } catch (removeError) {
+      if (!(removeError instanceof Deno.errors.NotFound)) {
+        throw removeError;
+      }
+    }
+  }
+}
+
+/**
+ * Per-connection IPC loop. Decodes envelopes from `conn.readable`, routes
+ * each one through {@link dispatch}, and writes replies and pushed events
+ * back through `conn.writable`. Any subscriptions opened during the
+ * connection are torn down on exit.
+ */
+async function handleConnection(args: {
+  readonly conn: Deno.Conn;
+  readonly opts: DaemonServerOptions;
+  readonly daemonVersion: string;
+  readonly onError: (error: unknown, context: string) => void;
+}): Promise<void> {
+  const { conn, opts, daemonVersion, onError } = args;
+  const writer = conn.writable.getWriter();
+  let writerReleased = false;
+  const subscriptions = new Map<string, EventSubscription>();
+  const writeMutex = new SerialMutex();
+
+  /**
+   * Serialize writes through a per-connection mutex. Multiple subscribed
+   * events can be published concurrently; without serialization their
+   * length-prefixed frames could interleave on the wire.
+   */
+  const sendEnvelope = (envelope: MessageEnvelope): Promise<void> =>
+    writeMutex.run(async () => {
+      if (writerReleased) {
+        return;
+      }
+      try {
+        await writer.write(encode(envelope));
+      } catch (error) {
+        if (isBrokenPipe(error)) {
+          // Peer disappeared mid-write; silently drop the frame and let
+          // the read loop unwind.
+          return;
+        }
+        throw error;
+      }
+    });
+
+  try {
+    for await (const envelope of decode(conn.readable)) {
+      try {
+        await dispatch({
+          envelope,
+          opts,
+          daemonVersion,
+          subscriptions,
+          sendEnvelope,
+        });
+      } catch (error) {
+        onError(error, `dispatch:${envelope.type}`);
+        await sendEnvelope({
+          id: envelope.id,
+          type: "ack",
+          payload: { ok: false, error: errorMessage(error) },
+        });
+      }
+    }
+  } catch (error) {
+    if (error instanceof IpcCodecError) {
+      onError(error, "decode");
+    } else if (!isBrokenPipe(error)) {
+      onError(error, "connection-read");
+    }
+  } finally {
+    for (const subscription of subscriptions.values()) {
+      try {
+        subscription.unsubscribe();
+      } catch (error) {
+        onError(error, "unsubscribe-on-close");
+      }
+    }
+    subscriptions.clear();
+    try {
+      await writer.close();
+    } catch {
+      // Already closed (peer disconnect); fine.
+    } finally {
+      writerReleased = true;
+    }
+    try {
+      conn.close();
+    } catch {
+      // Already closed; fine.
+    }
+  }
+}
+
+/**
+ * Route a single envelope to its handler. Built-in dispatch:
+ *
+ *  - `ping` → reply with `pong { daemonVersion }`.
+ *  - `subscribe { target }` → register an EventBus fan-out (or reply
+ *    `unimplemented` when no bus was supplied).
+ *  - `unsubscribe { subscriptionId }` → tear down a previously-registered
+ *    fan-out (or fall back to `opts.handlers.unsubscribe`).
+ *  - `command`, `prompt` → forward to `opts.handlers`; default is
+ *    `unimplemented`.
+ *  - Anything else is rejected with `unimplemented`.
+ */
+async function dispatch(args: {
+  readonly envelope: MessageEnvelope;
+  readonly opts: DaemonServerOptions;
+  readonly daemonVersion: string;
+  readonly subscriptions: Map<string, EventSubscription>;
+  readonly sendEnvelope: (envelope: MessageEnvelope) => Promise<void>;
+}): Promise<void> {
+  const { envelope, opts, daemonVersion, subscriptions, sendEnvelope } = args;
+  switch (envelope.type) {
+    case "ping": {
+      const reply: PongPayload = { daemonVersion };
+      await sendEnvelope({ id: envelope.id, type: "pong", payload: reply });
+      return;
+    }
+    case "subscribe": {
+      const ack = registerSubscription({
+        envelope,
+        opts,
+        subscriptions,
+        sendEnvelope,
+      });
+      await sendEnvelope({ id: envelope.id, type: "ack", payload: ack });
+      return;
+    }
+    case "unsubscribe": {
+      const ack = removeSubscription({ envelope, subscriptions, opts });
+      // If a custom handler was supplied and we did not own the
+      // subscription locally, defer to it.
+      if (ack === undefined) {
+        await runCustomHandler({
+          envelope,
+          handler: opts.handlers?.unsubscribe,
+          sendEnvelope,
+        });
+        return;
+      }
+      await sendEnvelope({ id: envelope.id, type: "ack", payload: ack });
+      return;
+    }
+    case "command": {
+      await runCustomHandler({
+        envelope,
+        handler: opts.handlers?.command,
+        sendEnvelope,
+      });
+      return;
+    }
+    case "prompt": {
+      await runCustomHandler({
+        envelope,
+        handler: opts.handlers?.prompt,
+        sendEnvelope,
+      });
+      return;
+    }
+    case "pong":
+    case "ack":
+    case "event": {
+      // These flow daemon→client; a client sending one is misbehaving.
+      await sendEnvelope({
+        id: envelope.id,
+        type: "ack",
+        payload: { ok: false, error: `unexpected message type from client: ${envelope.type}` },
+      });
+      return;
+    }
+  }
+}
+
+/**
+ * Subscribe to the {@link EventBus} on behalf of the connected client.
+ *
+ * The envelope's `id` is used as the subscription identifier so a
+ * later `unsubscribe { subscriptionId }` can find it again.
+ */
+function registerSubscription(args: {
+  readonly envelope: Extract<MessageEnvelope, { type: "subscribe" }>;
+  readonly opts: DaemonServerOptions;
+  readonly subscriptions: Map<string, EventSubscription>;
+  readonly sendEnvelope: (envelope: MessageEnvelope) => Promise<void>;
+}): AckPayload {
+  const { envelope, opts, subscriptions, sendEnvelope } = args;
+  const bus = opts.eventBus;
+  if (bus === undefined) {
+    return UNIMPLEMENTED_ACK;
+  }
+  if (subscriptions.has(envelope.id)) {
+    return { ok: false, error: `subscription id already in use: ${envelope.id}` };
+  }
+  const target = decodeSubscribeTarget(envelope.payload);
+  if (target === undefined) {
+    return { ok: false, error: `invalid subscribe target: ${envelope.payload.target}` };
+  }
+  const subscription = bus.subscribe(target, (taskEvent: TaskEvent) => {
+    const eventEnvelope: MessageEnvelope = {
+      id: envelope.id,
+      type: "event",
+      payload: taskEventToPayload(taskEvent),
+    };
+    // Fire-and-forget; sendEnvelope swallows broken pipes and the
+    // catch keeps the bus's publish loop free of exceptions.
+    sendEnvelope(eventEnvelope).catch(() => {
+      // Per-event delivery failures are logged inside sendEnvelope's
+      // caller; nothing else to do here.
+    });
+  });
+  subscriptions.set(envelope.id, subscription);
+  return { ok: true };
+}
+
+/**
+ * Remove a subscription previously registered under
+ * `envelope.payload.subscriptionId`.
+ *
+ * Returns the {@link AckPayload} to write back, or `undefined` if no
+ * matching local subscription exists (the caller may then defer to a
+ * custom handler).
+ */
+function removeSubscription(args: {
+  readonly envelope: Extract<MessageEnvelope, { type: "unsubscribe" }>;
+  readonly subscriptions: Map<string, EventSubscription>;
+  readonly opts: DaemonServerOptions;
+}): AckPayload | undefined {
+  const { envelope, subscriptions, opts } = args;
+  const subscription = subscriptions.get(envelope.payload.subscriptionId);
+  if (subscription === undefined) {
+    if (opts.handlers?.unsubscribe !== undefined) {
+      return undefined;
+    }
+    return { ok: false, error: `no such subscription: ${envelope.payload.subscriptionId}` };
+  }
+  subscription.unsubscribe();
+  subscriptions.delete(envelope.payload.subscriptionId);
+  return { ok: true };
+}
+
+/**
+ * Run a custom dispatch handler (or fall back to `unimplemented`) and
+ * write the resulting `ack` envelope.
+ */
+async function runCustomHandler<TEnvelope extends MessageEnvelope>(args: {
+  readonly envelope: TEnvelope;
+  readonly handler: DaemonHandler<TEnvelope> | undefined;
+  readonly sendEnvelope: (envelope: MessageEnvelope) => Promise<void>;
+}): Promise<void> {
+  const { envelope, handler, sendEnvelope } = args;
+  if (handler === undefined) {
+    await sendEnvelope({ id: envelope.id, type: "ack", payload: UNIMPLEMENTED_ACK });
+    return;
+  }
+  let ack: AckPayload;
+  try {
+    ack = await handler(envelope);
+  } catch (error) {
+    ack = { ok: false, error: errorMessage(error) };
+  }
+  await sendEnvelope({ id: envelope.id, type: "ack", payload: ack });
+}
+
+/**
+ * Convert a {@link SubscribePayload}'s `target` into the
+ * {@link EventBus.subscribe} argument shape (`TaskId` or `"*"`). Returns
+ * `undefined` when the target string fails the brand constructor.
+ */
+function decodeSubscribeTarget(payload: SubscribePayload): TaskId | "*" | undefined {
+  if (payload.target === "*") {
+    return "*";
+  }
+  try {
+    return makeTaskId(payload.target);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Project a {@link TaskEvent} into the {@link EventPayload} shape the
+ * envelope schema requires. The two shapes are deliberately
+ * structurally-identical at the field level (`taskId`, `atIso`, `kind`,
+ * `data`); this helper exists to make the brand cast explicit.
+ */
+function taskEventToPayload(event: TaskEvent): EventPayload {
+  // The brand on `taskId` is a TS-only artifact; at runtime it is a
+  // string, which is what `EventPayload` expects.
+  return {
+    taskId: event.taskId,
+    atIso: event.atIso,
+    kind: event.kind,
+    data: event.data,
+  } as EventPayload;
+}
+
+/**
+ * Whether `error` is one of the half-dozen "peer dropped the connection
+ * mid-write" shapes. Treated as benign — the read loop will see EOF on
+ * the next iteration and the connection will unwind cleanly.
+ */
+function isBrokenPipe(error: unknown): boolean {
+  return (
+    error instanceof Deno.errors.BrokenPipe ||
+    error instanceof Deno.errors.ConnectionReset ||
+    error instanceof Deno.errors.ConnectionAborted ||
+    error instanceof Deno.errors.NotConnected ||
+    error instanceof Deno.errors.Interrupted
+  );
+}
+
+/**
+ * Best-effort string projection of an arbitrary error value, used in
+ * `ack { ok: false, error }` payloads.
+ */
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+/**
+ * Default error sink. Writes a short diagnostic line to stderr; tests
+ * pass a recorder.
+ */
+function defaultOnError(error: unknown, context: string): void {
+  const message = errorMessage(error);
+  console.error(`[daemon] ${context}: ${message}`);
+}
+
+/**
+ * Tiny serial mutex. `run(fn)` queues `fn` after every previously-queued
+ * task; the queue resolves in FIFO order even when callers `await`
+ * out-of-order.
+ *
+ * Used per-connection to prevent interleaved length-prefixed frames on
+ * the wire when concurrent producers (the read loop and the event bus
+ * fan-out) race the writer.
+ */
+class SerialMutex {
+  private tail: Promise<unknown> = Promise.resolve();
+
+  /**
+   * Run `task` after every previously-queued task on this mutex.
+   *
+   * @param task The work to serialize.
+   * @returns A promise that resolves with `task`'s result.
+   */
+  run<T>(task: () => Promise<T>): Promise<T> {
+    const next = this.tail.then(task, task);
+    // Swallow rejections on the chain so a thrown task does not poison
+    // future runs.
+    this.tail = next.catch(() => undefined);
+    return next;
+  }
+}

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -227,18 +227,33 @@ export async function startDaemon(opts: DaemonServerOptions): Promise<DaemonHand
 }
 
 /**
- * Probe `socketPath` to detect a stale socket left behind by a previous
- * unclean shutdown and unlink it so {@link Deno.listen} can rebind.
+ * Probe `socketPath` to detect a stale Unix-domain socket left behind by a
+ * previous unclean shutdown and unlink it so {@link Deno.listen} can
+ * rebind.
  *
- * The probe order is important:
+ * The probe order is intentionally narrow to avoid data-loss scenarios:
  *  1. If the file does not exist, do nothing (the listener will create
  *     it).
- *  2. If `Deno.connect` succeeds, a live peer owns the socket — surface
- *     `Deno.errors.AddrInUse` so the caller sees a deterministic error.
- *  3. If `Deno.connect` fails (no listener answered), treat the file as
- *     stale and `Deno.remove` it.
+ *  2. If the path exists but is **not** a Unix-domain socket (regular
+ *     file, directory, symlink to either, etc.), do nothing. We refuse
+ *     to remove unrelated filesystem entries even when the user has
+ *     misconfigured `socketPath` to point at one — the subsequent
+ *     {@link Deno.listen} call will surface its native error
+ *     (`AddrInUse`, `IsADirectory`, …) and the user can correct the
+ *     configuration.
+ *  3. If the file is a socket and `Deno.connect` succeeds, a live peer
+ *     owns it — surface `Deno.errors.AddrInUse` so the caller sees a
+ *     deterministic error.
+ *  4. If the file is a socket and `Deno.connect` fails with a recognised
+ *     "no listener" error (`ConnectionRefused`, `NotFound`), treat it as
+ *     stale and `Deno.remove` it. Any other probe failure (e.g.,
+ *     `PermissionDenied`) is rethrown — silently deleting the entry on a
+ *     misconfiguration is more dangerous than an explicit failure.
  *
  * @param socketPath The candidate socket file to probe.
+ * @throws Deno.errors.AddrInUse when a live peer is already bound.
+ * @throws Deno.errors.PermissionDenied (or other unexpected probe error)
+ *   so misconfiguration cannot silently delete filesystem entries.
  */
 async function cleanupStaleSocket(socketPath: string): Promise<void> {
   let stat: Deno.FileInfo;
@@ -250,29 +265,52 @@ async function cleanupStaleSocket(socketPath: string): Promise<void> {
     }
     throw error;
   }
-  // Only probe regular sockets; refuse to remove a real file that happens
-  // to share the path so we cannot be tricked into deleting unrelated
-  // data.
-  if (!stat.isSocket && !stat.isFile) {
+  // Strict gate: only ever unlink a real Unix-domain socket file. A
+  // regular file, directory, or anything else at this path is left
+  // untouched — `Deno.listen` will surface the native error and the
+  // operator can correct the configuration without losing data.
+  if (!stat.isSocket) {
     return;
   }
+  let probe: Deno.UnixConn;
   try {
-    const probe = await Deno.connect({ transport: "unix", path: socketPath });
-    probe.close();
-    throw new Deno.errors.AddrInUse(`socket already in use: ${socketPath}`);
+    probe = await Deno.connect({ transport: "unix", path: socketPath });
   } catch (error) {
-    if (error instanceof Deno.errors.AddrInUse) {
-      throw error;
-    }
-    // No peer answered — the file is stale; remove it.
-    try {
-      await Deno.remove(socketPath);
-    } catch (removeError) {
-      if (!(removeError instanceof Deno.errors.NotFound)) {
-        throw removeError;
+    if (isStaleSocketProbeError(error)) {
+      // No peer answered — the file is stale; remove it.
+      try {
+        await Deno.remove(socketPath);
+      } catch (removeError) {
+        if (!(removeError instanceof Deno.errors.NotFound)) {
+          throw removeError;
+        }
       }
+      return;
     }
+    // Anything else (PermissionDenied, etc.) is a misconfiguration we
+    // refuse to recover from silently.
+    throw error;
   }
+  probe.close();
+  throw new Deno.errors.AddrInUse(`socket already in use: ${socketPath}`);
+}
+
+/**
+ * Whether `error` from a `Deno.connect({ transport: "unix" })` probe
+ * indicates that the socket file exists but no listener is bound.
+ *
+ * The kernel returns `ECONNREFUSED` when a Unix-domain socket file is
+ * present but no process has called `accept()` on it — that is the
+ * canonical "stale socket from a crashed daemon" signal. `NotFound`
+ * covers the race where the file vanishes between the `lstat` and the
+ * `connect`. Every other error (permission, address family, runtime
+ * resource limits) is treated as suspect and rethrown by the caller.
+ */
+function isStaleSocketProbeError(error: unknown): boolean {
+  return (
+    error instanceof Deno.errors.ConnectionRefused ||
+    error instanceof Deno.errors.NotFound
+  );
 }
 
 /**
@@ -478,8 +516,11 @@ function registerSubscription(args: {
     // Fire-and-forget; sendEnvelope swallows broken pipes and the
     // catch keeps the bus's publish loop free of exceptions.
     sendEnvelope(eventEnvelope).catch(() => {
-      // Per-event delivery failures are logged inside sendEnvelope's
-      // caller; nothing else to do here.
+      // Per-event delivery failures are intentionally ignored here to
+      // avoid surfacing exceptions into the event bus publish loop.
+      // sendEnvelope already converts broken-pipe errors into a benign
+      // no-op; anything else would be a daemon bug we cannot meaningfully
+      // recover from inside a fan-out callback.
     });
   });
   subscriptions.set(envelope.id, subscription);

--- a/tests/integration/daemon_server_test.ts
+++ b/tests/integration/daemon_server_test.ts
@@ -253,19 +253,35 @@ Deno.test("startDaemon fans out a published event to a per-task subscription", a
   }
 });
 
-Deno.test("startDaemon cleans up a stale socket file on startup", async () => {
-  // Create a leftover regular file at the socket path; the daemon should
-  // detect it as stale (no listener) and unlink it before binding.
+Deno.test("startDaemon cleans up a stale socket left by a crashed predecessor", async () => {
+  // Simulate a crashed daemon: bind a Unix-domain socket through
+  // `node:net` and close the server WITHOUT unlinking the file. Unlike
+  // `Deno.listen({ transport: "unix" })` (whose drop hook unlinks on
+  // close), `net.Server#close` leaves the socket entry on disk — which
+  // is precisely the "crashed daemon" state the cleanup helper exists
+  // to recover from. The leftover entry is a real Unix-domain socket
+  // (`isSocket === true`) with no listener accepting connections, so a
+  // probe via `Deno.connect` will fail with `ConnectionRefused`.
+  const { createServer } = await import("node:net");
   const dir = await Deno.makeTempDir({ prefix: "makina-stale-" });
   const socketPath = `${dir}/sock`;
-  await Deno.writeTextFile(socketPath, "leftover");
-  // Sanity: file is present.
+
+  const leakedServer = createServer();
+  await new Promise<void>((resolve, reject) => {
+    leakedServer.once("error", reject);
+    leakedServer.listen(socketPath, () => resolve());
+  });
+  await new Promise<void>((resolve) => {
+    leakedServer.close(() => resolve());
+  });
+
+  // Sanity: the socket file is still on disk and is a real socket.
   const before = await Deno.lstat(socketPath);
-  assertEquals(before.isFile, true);
+  assertEquals(before.isSocket, true);
 
   const handle = await startDaemon({ socketPath });
   try {
-    // After startup, the file is replaced by a bound socket.
+    // After startup, the path is bound by our fresh listener.
     const after = await Deno.lstat(socketPath);
     assertEquals(after.isSocket, true);
 
@@ -281,6 +297,26 @@ Deno.test("startDaemon cleans up a stale socket file on startup", async () => {
   } finally {
     await handle.stop();
   }
+});
+
+Deno.test("startDaemon refuses to delete a regular file left at the socket path", async () => {
+  // Misconfiguration check: if the operator points `socketPath` at a
+  // real file (e.g., a typo'd path that hits an unrelated file), the
+  // daemon must leave the file intact and surface an error instead of
+  // silently `unlink`ing it. We let `Deno.listen` produce the error
+  // rather than reinventing the diagnostic.
+  const dir = await Deno.makeTempDir({ prefix: "makina-regular-" });
+  const socketPath = `${dir}/important.txt`;
+  const contents = "important user data";
+  await Deno.writeTextFile(socketPath, contents);
+
+  await assertRejects(() => startDaemon({ socketPath }));
+
+  // The file is still on disk with its original contents.
+  const after = await Deno.lstat(socketPath);
+  assertEquals(after.isFile, true);
+  const surviving = await Deno.readTextFile(socketPath);
+  assertEquals(surviving, contents);
 });
 
 Deno.test("startDaemon refuses to bind when the socket is still in use", async () => {
@@ -372,11 +408,20 @@ Deno.test("startDaemon drops events for a closed peer without crashing", async (
 
 Deno.test("startDaemon dispatches to a custom command handler", async () => {
   const socketPath = await makeSocketPath();
+  // The AckPayload contract reserves `error` for failure descriptions
+  // (see `src/ipc/protocol.ts`), so verifying dispatch by stuffing
+  // success output into `error` would invite confusion. Use a captured
+  // side effect instead, then assert a clean `{ ok: true }` ack.
+  const observed: { name: string; args: readonly string[] }[] = [];
   const handle = await startDaemon({
     socketPath,
     handlers: {
       command: (envelope) => {
-        return { ok: true, error: `executed:${envelope.payload.name}` };
+        observed.push({
+          name: envelope.payload.name,
+          args: envelope.payload.args,
+        });
+        return { ok: true };
       },
     },
   });
@@ -390,14 +435,18 @@ Deno.test("startDaemon dispatches to a custom command handler", async () => {
       });
       const reply = await client.next();
       assertEquals(reply.type, "ack");
-      assertEquals((reply.payload as AckPayload).ok, true);
-      assertEquals((reply.payload as AckPayload).error, "executed:issue");
+      const payload = reply.payload as AckPayload;
+      assertEquals(payload.ok, true);
+      assertEquals(payload.error, undefined);
     } finally {
       await client.close();
     }
   } finally {
     await handle.stop();
   }
+  assertEquals(observed.length, 1);
+  assertEquals(observed[0]?.name, "issue");
+  assertEquals(observed[0]?.args, ["42"]);
 });
 
 Deno.test("startDaemon dispatches to a custom prompt handler", async () => {
@@ -656,12 +705,15 @@ Deno.test("startDaemon stop() is idempotent and unlinks the socket file", async 
   await assertRejects(() => Deno.lstat(socketPath), Deno.errors.NotFound);
 });
 
-Deno.test("startDaemon ignores a non-socket regular file at the same path that is not a socket", async () => {
-  // A directory at the path is neither isSocket nor isFile; the daemon
-  // skips the unlink, lets Deno.listen surface its native error, and
-  // does not blow up our cleanup helper.
+Deno.test("startDaemon refuses to delete a directory at the socket path", async () => {
+  // A directory at the path is not a socket; the daemon skips the
+  // unlink, lets Deno.listen surface its native error, and does not
+  // blow up our cleanup helper. The directory must still exist after
+  // the failure so the operator can inspect what they hit.
   const dir = await Deno.makeTempDir({ prefix: "makina-dir-" });
   await assertRejects(() => startDaemon({ socketPath: dir }));
+  const stillThere = await Deno.lstat(dir);
+  assertEquals(stillThere.isDirectory, true);
   // Tidy up.
   await Deno.remove(dir);
 });

--- a/tests/integration/daemon_server_test.ts
+++ b/tests/integration/daemon_server_test.ts
@@ -1,0 +1,675 @@
+/**
+ * Integration tests for `src/daemon/server.ts`. Boots the server on a
+ * `Deno.makeTempDir`-backed Unix socket, opens a real client over
+ * `Deno.connect`, and round-trips encoded {@link MessageEnvelope}s.
+ *
+ * Coverage targets:
+ *  - `ping → pong` round trip (with custom `daemonVersion`).
+ *  - `subscribe { target: "*" }` → event fan-out for a published
+ *    {@link TaskEvent}; the client receives a matching `event` envelope.
+ *  - Stale socket cleanup: a non-listening file at the socket path is
+ *    removed before {@link Deno.listen} runs, and an `AddrInUse` is
+ *    raised when the socket is still owned by a live peer.
+ *  - Broken pipe: a TUI that closes mid-write does not kill the daemon;
+ *    a follow-up client can still round-trip.
+ *  - Custom handler dispatch (`command`, `prompt`, `unsubscribe`).
+ *  - Unknown subscriptions: `unsubscribe` for an unregistered id.
+ *  - Daemon-only message types (`pong`, `event`, `ack`) sent by a client
+ *    are rejected with an `ack`.
+ *  - Custom handler errors are translated into `ack { ok: false }`.
+ */
+
+import { assertEquals, assertNotEquals, assertRejects } from "@std/assert";
+
+import { decode, encode } from "../../src/ipc/codec.ts";
+import { type AckPayload, type MessageEnvelope, type PongPayload } from "../../src/ipc/protocol.ts";
+import {
+  type EventBus,
+  type EventSubscription,
+  makeTaskId,
+  type TaskEvent,
+  type TaskId,
+} from "../../src/types.ts";
+import { startDaemon } from "../../src/daemon/server.ts";
+
+/**
+ * Minimal in-test {@link EventBus}. Wave 2's #8 ships the production
+ * implementation; this test fixture mirrors the surface (`publish`,
+ * `subscribe`) just enough to exercise the daemon's fan-out.
+ */
+class TestEventBus implements EventBus {
+  private readonly handlers = new Map<
+    TaskId | "*",
+    Set<(event: TaskEvent) => void>
+  >();
+
+  publish(event: TaskEvent): void {
+    for (const target of [event.taskId, "*"] as const) {
+      const set = this.handlers.get(target);
+      if (set === undefined) continue;
+      for (const handler of [...set]) {
+        try {
+          handler(event);
+        } catch {
+          // Match production EventBus contract: handler throws are
+          // contained.
+        }
+      }
+    }
+  }
+
+  subscribe(
+    target: TaskId | "*",
+    handler: (event: TaskEvent) => void,
+  ): EventSubscription {
+    let set = this.handlers.get(target);
+    if (set === undefined) {
+      set = new Set();
+      this.handlers.set(target, set);
+    }
+    set.add(handler);
+    return {
+      unsubscribe: () => {
+        set?.delete(handler);
+      },
+    };
+  }
+
+  subscriberCount(target: TaskId | "*"): number {
+    return this.handlers.get(target)?.size ?? 0;
+  }
+}
+
+/**
+ * Allocate a unique socket path under `Deno.makeTempDir`. Each test gets
+ * its own directory so they can run in parallel without colliding.
+ */
+async function makeSocketPath(): Promise<string> {
+  const dir = await Deno.makeTempDir({ prefix: "makina-daemon-" });
+  return `${dir}/sock`;
+}
+
+/**
+ * Open a Unix client connection and yield raw decoded envelopes alongside
+ * a `send` helper for typed envelopes.
+ */
+async function connectClient(socketPath: string) {
+  const conn = await Deno.connect({ transport: "unix", path: socketPath });
+  const writer = conn.writable.getWriter();
+  // Decode wraps the stream; the reader lock is held internally so we
+  // never need to `getReader()` ourselves.
+  const reader = (async function* () {
+    for await (const envelope of decode(conn.readable)) {
+      yield envelope;
+    }
+  })();
+  return {
+    conn,
+    send: async (envelope: MessageEnvelope) => {
+      await writer.write(encode(envelope));
+    },
+    next: async (): Promise<MessageEnvelope> => {
+      const result = await reader.next();
+      if (result.done) {
+        throw new Error("connection closed before next envelope");
+      }
+      return result.value;
+    },
+    close: async () => {
+      try {
+        await writer.close();
+      } catch {
+        // Ignore.
+      }
+      try {
+        conn.close();
+      } catch {
+        // Ignore.
+      }
+    },
+  };
+}
+
+Deno.test("startDaemon round-trips ping → pong", async () => {
+  const socketPath = await makeSocketPath();
+  const handle = await startDaemon({
+    socketPath,
+    daemonVersion: "0.0.0-test",
+  });
+  try {
+    const client = await connectClient(socketPath);
+    try {
+      await client.send({ id: "1", type: "ping", payload: {} });
+      const reply = await client.next();
+      assertEquals(reply.type, "pong");
+      assertEquals(reply.id, "1");
+      assertEquals(
+        (reply.payload as PongPayload).daemonVersion,
+        "0.0.0-test",
+      );
+    } finally {
+      await client.close();
+    }
+  } finally {
+    await handle.stop();
+  }
+});
+
+Deno.test("startDaemon fans out a published event to a wildcard subscription", async () => {
+  const socketPath = await makeSocketPath();
+  const bus = new TestEventBus();
+  const handle = await startDaemon({ socketPath, eventBus: bus });
+  try {
+    const client = await connectClient(socketPath);
+    try {
+      await client.send({
+        id: "sub-1",
+        type: "subscribe",
+        payload: { target: "*" },
+      });
+      const ack = await client.next();
+      assertEquals(ack.type, "ack");
+      assertEquals((ack.payload as AckPayload).ok, true);
+
+      // Give the bus subscription a tick to register, then publish.
+      const taskId = makeTaskId("task_under_test");
+      const taskEvent: TaskEvent = {
+        taskId,
+        atIso: "2026-04-26T12:00:00.000Z",
+        kind: "log",
+        data: { level: "info", message: "hello world" },
+      };
+      bus.publish(taskEvent);
+
+      const event = await client.next();
+      assertEquals(event.type, "event");
+      assertEquals(event.id, "sub-1");
+      if (event.type !== "event") throw new Error("unreachable");
+      assertEquals(event.payload.taskId, "task_under_test");
+      assertEquals(event.payload.kind, "log");
+      if (event.payload.kind !== "log") throw new Error("unreachable");
+      assertEquals(event.payload.data.message, "hello world");
+
+      // Unsubscribe and verify the bus drops the handler.
+      await client.send({
+        id: "unsub-1",
+        type: "unsubscribe",
+        payload: { subscriptionId: "sub-1" },
+      });
+      const unsubAck = await client.next();
+      assertEquals(unsubAck.type, "ack");
+      assertEquals((unsubAck.payload as AckPayload).ok, true);
+      assertEquals(bus.subscriberCount("*"), 0);
+    } finally {
+      await client.close();
+    }
+  } finally {
+    await handle.stop();
+  }
+});
+
+Deno.test("startDaemon fans out a published event to a per-task subscription", async () => {
+  const socketPath = await makeSocketPath();
+  const bus = new TestEventBus();
+  const handle = await startDaemon({ socketPath, eventBus: bus });
+  try {
+    const client = await connectClient(socketPath);
+    try {
+      await client.send({
+        id: "sub-2",
+        type: "subscribe",
+        payload: { target: "task_specific" },
+      });
+      const ack = await client.next();
+      assertEquals(ack.type, "ack");
+      assertEquals((ack.payload as AckPayload).ok, true);
+
+      // Publish an event for an unrelated task — should NOT fan out.
+      bus.publish({
+        taskId: makeTaskId("task_other"),
+        atIso: "2026-04-26T12:00:00.000Z",
+        kind: "log",
+        data: { level: "info", message: "irrelevant" },
+      });
+      // Publish the matching event.
+      bus.publish({
+        taskId: makeTaskId("task_specific"),
+        atIso: "2026-04-26T12:00:01.000Z",
+        kind: "log",
+        data: { level: "info", message: "matched" },
+      });
+
+      const event = await client.next();
+      assertEquals(event.type, "event");
+      if (event.type !== "event") throw new Error("unreachable");
+      assertEquals(event.payload.taskId, "task_specific");
+      if (event.payload.kind !== "log") throw new Error("unreachable");
+      assertEquals(event.payload.data.message, "matched");
+    } finally {
+      await client.close();
+    }
+  } finally {
+    await handle.stop();
+  }
+});
+
+Deno.test("startDaemon cleans up a stale socket file on startup", async () => {
+  // Create a leftover regular file at the socket path; the daemon should
+  // detect it as stale (no listener) and unlink it before binding.
+  const dir = await Deno.makeTempDir({ prefix: "makina-stale-" });
+  const socketPath = `${dir}/sock`;
+  await Deno.writeTextFile(socketPath, "leftover");
+  // Sanity: file is present.
+  const before = await Deno.lstat(socketPath);
+  assertEquals(before.isFile, true);
+
+  const handle = await startDaemon({ socketPath });
+  try {
+    // After startup, the file is replaced by a bound socket.
+    const after = await Deno.lstat(socketPath);
+    assertEquals(after.isSocket, true);
+
+    // And it is functional.
+    const client = await connectClient(socketPath);
+    try {
+      await client.send({ id: "1", type: "ping", payload: {} });
+      const reply = await client.next();
+      assertEquals(reply.type, "pong");
+    } finally {
+      await client.close();
+    }
+  } finally {
+    await handle.stop();
+  }
+});
+
+Deno.test("startDaemon refuses to bind when the socket is still in use", async () => {
+  const socketPath = await makeSocketPath();
+  const first = await startDaemon({ socketPath });
+  try {
+    await assertRejects(
+      () => startDaemon({ socketPath }),
+      Deno.errors.AddrInUse,
+    );
+  } finally {
+    await first.stop();
+  }
+});
+
+Deno.test("startDaemon survives a client that closes mid-conversation", async () => {
+  const socketPath = await makeSocketPath();
+  const errors: { error: unknown; context: string }[] = [];
+  const handle = await startDaemon({
+    socketPath,
+    onError: (error, context) => {
+      errors.push({ error, context });
+    },
+  });
+  try {
+    // First client: send a ping then immediately close, simulating a
+    // TUI that quit before reading the reply.
+    const client1 = await connectClient(socketPath);
+    await client1.send({ id: "1", type: "ping", payload: {} });
+    await client1.close();
+
+    // Second client: round-trips fine.
+    const client2 = await connectClient(socketPath);
+    try {
+      await client2.send({ id: "2", type: "ping", payload: {} });
+      const reply = await client2.next();
+      assertEquals(reply.type, "pong");
+      assertEquals(reply.id, "2");
+    } finally {
+      await client2.close();
+    }
+  } finally {
+    await handle.stop();
+  }
+  // Even if the daemon logged a broken-pipe error, the connection
+  // unwound cleanly and the second client succeeded — that's the
+  // contract we're verifying.
+});
+
+Deno.test("startDaemon drops events for a closed peer without crashing", async () => {
+  const socketPath = await makeSocketPath();
+  const bus = new TestEventBus();
+  const handle = await startDaemon({ socketPath, eventBus: bus });
+  try {
+    const client = await connectClient(socketPath);
+    await client.send({
+      id: "sub-3",
+      type: "subscribe",
+      payload: { target: "*" },
+    });
+    const ack = await client.next();
+    assertEquals(ack.type, "ack");
+    // Close the client while a fan-out is queued.
+    await client.close();
+
+    // Publish many events; the daemon should swallow the broken pipes.
+    for (let index = 0; index < 50; index += 1) {
+      bus.publish({
+        taskId: makeTaskId("task_x"),
+        atIso: "2026-04-26T12:00:00.000Z",
+        kind: "log",
+        data: { level: "info", message: `n=${index}` },
+      });
+    }
+
+    // Daemon is still alive: a fresh client round-trips.
+    const fresh = await connectClient(socketPath);
+    try {
+      await fresh.send({ id: "after", type: "ping", payload: {} });
+      const reply = await fresh.next();
+      assertEquals(reply.type, "pong");
+    } finally {
+      await fresh.close();
+    }
+  } finally {
+    await handle.stop();
+  }
+});
+
+Deno.test("startDaemon dispatches to a custom command handler", async () => {
+  const socketPath = await makeSocketPath();
+  const handle = await startDaemon({
+    socketPath,
+    handlers: {
+      command: (envelope) => {
+        return { ok: true, error: `executed:${envelope.payload.name}` };
+      },
+    },
+  });
+  try {
+    const client = await connectClient(socketPath);
+    try {
+      await client.send({
+        id: "cmd-1",
+        type: "command",
+        payload: { name: "issue", args: ["42"] },
+      });
+      const reply = await client.next();
+      assertEquals(reply.type, "ack");
+      assertEquals((reply.payload as AckPayload).ok, true);
+      assertEquals((reply.payload as AckPayload).error, "executed:issue");
+    } finally {
+      await client.close();
+    }
+  } finally {
+    await handle.stop();
+  }
+});
+
+Deno.test("startDaemon dispatches to a custom prompt handler", async () => {
+  const socketPath = await makeSocketPath();
+  const handle = await startDaemon({
+    socketPath,
+    handlers: {
+      prompt: () => Promise.resolve({ ok: true }),
+    },
+  });
+  try {
+    const client = await connectClient(socketPath);
+    try {
+      await client.send({
+        id: "p-1",
+        type: "prompt",
+        payload: { taskId: "task_x", text: "carry on" },
+      });
+      const reply = await client.next();
+      assertEquals(reply.type, "ack");
+      assertEquals((reply.payload as AckPayload).ok, true);
+    } finally {
+      await client.close();
+    }
+  } finally {
+    await handle.stop();
+  }
+});
+
+Deno.test("startDaemon translates a thrown handler into ack { ok: false }", async () => {
+  const socketPath = await makeSocketPath();
+  const handle = await startDaemon({
+    socketPath,
+    handlers: {
+      command: () => {
+        throw new Error("boom");
+      },
+    },
+    onError: () => {/* swallow for the test */},
+  });
+  try {
+    const client = await connectClient(socketPath);
+    try {
+      await client.send({
+        id: "err-1",
+        type: "command",
+        payload: { name: "broken", args: [] },
+      });
+      const reply = await client.next();
+      assertEquals(reply.type, "ack");
+      const payload = reply.payload as AckPayload;
+      assertEquals(payload.ok, false);
+      assertEquals(payload.error, "boom");
+    } finally {
+      await client.close();
+    }
+  } finally {
+    await handle.stop();
+  }
+});
+
+Deno.test("startDaemon answers unimplemented when no handler is registered", async () => {
+  const socketPath = await makeSocketPath();
+  const handle = await startDaemon({ socketPath });
+  try {
+    const client = await connectClient(socketPath);
+    try {
+      await client.send({
+        id: "no-handler",
+        type: "command",
+        payload: { name: "noop", args: [] },
+      });
+      const reply = await client.next();
+      assertEquals(reply.type, "ack");
+      const payload = reply.payload as AckPayload;
+      assertEquals(payload.ok, false);
+      assertEquals(payload.error, "unimplemented");
+    } finally {
+      await client.close();
+    }
+  } finally {
+    await handle.stop();
+  }
+});
+
+Deno.test("startDaemon answers unimplemented for subscribe when no event bus is supplied", async () => {
+  const socketPath = await makeSocketPath();
+  const handle = await startDaemon({ socketPath });
+  try {
+    const client = await connectClient(socketPath);
+    try {
+      await client.send({
+        id: "sub-no-bus",
+        type: "subscribe",
+        payload: { target: "*" },
+      });
+      const reply = await client.next();
+      assertEquals(reply.type, "ack");
+      const payload = reply.payload as AckPayload;
+      assertEquals(payload.ok, false);
+      assertEquals(payload.error, "unimplemented");
+    } finally {
+      await client.close();
+    }
+  } finally {
+    await handle.stop();
+  }
+});
+
+Deno.test("startDaemon rejects an unsubscribe for an unknown subscription id", async () => {
+  const socketPath = await makeSocketPath();
+  const bus = new TestEventBus();
+  const handle = await startDaemon({ socketPath, eventBus: bus });
+  try {
+    const client = await connectClient(socketPath);
+    try {
+      await client.send({
+        id: "u-1",
+        type: "unsubscribe",
+        payload: { subscriptionId: "does-not-exist" },
+      });
+      const reply = await client.next();
+      assertEquals(reply.type, "ack");
+      const payload = reply.payload as AckPayload;
+      assertEquals(payload.ok, false);
+    } finally {
+      await client.close();
+    }
+  } finally {
+    await handle.stop();
+  }
+});
+
+Deno.test("startDaemon rejects a daemon-only envelope sent by a client", async () => {
+  const socketPath = await makeSocketPath();
+  const handle = await startDaemon({ socketPath });
+  try {
+    const client = await connectClient(socketPath);
+    try {
+      await client.send({
+        id: "wrong-direction",
+        type: "pong",
+        payload: { daemonVersion: "x" },
+      });
+      const reply = await client.next();
+      assertEquals(reply.type, "ack");
+      const payload = reply.payload as AckPayload;
+      assertEquals(payload.ok, false);
+    } finally {
+      await client.close();
+    }
+  } finally {
+    await handle.stop();
+  }
+});
+
+Deno.test("startDaemon rejects a subscribe with an invalid target", async () => {
+  const socketPath = await makeSocketPath();
+  const bus = new TestEventBus();
+  const handle = await startDaemon({ socketPath, eventBus: bus });
+  try {
+    const client = await connectClient(socketPath);
+    try {
+      // Whitespace-only target trips makeTaskId(); the daemon answers
+      // with ack { ok: false }.
+      await client.send({
+        id: "sub-bad",
+        type: "subscribe",
+        payload: { target: "   " },
+      });
+      const reply = await client.next();
+      assertEquals(reply.type, "ack");
+      const payload = reply.payload as AckPayload;
+      assertEquals(payload.ok, false);
+    } finally {
+      await client.close();
+    }
+  } finally {
+    await handle.stop();
+  }
+});
+
+Deno.test("startDaemon rejects duplicate subscription ids on the same connection", async () => {
+  const socketPath = await makeSocketPath();
+  const bus = new TestEventBus();
+  const handle = await startDaemon({ socketPath, eventBus: bus });
+  try {
+    const client = await connectClient(socketPath);
+    try {
+      await client.send({
+        id: "dup",
+        type: "subscribe",
+        payload: { target: "*" },
+      });
+      const first = await client.next();
+      assertEquals(first.type, "ack");
+      assertEquals((first.payload as AckPayload).ok, true);
+
+      // Re-using the same id is a client bug.
+      await client.send({
+        id: "dup",
+        type: "subscribe",
+        payload: { target: "task_y" },
+      });
+      const second = await client.next();
+      assertEquals(second.type, "ack");
+      assertEquals((second.payload as AckPayload).ok, false);
+    } finally {
+      await client.close();
+    }
+  } finally {
+    await handle.stop();
+  }
+});
+
+Deno.test("startDaemon defers an unsubscribe to a custom handler when no local subscription exists", async () => {
+  const socketPath = await makeSocketPath();
+  let observed = false;
+  const bus = new TestEventBus();
+  const handle = await startDaemon({
+    socketPath,
+    eventBus: bus,
+    handlers: {
+      unsubscribe: () => {
+        observed = true;
+        return { ok: true };
+      },
+    },
+  });
+  try {
+    const client = await connectClient(socketPath);
+    try {
+      await client.send({
+        id: "u-defer",
+        type: "unsubscribe",
+        payload: { subscriptionId: "not-mine" },
+      });
+      const reply = await client.next();
+      assertEquals(reply.type, "ack");
+      assertEquals((reply.payload as AckPayload).ok, true);
+      assertEquals(observed, true);
+    } finally {
+      await client.close();
+    }
+  } finally {
+    await handle.stop();
+  }
+});
+
+Deno.test("startDaemon stop() is idempotent and unlinks the socket file", async () => {
+  const socketPath = await makeSocketPath();
+  const handle = await startDaemon({ socketPath });
+  await handle.stop();
+  await handle.stop(); // No-op the second time.
+  // Socket file is gone after a clean stop.
+  await assertRejects(() => Deno.lstat(socketPath), Deno.errors.NotFound);
+});
+
+Deno.test("startDaemon ignores a non-socket regular file at the same path that is not a socket", async () => {
+  // A directory at the path is neither isSocket nor isFile; the daemon
+  // skips the unlink, lets Deno.listen surface its native error, and
+  // does not blow up our cleanup helper.
+  const dir = await Deno.makeTempDir({ prefix: "makina-dir-" });
+  await assertRejects(() => startDaemon({ socketPath: dir }));
+  // Tidy up.
+  await Deno.remove(dir);
+});
+
+Deno.test("startDaemon stop() runs even before any connection arrives", async () => {
+  // Sanity-check the accept-loop teardown path on an idle listener.
+  const socketPath = await makeSocketPath();
+  const handle = await startDaemon({ socketPath });
+  await handle.stop();
+  assertNotEquals(handle.socketPath, "");
+});


### PR DESCRIPTION
## Summary

Implements [#9](https://github.com/koraytaylan/makina/issues/9) — daemon Unix-socket listener with NDJSON dispatch and a pluggable handler map.

## Linked issue

Closes #9

## Definition of Done

- [x] JSDoc on every exported symbol; `deno doc --lint` green.
- [x] `ping → pong` and `subscribe` event fan-out covered by integration tests.
- [x] Stale socket cleaned on startup; broken pipe doesn't kill the daemon.
- [x] `deno task ci` is green.

## References

- Plan §Architecture (Process model, IPC).
