### PR TITLE
feat(#7): atomic JSON state store with replay

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,52 +1,21 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@std/assert@1": "1.0.19",
-    "jsr:@std/assert@^1.0.19": "1.0.19",
-    "jsr:@std/async@1": "1.3.0",
-    "jsr:@std/cli@1": "1.0.29",
     "jsr:@std/fmt@^1.0.5": "1.0.10",
     "jsr:@std/fs@^1.0.11": "1.0.23",
-    "jsr:@std/fs@^1.0.23": "1.0.23",
-    "jsr:@std/internal@^1.0.12": "1.0.13",
-    "jsr:@std/internal@^1.0.13": "1.0.13",
     "jsr:@std/io@~0.225.2": "0.225.3",
     "jsr:@std/log@0.224": "0.224.14",
-    "jsr:@std/path@1": "1.1.4",
-    "jsr:@std/path@^1.1.4": "1.1.4",
-    "jsr:@std/testing@1": "1.0.18",
-    "npm:@anthropic-ai/claude-agent-sdk@*": "0.2.119_zod@3.25.76",
-    "npm:@octokit/auth-app@7": "7.2.2",
-    "npm:@octokit/core@5": "5.2.2",
     "npm:@types/react@18": "18.3.28",
     "npm:ink@5": "5.2.1_@types+react@18.3.28_react@18.3.1",
     "npm:react@18": "18.3.1",
     "npm:zod@3": "3.25.76"
   },
   "jsr": {
-    "@std/assert@1.0.19": {
-      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
-      "dependencies": [
-        "jsr:@std/internal@^1.0.12"
-      ]
-    },
-    "@std/async@1.3.0": {
-      "integrity": "80485538a4f7baaa46bfe2246168069e02ed142b9f9079cd164f43bb060ad9e9"
-    },
-    "@std/cli@1.0.29": {
-      "integrity": "fa4ef29130baa834d8a13b7d138240c3a2fcfba740bfb7afa646a360a15ec84f"
-    },
     "@std/fmt@1.0.10": {
       "integrity": "90dfba288802ac6de82fb31d0917eb9e4450b9925b954d5e51fc29ac07419db5"
     },
     "@std/fs@1.0.23": {
-      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
-      "dependencies": [
-        "jsr:@std/path@^1.1.4"
-      ]
-    },
-    "@std/internal@1.0.13": {
-      "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
+      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37"
     },
     "@std/io@0.225.3": {
       "integrity": "27b07b591384d12d7b568f39e61dff966b8230559122df1e9fd11cc068f7ddd1"
@@ -55,23 +24,8 @@
       "integrity": "257f7adceee3b53bb2bc86c7242e7d1bc59729e57d4981c4a7e5b876c808f05e",
       "dependencies": [
         "jsr:@std/fmt",
-        "jsr:@std/fs@^1.0.11",
+        "jsr:@std/fs",
         "jsr:@std/io"
-      ]
-    },
-    "@std/path@1.1.4": {
-      "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
-      "dependencies": [
-        "jsr:@std/internal@^1.0.12"
-      ]
-    },
-    "@std/testing@1.0.18": {
-      "integrity": "d3152f57b11666bf6358d0e127c7e3488e91178b0c2d8fbf0793e1c53cd13cb1",
-      "dependencies": [
-        "jsr:@std/assert@^1.0.19",
-        "jsr:@std/fs@^1.0.23",
-        "jsr:@std/internal@^1.0.13",
-        "jsr:@std/path@^1.1.4"
       ]
     }
   },
@@ -83,248 +37,6 @@
         "is-fullwidth-code-point@4.0.0"
       ]
     },
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.119": {
-      "integrity": "sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw==",
-      "os": ["darwin"],
-      "cpu": ["arm64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.119": {
-      "integrity": "sha512-9Aj8g3ELsmZuOFg17TCkikeg/Wt2ucVT8hOOPQUatzLd7BKhydrHLA0RP42nBpWECO1B/n/mPdQ4iS/LS3s2Fg==",
-      "os": ["darwin"],
-      "cpu": ["x64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.119": {
-      "integrity": "sha512-IPGWgtz+gGnD7fxKAvSf913EUT/lYBTBE8EZ7lh3+x5ZP2859LWLmrCm053Lf3nMWo/CWikZsVPwkDVwpz6tIQ==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.119": {
-      "integrity": "sha512-v3o464XkiYehp/OKidQQirxdVb+aGSvdJvHF2zH9p33W8M/NC21zwwh4dhwDnKsyrtBIgkt2CcMwzIl30r0OtA==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.119": {
-      "integrity": "sha512-QYxFNAe4FFridPkKhGlNcNBJ0TaIygWYyvfI9g4kX0i+RVbresUWuZVkWY06ioJ0fXoixFJ+HNQBMB7dLrIp8Q==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-linux-x64@0.2.119": {
-      "integrity": "sha512-9ePt4ZN+hsqDw4AgS4KtcWIGKfL9Oq28kwkrTER/QAcSrVKxiLonp81cCLzg7Ok/IUJu4Cfd71GZbFv/WE54zw==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.119": {
-      "integrity": "sha512-p/TjcKQvkCYtXGPlR+mdyNwqCmvRcQL34Wtq0yUZ+iqmI/eyCe59IJ3AZrE0EZoqmiAevEYzatPIt9sncC9uxw==",
-      "os": ["win32"],
-      "cpu": ["arm64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-win32-x64@0.2.119": {
-      "integrity": "sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA==",
-      "os": ["win32"],
-      "cpu": ["x64"]
-    },
-    "@anthropic-ai/claude-agent-sdk@0.2.119_zod@3.25.76": {
-      "integrity": "sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA==",
-      "dependencies": [
-        "@anthropic-ai/sdk",
-        "@modelcontextprotocol/sdk",
-        "zod"
-      ],
-      "optionalDependencies": [
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl",
-        "@anthropic-ai/claude-agent-sdk-linux-x64",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64",
-        "@anthropic-ai/claude-agent-sdk-win32-x64"
-      ]
-    },
-    "@anthropic-ai/sdk@0.81.0_zod@3.25.76": {
-      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
-      "dependencies": [
-        "json-schema-to-ts",
-        "zod"
-      ],
-      "optionalPeers": [
-        "zod"
-      ],
-      "bin": true
-    },
-    "@babel/runtime@7.29.2": {
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
-    },
-    "@hono/node-server@1.19.14_hono@4.12.15": {
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
-      "dependencies": [
-        "hono"
-      ]
-    },
-    "@modelcontextprotocol/sdk@1.29.0_zod@3.25.76": {
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
-      "dependencies": [
-        "@hono/node-server",
-        "ajv",
-        "ajv-formats",
-        "content-type",
-        "cors",
-        "cross-spawn",
-        "eventsource",
-        "eventsource-parser",
-        "express",
-        "express-rate-limit",
-        "hono",
-        "jose",
-        "json-schema-typed",
-        "pkce-challenge",
-        "raw-body",
-        "zod",
-        "zod-to-json-schema"
-      ]
-    },
-    "@octokit/auth-app@7.2.2": {
-      "integrity": "sha512-p6hJtEyQDCJEPN9ijjhEC/kpFHMHN4Gca9r+8S0S8EJi7NaWftaEmexjxxpT1DFBeJpN4u/5RE22ArnyypupJw==",
-      "dependencies": [
-        "@octokit/auth-oauth-app",
-        "@octokit/auth-oauth-user",
-        "@octokit/request@9.2.4",
-        "@octokit/request-error@6.1.8",
-        "@octokit/types@14.1.0",
-        "toad-cache",
-        "universal-github-app-jwt",
-        "universal-user-agent@7.0.3"
-      ]
-    },
-    "@octokit/auth-oauth-app@8.1.4": {
-      "integrity": "sha512-71iBa5SflSXcclk/OL3lJzdt4iFs56OJdpBGEBl1wULp7C58uiswZLV6TdRaiAzHP1LT8ezpbHlKuxADb+4NkQ==",
-      "dependencies": [
-        "@octokit/auth-oauth-device",
-        "@octokit/auth-oauth-user",
-        "@octokit/request@9.2.4",
-        "@octokit/types@14.1.0",
-        "universal-user-agent@7.0.3"
-      ]
-    },
-    "@octokit/auth-oauth-device@7.1.5": {
-      "integrity": "sha512-lR00+k7+N6xeECj0JuXeULQ2TSBB/zjTAmNF2+vyGPDEFx1dgk1hTDmL13MjbSmzusuAmuJD8Pu39rjp9jH6yw==",
-      "dependencies": [
-        "@octokit/oauth-methods",
-        "@octokit/request@9.2.4",
-        "@octokit/types@14.1.0",
-        "universal-user-agent@7.0.3"
-      ]
-    },
-    "@octokit/auth-oauth-user@5.1.6": {
-      "integrity": "sha512-/R8vgeoulp7rJs+wfJ2LtXEVC7pjQTIqDab7wPKwVG6+2v/lUnCOub6vaHmysQBbb45FknM3tbHW8TOVqYHxCw==",
-      "dependencies": [
-        "@octokit/auth-oauth-device",
-        "@octokit/oauth-methods",
-        "@octokit/request@9.2.4",
-        "@octokit/types@14.1.0",
-        "universal-user-agent@7.0.3"
-      ]
-    },
-    "@octokit/auth-token@4.0.0": {
-      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="
-    },
-    "@octokit/core@5.2.2": {
-      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
-      "dependencies": [
-        "@octokit/auth-token",
-        "@octokit/graphql",
-        "@octokit/request@8.4.1",
-        "@octokit/request-error@5.1.1",
-        "@octokit/types@13.10.0",
-        "before-after-hook",
-        "universal-user-agent@6.0.1"
-      ]
-    },
-    "@octokit/endpoint@10.1.4": {
-      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
-      "dependencies": [
-        "@octokit/types@14.1.0",
-        "universal-user-agent@7.0.3"
-      ]
-    },
-    "@octokit/endpoint@9.0.6": {
-      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
-      "dependencies": [
-        "@octokit/types@13.10.0",
-        "universal-user-agent@6.0.1"
-      ]
-    },
-    "@octokit/graphql@7.1.1": {
-      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
-      "dependencies": [
-        "@octokit/request@8.4.1",
-        "@octokit/types@13.10.0",
-        "universal-user-agent@6.0.1"
-      ]
-    },
-    "@octokit/oauth-authorization-url@7.1.1": {
-      "integrity": "sha512-ooXV8GBSabSWyhLUowlMIVd9l1s2nsOGQdlP2SQ4LnkEsGXzeCvbSbCPdZThXhEFzleGPwbapT0Sb+YhXRyjCA=="
-    },
-    "@octokit/oauth-methods@5.1.5": {
-      "integrity": "sha512-Ev7K8bkYrYLhoOSZGVAGsLEscZQyq7XQONCBBAl2JdMg7IT3PQn/y8P0KjloPoYpI5UylqYrLeUcScaYWXwDvw==",
-      "dependencies": [
-        "@octokit/oauth-authorization-url",
-        "@octokit/request@9.2.4",
-        "@octokit/request-error@6.1.8",
-        "@octokit/types@14.1.0"
-      ]
-    },
-    "@octokit/openapi-types@24.2.0": {
-      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="
-    },
-    "@octokit/openapi-types@25.1.0": {
-      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA=="
-    },
-    "@octokit/request-error@5.1.1": {
-      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
-      "dependencies": [
-        "@octokit/types@13.10.0",
-        "deprecation",
-        "once"
-      ]
-    },
-    "@octokit/request-error@6.1.8": {
-      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
-      "dependencies": [
-        "@octokit/types@14.1.0"
-      ]
-    },
-    "@octokit/request@8.4.1": {
-      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
-      "dependencies": [
-        "@octokit/endpoint@9.0.6",
-        "@octokit/request-error@5.1.1",
-        "@octokit/types@13.10.0",
-        "universal-user-agent@6.0.1"
-      ]
-    },
-    "@octokit/request@9.2.4": {
-      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
-      "dependencies": [
-        "@octokit/endpoint@10.1.4",
-        "@octokit/request-error@6.1.8",
-        "@octokit/types@14.1.0",
-        "fast-content-type-parse",
-        "universal-user-agent@7.0.3"
-      ]
-    },
-    "@octokit/types@13.10.0": {
-      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
-      "dependencies": [
-        "@octokit/openapi-types@24.2.0"
-      ]
-    },
-    "@octokit/types@14.1.0": {
-      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
-      "dependencies": [
-        "@octokit/openapi-types@25.1.0"
-      ]
-    },
     "@types/prop-types@15.7.15": {
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="
     },
@@ -333,31 +45,6 @@
       "dependencies": [
         "@types/prop-types",
         "csstype"
-      ]
-    },
-    "accepts@2.0.0": {
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "dependencies": [
-        "mime-types",
-        "negotiator"
-      ]
-    },
-    "ajv-formats@3.0.1_ajv@8.20.0": {
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dependencies": [
-        "ajv"
-      ],
-      "optionalPeers": [
-        "ajv"
-      ]
-    },
-    "ajv@8.20.0": {
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dependencies": [
-        "fast-deep-equal",
-        "fast-uri",
-        "json-schema-traverse",
-        "require-from-string"
       ]
     },
     "ansi-escapes@7.3.0": {
@@ -374,40 +61,6 @@
     },
     "auto-bind@5.0.1": {
       "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="
-    },
-    "before-after-hook@2.2.3": {
-      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
-    },
-    "body-parser@2.2.2": {
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
-      "dependencies": [
-        "bytes",
-        "content-type",
-        "debug",
-        "http-errors",
-        "iconv-lite",
-        "on-finished",
-        "qs",
-        "raw-body",
-        "type-is"
-      ]
-    },
-    "bytes@3.1.2": {
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
-    },
-    "call-bind-apply-helpers@1.0.2": {
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dependencies": [
-        "es-errors",
-        "function-bind"
-      ]
-    },
-    "call-bound@1.0.4": {
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dependencies": [
-        "call-bind-apply-helpers",
-        "get-intrinsic"
-      ]
     },
     "chalk@5.6.2": {
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
@@ -434,234 +87,29 @@
         "convert-to-spaces"
       ]
     },
-    "content-disposition@1.1.0": {
-      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="
-    },
-    "content-type@1.0.5": {
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
-    },
     "convert-to-spaces@2.0.1": {
       "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="
-    },
-    "cookie-signature@1.2.2": {
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
-    },
-    "cookie@0.7.2": {
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
-    },
-    "cors@2.8.6": {
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "dependencies": [
-        "object-assign",
-        "vary"
-      ]
-    },
-    "cross-spawn@7.0.6": {
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dependencies": [
-        "path-key",
-        "shebang-command",
-        "which"
-      ]
     },
     "csstype@3.2.3": {
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
-    "debug@4.4.3": {
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dependencies": [
-        "ms"
-      ]
-    },
-    "depd@2.0.0": {
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-    },
-    "deprecation@2.3.1": {
-      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
-    },
-    "dunder-proto@1.0.1": {
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dependencies": [
-        "call-bind-apply-helpers",
-        "es-errors",
-        "gopd"
-      ]
-    },
-    "ee-first@1.1.1": {
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
-    },
     "emoji-regex@10.6.0": {
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
-    },
-    "encodeurl@2.0.0": {
-      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
     },
     "environment@1.1.0": {
       "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="
     },
-    "es-define-property@1.0.1": {
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
-    },
-    "es-errors@1.3.0": {
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-    },
-    "es-object-atoms@1.1.1": {
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dependencies": [
-        "es-errors"
-      ]
-    },
     "es-toolkit@1.46.0": {
       "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA=="
-    },
-    "escape-html@1.0.3": {
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "escape-string-regexp@2.0.0": {
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
     },
-    "etag@1.8.1": {
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
-    },
-    "eventsource-parser@3.0.8": {
-      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="
-    },
-    "eventsource@3.0.7": {
-      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-      "dependencies": [
-        "eventsource-parser"
-      ]
-    },
-    "express-rate-limit@8.4.1_express@5.2.1": {
-      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
-      "dependencies": [
-        "express",
-        "ip-address"
-      ]
-    },
-    "express@5.2.1": {
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "dependencies": [
-        "accepts",
-        "body-parser",
-        "content-disposition",
-        "content-type",
-        "cookie",
-        "cookie-signature",
-        "debug",
-        "depd",
-        "encodeurl",
-        "escape-html",
-        "etag",
-        "finalhandler",
-        "fresh",
-        "http-errors",
-        "merge-descriptors",
-        "mime-types",
-        "on-finished",
-        "once",
-        "parseurl",
-        "proxy-addr",
-        "qs",
-        "range-parser",
-        "router",
-        "send",
-        "serve-static",
-        "statuses",
-        "type-is",
-        "vary"
-      ]
-    },
-    "fast-content-type-parse@2.0.1": {
-      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q=="
-    },
-    "fast-deep-equal@3.1.3": {
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "fast-uri@3.1.0": {
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
-    },
-    "finalhandler@2.1.1": {
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "dependencies": [
-        "debug",
-        "encodeurl",
-        "escape-html",
-        "on-finished",
-        "parseurl",
-        "statuses"
-      ]
-    },
-    "forwarded@0.2.0": {
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
-    },
-    "fresh@2.0.0": {
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="
-    },
-    "function-bind@1.1.2": {
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-    },
     "get-east-asian-width@1.5.0": {
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="
     },
-    "get-intrinsic@1.3.0": {
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dependencies": [
-        "call-bind-apply-helpers",
-        "es-define-property",
-        "es-errors",
-        "es-object-atoms",
-        "function-bind",
-        "get-proto",
-        "gopd",
-        "has-symbols",
-        "hasown",
-        "math-intrinsics"
-      ]
-    },
-    "get-proto@1.0.1": {
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dependencies": [
-        "dunder-proto",
-        "es-object-atoms"
-      ]
-    },
-    "gopd@1.2.0": {
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
-    },
-    "has-symbols@1.1.0": {
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
-    },
-    "hasown@2.0.3": {
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "dependencies": [
-        "function-bind"
-      ]
-    },
-    "hono@4.12.15": {
-      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg=="
-    },
-    "http-errors@2.0.1": {
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "dependencies": [
-        "depd",
-        "inherits",
-        "setprototypeof",
-        "statuses",
-        "toidentifier"
-      ]
-    },
-    "iconv-lite@0.7.2": {
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "dependencies": [
-        "safer-buffer"
-      ]
-    },
     "indent-string@5.0.0": {
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
-    },
-    "inherits@2.0.4": {
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ink@5.2.1_@types+react@18.3.28_react@18.3.1": {
       "integrity": "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==",
@@ -697,12 +145,6 @@
         "@types/react"
       ]
     },
-    "ip-address@10.1.0": {
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="
-    },
-    "ipaddr.js@1.9.1": {
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
-    },
     "is-fullwidth-code-point@4.0.0": {
       "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="
     },
@@ -716,30 +158,8 @@
       "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
       "bin": true
     },
-    "is-promise@4.0.0": {
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
-    },
-    "isexe@2.0.0": {
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-    },
-    "jose@6.2.2": {
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="
-    },
     "js-tokens@4.0.0": {
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
-    "json-schema-to-ts@3.1.1": {
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "dependencies": [
-        "@babel/runtime",
-        "ts-algebra"
-      ]
-    },
-    "json-schema-traverse@1.0.0": {
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "json-schema-typed@8.0.2": {
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
     },
     "loose-envify@1.4.0": {
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
@@ -748,50 +168,8 @@
       ],
       "bin": true
     },
-    "math-intrinsics@1.1.0": {
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
-    },
-    "media-typer@1.1.0": {
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
-    },
-    "merge-descriptors@2.0.0": {
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="
-    },
-    "mime-db@1.54.0": {
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
-    },
-    "mime-types@3.0.2": {
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "dependencies": [
-        "mime-db"
-      ]
-    },
     "mimic-fn@2.1.0": {
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
-    },
-    "ms@2.1.3": {
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "negotiator@1.0.0": {
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
-    },
-    "object-assign@4.1.1": {
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
-    },
-    "object-inspect@1.13.4": {
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
-    },
-    "on-finished@2.4.1": {
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "dependencies": [
-        "ee-first"
-      ]
-    },
-    "once@1.4.0": {
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dependencies": [
-        "wrappy"
-      ]
     },
     "onetime@5.1.2": {
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
@@ -799,45 +177,8 @@
         "mimic-fn"
       ]
     },
-    "parseurl@1.3.3": {
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-    },
     "patch-console@2.0.0": {
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="
-    },
-    "path-key@3.1.1": {
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-    },
-    "path-to-regexp@8.4.2": {
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="
-    },
-    "pkce-challenge@5.0.1": {
-      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="
-    },
-    "proxy-addr@2.0.7": {
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "dependencies": [
-        "forwarded",
-        "ipaddr.js"
-      ]
-    },
-    "qs@6.15.1": {
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "dependencies": [
-        "side-channel"
-      ]
-    },
-    "range-parser@1.2.1": {
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-    },
-    "raw-body@3.0.2": {
-      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "dependencies": [
-        "bytes",
-        "http-errors",
-        "iconv-lite",
-        "unpipe"
-      ]
     },
     "react-reconciler@0.29.2_react@18.3.1": {
       "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
@@ -853,9 +194,6 @@
         "loose-envify"
       ]
     },
-    "require-from-string@2.0.2": {
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
-    },
     "restore-cursor@4.0.0": {
       "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
       "dependencies": [
@@ -863,96 +201,10 @@
         "signal-exit"
       ]
     },
-    "router@2.2.0": {
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "dependencies": [
-        "debug",
-        "depd",
-        "is-promise",
-        "parseurl",
-        "path-to-regexp"
-      ]
-    },
-    "safer-buffer@2.1.2": {
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "scheduler@0.23.2": {
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dependencies": [
         "loose-envify"
-      ]
-    },
-    "send@1.2.1": {
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "dependencies": [
-        "debug",
-        "encodeurl",
-        "escape-html",
-        "etag",
-        "fresh",
-        "http-errors",
-        "mime-types",
-        "ms",
-        "on-finished",
-        "range-parser",
-        "statuses"
-      ]
-    },
-    "serve-static@2.2.1": {
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "dependencies": [
-        "encodeurl",
-        "escape-html",
-        "parseurl",
-        "send"
-      ]
-    },
-    "setprototypeof@1.2.0": {
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
-    },
-    "shebang-command@2.0.0": {
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dependencies": [
-        "shebang-regex"
-      ]
-    },
-    "shebang-regex@3.0.0": {
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-    },
-    "side-channel-list@1.0.1": {
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "dependencies": [
-        "es-errors",
-        "object-inspect"
-      ]
-    },
-    "side-channel-map@1.0.1": {
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dependencies": [
-        "call-bound",
-        "es-errors",
-        "get-intrinsic",
-        "object-inspect"
-      ]
-    },
-    "side-channel-weakmap@1.0.2": {
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dependencies": [
-        "call-bound",
-        "es-errors",
-        "get-intrinsic",
-        "object-inspect",
-        "side-channel-map"
-      ]
-    },
-    "side-channel@1.1.0": {
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dependencies": [
-        "es-errors",
-        "object-inspect",
-        "side-channel-list",
-        "side-channel-map",
-        "side-channel-weakmap"
       ]
     },
     "signal-exit@3.0.7": {
@@ -978,9 +230,6 @@
         "escape-string-regexp"
       ]
     },
-    "statuses@2.0.2": {
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
-    },
     "string-width@7.2.0": {
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dependencies": [
@@ -995,47 +244,8 @@
         "ansi-regex"
       ]
     },
-    "toad-cache@3.7.0": {
-      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="
-    },
-    "toidentifier@1.0.1": {
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
-    },
-    "ts-algebra@2.0.0": {
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="
-    },
     "type-fest@4.41.0": {
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="
-    },
-    "type-is@2.0.1": {
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-      "dependencies": [
-        "content-type",
-        "media-typer",
-        "mime-types"
-      ]
-    },
-    "universal-github-app-jwt@2.2.2": {
-      "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw=="
-    },
-    "universal-user-agent@6.0.1": {
-      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
-    },
-    "universal-user-agent@7.0.3": {
-      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="
-    },
-    "unpipe@1.0.0": {
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
-    },
-    "vary@1.1.2": {
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
-    },
-    "which@2.0.2": {
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dependencies": [
-        "isexe"
-      ],
-      "bin": true
     },
     "widest-line@5.0.0": {
       "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
@@ -1051,20 +261,11 @@
         "strip-ansi"
       ]
     },
-    "wrappy@1.0.2": {
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
     "ws@8.20.0": {
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="
     },
     "yoga-layout@3.2.1": {
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="
-    },
-    "zod-to-json-schema@3.25.2_zod@3.25.76": {
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "dependencies": [
-        "zod"
-      ]
     },
     "zod@3.25.76": {
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="

--- a/deno.lock
+++ b/deno.lock
@@ -1,21 +1,54 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/async@1": "1.3.0",
+    "jsr:@std/cli@1": "1.0.29",
     "jsr:@std/fmt@^1.0.5": "1.0.10",
+    "jsr:@std/fs@1": "1.0.23",
     "jsr:@std/fs@^1.0.11": "1.0.23",
+    "jsr:@std/fs@^1.0.23": "1.0.23",
+    "jsr:@std/internal@^1.0.12": "1.0.13",
+    "jsr:@std/internal@^1.0.13": "1.0.13",
     "jsr:@std/io@~0.225.2": "0.225.3",
     "jsr:@std/log@0.224": "0.224.14",
+    "jsr:@std/path@1": "1.1.4",
+    "jsr:@std/path@^1.1.4": "1.1.4",
+    "jsr:@std/testing@1": "1.0.18",
+    "npm:@anthropic-ai/claude-agent-sdk@*": "0.2.119_zod@3.25.76",
+    "npm:@octokit/auth-app@7": "7.2.2",
+    "npm:@octokit/core@5": "5.2.2",
     "npm:@types/react@18": "18.3.28",
     "npm:ink@5": "5.2.1_@types+react@18.3.28_react@18.3.1",
     "npm:react@18": "18.3.1",
     "npm:zod@3": "3.25.76"
   },
   "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/async@1.3.0": {
+      "integrity": "80485538a4f7baaa46bfe2246168069e02ed142b9f9079cd164f43bb060ad9e9"
+    },
+    "@std/cli@1.0.29": {
+      "integrity": "fa4ef29130baa834d8a13b7d138240c3a2fcfba740bfb7afa646a360a15ec84f"
+    },
     "@std/fmt@1.0.10": {
       "integrity": "90dfba288802ac6de82fb31d0917eb9e4450b9925b954d5e51fc29ac07419db5"
     },
     "@std/fs@1.0.23": {
-      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37"
+      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12",
+        "jsr:@std/path@^1.1.4"
+      ]
+    },
+    "@std/internal@1.0.13": {
+      "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
     },
     "@std/io@0.225.3": {
       "integrity": "27b07b591384d12d7b568f39e61dff966b8230559122df1e9fd11cc068f7ddd1"
@@ -24,8 +57,23 @@
       "integrity": "257f7adceee3b53bb2bc86c7242e7d1bc59729e57d4981c4a7e5b876c808f05e",
       "dependencies": [
         "jsr:@std/fmt",
-        "jsr:@std/fs",
+        "jsr:@std/fs@^1.0.11",
         "jsr:@std/io"
+      ]
+    },
+    "@std/path@1.1.4": {
+      "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/testing@1.0.18": {
+      "integrity": "d3152f57b11666bf6358d0e127c7e3488e91178b0c2d8fbf0793e1c53cd13cb1",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.19",
+        "jsr:@std/fs@^1.0.23",
+        "jsr:@std/internal@^1.0.13",
+        "jsr:@std/path@^1.1.4"
       ]
     }
   },
@@ -37,6 +85,248 @@
         "is-fullwidth-code-point@4.0.0"
       ]
     },
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.119": {
+      "integrity": "sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.119": {
+      "integrity": "sha512-9Aj8g3ELsmZuOFg17TCkikeg/Wt2ucVT8hOOPQUatzLd7BKhydrHLA0RP42nBpWECO1B/n/mPdQ4iS/LS3s2Fg==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.119": {
+      "integrity": "sha512-IPGWgtz+gGnD7fxKAvSf913EUT/lYBTBE8EZ7lh3+x5ZP2859LWLmrCm053Lf3nMWo/CWikZsVPwkDVwpz6tIQ==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.119": {
+      "integrity": "sha512-v3o464XkiYehp/OKidQQirxdVb+aGSvdJvHF2zH9p33W8M/NC21zwwh4dhwDnKsyrtBIgkt2CcMwzIl30r0OtA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.119": {
+      "integrity": "sha512-QYxFNAe4FFridPkKhGlNcNBJ0TaIygWYyvfI9g4kX0i+RVbresUWuZVkWY06ioJ0fXoixFJ+HNQBMB7dLrIp8Q==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-linux-x64@0.2.119": {
+      "integrity": "sha512-9ePt4ZN+hsqDw4AgS4KtcWIGKfL9Oq28kwkrTER/QAcSrVKxiLonp81cCLzg7Ok/IUJu4Cfd71GZbFv/WE54zw==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.119": {
+      "integrity": "sha512-p/TjcKQvkCYtXGPlR+mdyNwqCmvRcQL34Wtq0yUZ+iqmI/eyCe59IJ3AZrE0EZoqmiAevEYzatPIt9sncC9uxw==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-win32-x64@0.2.119": {
+      "integrity": "sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@anthropic-ai/claude-agent-sdk@0.2.119_zod@3.25.76": {
+      "integrity": "sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA==",
+      "dependencies": [
+        "@anthropic-ai/sdk",
+        "@modelcontextprotocol/sdk",
+        "zod"
+      ],
+      "optionalDependencies": [
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl",
+        "@anthropic-ai/claude-agent-sdk-linux-x64",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64",
+        "@anthropic-ai/claude-agent-sdk-win32-x64"
+      ]
+    },
+    "@anthropic-ai/sdk@0.81.0_zod@3.25.76": {
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
+      "dependencies": [
+        "json-schema-to-ts",
+        "zod"
+      ],
+      "optionalPeers": [
+        "zod"
+      ],
+      "bin": true
+    },
+    "@babel/runtime@7.29.2": {
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
+    },
+    "@hono/node-server@1.19.14_hono@4.12.15": {
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dependencies": [
+        "hono"
+      ]
+    },
+    "@modelcontextprotocol/sdk@1.29.0_zod@3.25.76": {
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dependencies": [
+        "@hono/node-server",
+        "ajv",
+        "ajv-formats",
+        "content-type",
+        "cors",
+        "cross-spawn",
+        "eventsource",
+        "eventsource-parser",
+        "express",
+        "express-rate-limit",
+        "hono",
+        "jose",
+        "json-schema-typed",
+        "pkce-challenge",
+        "raw-body",
+        "zod",
+        "zod-to-json-schema"
+      ]
+    },
+    "@octokit/auth-app@7.2.2": {
+      "integrity": "sha512-p6hJtEyQDCJEPN9ijjhEC/kpFHMHN4Gca9r+8S0S8EJi7NaWftaEmexjxxpT1DFBeJpN4u/5RE22ArnyypupJw==",
+      "dependencies": [
+        "@octokit/auth-oauth-app",
+        "@octokit/auth-oauth-user",
+        "@octokit/request@9.2.4",
+        "@octokit/request-error@6.1.8",
+        "@octokit/types@14.1.0",
+        "toad-cache",
+        "universal-github-app-jwt",
+        "universal-user-agent@7.0.3"
+      ]
+    },
+    "@octokit/auth-oauth-app@8.1.4": {
+      "integrity": "sha512-71iBa5SflSXcclk/OL3lJzdt4iFs56OJdpBGEBl1wULp7C58uiswZLV6TdRaiAzHP1LT8ezpbHlKuxADb+4NkQ==",
+      "dependencies": [
+        "@octokit/auth-oauth-device",
+        "@octokit/auth-oauth-user",
+        "@octokit/request@9.2.4",
+        "@octokit/types@14.1.0",
+        "universal-user-agent@7.0.3"
+      ]
+    },
+    "@octokit/auth-oauth-device@7.1.5": {
+      "integrity": "sha512-lR00+k7+N6xeECj0JuXeULQ2TSBB/zjTAmNF2+vyGPDEFx1dgk1hTDmL13MjbSmzusuAmuJD8Pu39rjp9jH6yw==",
+      "dependencies": [
+        "@octokit/oauth-methods",
+        "@octokit/request@9.2.4",
+        "@octokit/types@14.1.0",
+        "universal-user-agent@7.0.3"
+      ]
+    },
+    "@octokit/auth-oauth-user@5.1.6": {
+      "integrity": "sha512-/R8vgeoulp7rJs+wfJ2LtXEVC7pjQTIqDab7wPKwVG6+2v/lUnCOub6vaHmysQBbb45FknM3tbHW8TOVqYHxCw==",
+      "dependencies": [
+        "@octokit/auth-oauth-device",
+        "@octokit/oauth-methods",
+        "@octokit/request@9.2.4",
+        "@octokit/types@14.1.0",
+        "universal-user-agent@7.0.3"
+      ]
+    },
+    "@octokit/auth-token@4.0.0": {
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="
+    },
+    "@octokit/core@5.2.2": {
+      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+      "dependencies": [
+        "@octokit/auth-token",
+        "@octokit/graphql",
+        "@octokit/request@8.4.1",
+        "@octokit/request-error@5.1.1",
+        "@octokit/types@13.10.0",
+        "before-after-hook",
+        "universal-user-agent@6.0.1"
+      ]
+    },
+    "@octokit/endpoint@10.1.4": {
+      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
+      "dependencies": [
+        "@octokit/types@14.1.0",
+        "universal-user-agent@7.0.3"
+      ]
+    },
+    "@octokit/endpoint@9.0.6": {
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "dependencies": [
+        "@octokit/types@13.10.0",
+        "universal-user-agent@6.0.1"
+      ]
+    },
+    "@octokit/graphql@7.1.1": {
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "dependencies": [
+        "@octokit/request@8.4.1",
+        "@octokit/types@13.10.0",
+        "universal-user-agent@6.0.1"
+      ]
+    },
+    "@octokit/oauth-authorization-url@7.1.1": {
+      "integrity": "sha512-ooXV8GBSabSWyhLUowlMIVd9l1s2nsOGQdlP2SQ4LnkEsGXzeCvbSbCPdZThXhEFzleGPwbapT0Sb+YhXRyjCA=="
+    },
+    "@octokit/oauth-methods@5.1.5": {
+      "integrity": "sha512-Ev7K8bkYrYLhoOSZGVAGsLEscZQyq7XQONCBBAl2JdMg7IT3PQn/y8P0KjloPoYpI5UylqYrLeUcScaYWXwDvw==",
+      "dependencies": [
+        "@octokit/oauth-authorization-url",
+        "@octokit/request@9.2.4",
+        "@octokit/request-error@6.1.8",
+        "@octokit/types@14.1.0"
+      ]
+    },
+    "@octokit/openapi-types@24.2.0": {
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="
+    },
+    "@octokit/openapi-types@25.1.0": {
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA=="
+    },
+    "@octokit/request-error@5.1.1": {
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "dependencies": [
+        "@octokit/types@13.10.0",
+        "deprecation",
+        "once"
+      ]
+    },
+    "@octokit/request-error@6.1.8": {
+      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
+      "dependencies": [
+        "@octokit/types@14.1.0"
+      ]
+    },
+    "@octokit/request@8.4.1": {
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "dependencies": [
+        "@octokit/endpoint@9.0.6",
+        "@octokit/request-error@5.1.1",
+        "@octokit/types@13.10.0",
+        "universal-user-agent@6.0.1"
+      ]
+    },
+    "@octokit/request@9.2.4": {
+      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
+      "dependencies": [
+        "@octokit/endpoint@10.1.4",
+        "@octokit/request-error@6.1.8",
+        "@octokit/types@14.1.0",
+        "fast-content-type-parse",
+        "universal-user-agent@7.0.3"
+      ]
+    },
+    "@octokit/types@13.10.0": {
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dependencies": [
+        "@octokit/openapi-types@24.2.0"
+      ]
+    },
+    "@octokit/types@14.1.0": {
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "dependencies": [
+        "@octokit/openapi-types@25.1.0"
+      ]
+    },
     "@types/prop-types@15.7.15": {
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="
     },
@@ -45,6 +335,31 @@
       "dependencies": [
         "@types/prop-types",
         "csstype"
+      ]
+    },
+    "accepts@2.0.0": {
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dependencies": [
+        "mime-types",
+        "negotiator"
+      ]
+    },
+    "ajv-formats@3.0.1_ajv@8.20.0": {
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dependencies": [
+        "ajv"
+      ],
+      "optionalPeers": [
+        "ajv"
+      ]
+    },
+    "ajv@8.20.0": {
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dependencies": [
+        "fast-deep-equal",
+        "fast-uri",
+        "json-schema-traverse",
+        "require-from-string"
       ]
     },
     "ansi-escapes@7.3.0": {
@@ -61,6 +376,40 @@
     },
     "auto-bind@5.0.1": {
       "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="
+    },
+    "before-after-hook@2.2.3": {
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+    },
+    "body-parser@2.2.2": {
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dependencies": [
+        "bytes",
+        "content-type",
+        "debug",
+        "http-errors",
+        "iconv-lite",
+        "on-finished",
+        "qs",
+        "raw-body",
+        "type-is"
+      ]
+    },
+    "bytes@3.1.2": {
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+    },
+    "call-bind-apply-helpers@1.0.2": {
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": [
+        "es-errors",
+        "function-bind"
+      ]
+    },
+    "call-bound@1.0.4": {
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "get-intrinsic"
+      ]
     },
     "chalk@5.6.2": {
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
@@ -87,29 +436,234 @@
         "convert-to-spaces"
       ]
     },
+    "content-disposition@1.1.0": {
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="
+    },
+    "content-type@1.0.5": {
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
+    },
     "convert-to-spaces@2.0.1": {
       "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="
+    },
+    "cookie-signature@1.2.2": {
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
+    },
+    "cookie@0.7.2": {
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
+    },
+    "cors@2.8.6": {
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dependencies": [
+        "object-assign",
+        "vary"
+      ]
+    },
+    "cross-spawn@7.0.6": {
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dependencies": [
+        "path-key",
+        "shebang-command",
+        "which"
+      ]
     },
     "csstype@3.2.3": {
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
+    "debug@4.4.3": {
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "depd@2.0.0": {
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+    },
+    "deprecation@2.3.1": {
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "dunder-proto@1.0.1": {
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-errors",
+        "gopd"
+      ]
+    },
+    "ee-first@1.1.1": {
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
     "emoji-regex@10.6.0": {
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
+    },
+    "encodeurl@2.0.0": {
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
     },
     "environment@1.1.0": {
       "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="
     },
+    "es-define-property@1.0.1": {
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors@1.3.0": {
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms@1.1.1": {
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": [
+        "es-errors"
+      ]
+    },
     "es-toolkit@1.46.0": {
       "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA=="
+    },
+    "escape-html@1.0.3": {
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "escape-string-regexp@2.0.0": {
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
     },
+    "etag@1.8.1": {
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+    },
+    "eventsource-parser@3.0.8": {
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="
+    },
+    "eventsource@3.0.7": {
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dependencies": [
+        "eventsource-parser"
+      ]
+    },
+    "express-rate-limit@8.4.1_express@5.2.1": {
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "dependencies": [
+        "express",
+        "ip-address"
+      ]
+    },
+    "express@5.2.1": {
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dependencies": [
+        "accepts",
+        "body-parser",
+        "content-disposition",
+        "content-type",
+        "cookie",
+        "cookie-signature",
+        "debug",
+        "depd",
+        "encodeurl",
+        "escape-html",
+        "etag",
+        "finalhandler",
+        "fresh",
+        "http-errors",
+        "merge-descriptors",
+        "mime-types",
+        "on-finished",
+        "once",
+        "parseurl",
+        "proxy-addr",
+        "qs",
+        "range-parser",
+        "router",
+        "send",
+        "serve-static",
+        "statuses",
+        "type-is",
+        "vary"
+      ]
+    },
+    "fast-content-type-parse@2.0.1": {
+      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q=="
+    },
+    "fast-deep-equal@3.1.3": {
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-uri@3.1.0": {
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
+    },
+    "finalhandler@2.1.1": {
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dependencies": [
+        "debug",
+        "encodeurl",
+        "escape-html",
+        "on-finished",
+        "parseurl",
+        "statuses"
+      ]
+    },
+    "forwarded@0.2.0": {
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
+    "fresh@2.0.0": {
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="
+    },
+    "function-bind@1.1.2": {
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
     "get-east-asian-width@1.5.0": {
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="
     },
+    "get-intrinsic@1.3.0": {
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "es-errors",
+        "es-object-atoms",
+        "function-bind",
+        "get-proto",
+        "gopd",
+        "has-symbols",
+        "hasown",
+        "math-intrinsics"
+      ]
+    },
+    "get-proto@1.0.1": {
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": [
+        "dunder-proto",
+        "es-object-atoms"
+      ]
+    },
+    "gopd@1.2.0": {
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-symbols@1.1.0": {
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "hasown@2.0.3": {
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dependencies": [
+        "function-bind"
+      ]
+    },
+    "hono@4.12.15": {
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg=="
+    },
+    "http-errors@2.0.1": {
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dependencies": [
+        "depd",
+        "inherits",
+        "setprototypeof",
+        "statuses",
+        "toidentifier"
+      ]
+    },
+    "iconv-lite@0.7.2": {
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dependencies": [
+        "safer-buffer"
+      ]
+    },
     "indent-string@5.0.0": {
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
+    },
+    "inherits@2.0.4": {
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ink@5.2.1_@types+react@18.3.28_react@18.3.1": {
       "integrity": "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==",
@@ -145,6 +699,12 @@
         "@types/react"
       ]
     },
+    "ip-address@10.1.0": {
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="
+    },
+    "ipaddr.js@1.9.1": {
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
     "is-fullwidth-code-point@4.0.0": {
       "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="
     },
@@ -158,8 +718,30 @@
       "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
       "bin": true
     },
+    "is-promise@4.0.0": {
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+    },
+    "isexe@2.0.0": {
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "jose@6.2.2": {
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="
+    },
     "js-tokens@4.0.0": {
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "json-schema-to-ts@3.1.1": {
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dependencies": [
+        "@babel/runtime",
+        "ts-algebra"
+      ]
+    },
+    "json-schema-traverse@1.0.0": {
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "json-schema-typed@8.0.2": {
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
     },
     "loose-envify@1.4.0": {
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
@@ -168,8 +750,50 @@
       ],
       "bin": true
     },
+    "math-intrinsics@1.1.0": {
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "media-typer@1.1.0": {
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
+    },
+    "merge-descriptors@2.0.0": {
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="
+    },
+    "mime-db@1.54.0": {
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+    },
+    "mime-types@3.0.2": {
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dependencies": [
+        "mime-db"
+      ]
+    },
     "mimic-fn@2.1.0": {
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "negotiator@1.0.0": {
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
+    },
+    "object-assign@4.1.1": {
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
+    "object-inspect@1.13.4": {
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
+    },
+    "on-finished@2.4.1": {
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": [
+        "ee-first"
+      ]
+    },
+    "once@1.4.0": {
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": [
+        "wrappy"
+      ]
     },
     "onetime@5.1.2": {
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
@@ -177,8 +801,45 @@
         "mimic-fn"
       ]
     },
+    "parseurl@1.3.3": {
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
     "patch-console@2.0.0": {
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="
+    },
+    "path-key@3.1.1": {
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
+    "path-to-regexp@8.4.2": {
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="
+    },
+    "pkce-challenge@5.0.1": {
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="
+    },
+    "proxy-addr@2.0.7": {
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": [
+        "forwarded",
+        "ipaddr.js"
+      ]
+    },
+    "qs@6.15.1": {
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dependencies": [
+        "side-channel"
+      ]
+    },
+    "range-parser@1.2.1": {
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body@3.0.2": {
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dependencies": [
+        "bytes",
+        "http-errors",
+        "iconv-lite",
+        "unpipe"
+      ]
     },
     "react-reconciler@0.29.2_react@18.3.1": {
       "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
@@ -194,6 +855,9 @@
         "loose-envify"
       ]
     },
+    "require-from-string@2.0.2": {
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "restore-cursor@4.0.0": {
       "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
       "dependencies": [
@@ -201,10 +865,96 @@
         "signal-exit"
       ]
     },
+    "router@2.2.0": {
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dependencies": [
+        "debug",
+        "depd",
+        "is-promise",
+        "parseurl",
+        "path-to-regexp"
+      ]
+    },
+    "safer-buffer@2.1.2": {
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "scheduler@0.23.2": {
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dependencies": [
         "loose-envify"
+      ]
+    },
+    "send@1.2.1": {
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dependencies": [
+        "debug",
+        "encodeurl",
+        "escape-html",
+        "etag",
+        "fresh",
+        "http-errors",
+        "mime-types",
+        "ms",
+        "on-finished",
+        "range-parser",
+        "statuses"
+      ]
+    },
+    "serve-static@2.2.1": {
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dependencies": [
+        "encodeurl",
+        "escape-html",
+        "parseurl",
+        "send"
+      ]
+    },
+    "setprototypeof@1.2.0": {
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "shebang-command@2.0.0": {
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": [
+        "shebang-regex"
+      ]
+    },
+    "shebang-regex@3.0.0": {
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+    },
+    "side-channel-list@1.0.1": {
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dependencies": [
+        "es-errors",
+        "object-inspect"
+      ]
+    },
+    "side-channel-map@1.0.1": {
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "get-intrinsic",
+        "object-inspect"
+      ]
+    },
+    "side-channel-weakmap@1.0.2": {
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "get-intrinsic",
+        "object-inspect",
+        "side-channel-map"
+      ]
+    },
+    "side-channel@1.1.0": {
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dependencies": [
+        "es-errors",
+        "object-inspect",
+        "side-channel-list",
+        "side-channel-map",
+        "side-channel-weakmap"
       ]
     },
     "signal-exit@3.0.7": {
@@ -230,6 +980,9 @@
         "escape-string-regexp"
       ]
     },
+    "statuses@2.0.2": {
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
+    },
     "string-width@7.2.0": {
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dependencies": [
@@ -244,8 +997,47 @@
         "ansi-regex"
       ]
     },
+    "toad-cache@3.7.0": {
+      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="
+    },
+    "toidentifier@1.0.1": {
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+    },
+    "ts-algebra@2.0.0": {
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="
+    },
     "type-fest@4.41.0": {
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="
+    },
+    "type-is@2.0.1": {
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dependencies": [
+        "content-type",
+        "media-typer",
+        "mime-types"
+      ]
+    },
+    "universal-github-app-jwt@2.2.2": {
+      "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw=="
+    },
+    "universal-user-agent@6.0.1": {
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
+    },
+    "universal-user-agent@7.0.3": {
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="
+    },
+    "unpipe@1.0.0": {
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
+    },
+    "vary@1.1.2": {
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    },
+    "which@2.0.2": {
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": [
+        "isexe"
+      ],
+      "bin": true
     },
     "widest-line@5.0.0": {
       "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
@@ -261,11 +1053,20 @@
         "strip-ansi"
       ]
     },
+    "wrappy@1.0.2": {
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
     "ws@8.20.0": {
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="
     },
     "yoga-layout@3.2.1": {
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="
+    },
+    "zod-to-json-schema@3.25.2_zod@3.25.76": {
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dependencies": [
+        "zod"
+      ]
     },
     "zod@3.25.76": {
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="

--- a/docs/adrs/014-persistence-durability-protocol.md
+++ b/docs/adrs/014-persistence-durability-protocol.md
@@ -1,0 +1,175 @@
+# ADR-014: Persistence durability protocol — atomic JSON store with parent-chain fsync
+
+## Status
+
+Accepted (2026-04-26).
+
+## Context
+
+Issue #7 (Wave 2) ships the supervisor's persistence layer. The daemon is a long-lived process that
+must be able to crash at any byte boundary — `kill -9`, OOM, kernel panic, hardware power loss — and
+come back up with a coherent view of every in-flight task. The supervisor reloads state on boot
+through `Persistence.loadAll`, then drives every state transition through `Persistence.save` /
+`Persistence.remove`. The on-disk store is the single source of truth between daemon lifetimes.
+
+A concrete failure mode the protocol must rule out: an operator yanks the power cord one byte into
+the next `save`. On reboot the daemon must observe **either** the previous full snapshot **or** the
+new full snapshot — never a torn mix, never silent data loss, never a half-overwritten file that the
+JSON parser rejects on next startup.
+
+Two requirements push beyond a naive `Deno.writeTextFile`:
+
+1. **Atomicity across observers.** A concurrent `loadAll` (or an operator with `cat`) must always
+   see a complete snapshot. POSIX `rename(2)` within a single filesystem is the standard primitive
+   for this — readers see either the old inode or the new inode, never a partially written file.
+2. **Durability across power loss.** Linux ext4, XFS, macOS APFS, and FreeBSD UFS all let renames
+   live in the parent directory's dirty page cache after the syscall returns. A power loss between
+   `rename` and the next directory flush can drop the new directory entry **even though** the file
+   data is on disk. The same hazard applies to `mkdir(2)` for any intermediate directory we create
+   on first boot.
+
+The acceptance criteria for #7 require ADRs for any new architectural choice. Copilot's review on PR
+#27 (round 4, comment 3145359805) flagged the missing ADR for the durability protocol; this document
+is that ADR.
+
+## Decision
+
+### 1. Atomic write protocol
+
+Every mutation rewrites the **entire** store using the standard write-tmp + fsync + rename +
+parent-chain-fsync dance, in this exact order:
+
+1. **Serialize** the in-memory snapshot to JSON (2-space indent, matching `deno fmt`).
+2. **Ensure** every directory from the filesystem root down to the live file's parent exists,
+   tracking which directories we actually created so we can fsync their parents in step 7.
+3. **Open** `<path>.tmp` with `{ write: true, create: true, truncate: true }`. Truncating any
+   leftover from a previous crash is correct: the rename in step 5 never happened, so the live
+   `<path>` is still intact and the orphan tmp file carries no information.
+4. **Write** the bytes through a `writeAll` loop (Deno's `FsFile.write` may short-write), then
+   `fdatasync` the file descriptor via `FsFile.syncData()`.
+5. **Rename** `<path>.tmp` over `<path>` with `Deno.rename` — the atomic commit point.
+6. **Fsync the leaf parent directory.** Without this the rename's directory-entry update can live in
+   dirty page cache and be lost on power failure even after the file's data is durable.
+7. **Fsync every parent of every directory we just created** in step 2, walking outward from leaf to
+   root. Deduplicated against step 6 so we never fsync the same directory twice.
+
+POSIX `rename(2)` within one filesystem is atomic, so any observer — a concurrent `loadAll`, the
+next daemon restart, an operator with `cat` or `jq` — sees either the previous full snapshot or the
+new full snapshot. There is no third option.
+
+### 2. Concurrency
+
+A single internal mutex (a chained promise on the `AtomicJsonPersistence` instance) serializes
+`save` and `remove` so two callers cannot race the rename. `loadAll` waits behind any in-flight
+write so it never observes a partially serialized in-memory snapshot, even though the on-disk file
+is itself atomic.
+
+The mutex chain catches and discards rejection so a single failed save does not poison every
+subsequent caller. The cost — a few microseconds of promise-chain overhead per mutation — is
+negligible against disk IO.
+
+### 3. Crash recovery
+
+If `<path>.tmp` exists at startup it is the residue of a crash mid-write: the rename in step 5 never
+happened, so the live `<path>` is still intact and the orphan is information-free. `loadAll` ignores
+it; the next successful `save` overwrites it via `truncate: true`. If the live `<path>` is missing
+entirely, the store is empty — `loadAll` returns `[]` rather than failing. This is the correct
+semantics for a fresh daemon install and matches what the supervisor would reconstruct from GitHub's
+task list anyway.
+
+### 4. `@std/fs` posture (Option A)
+
+Issue #7 specifies "All file IO through `@std/fs` where possible". Copilot's round-4 review
+(comment 3145359822) asked us to reconsider. We evaluated three approaches and chose **Option A: use
+`Deno.*` natives directly with documented justification**.
+
+The persistence layer's IO calls split cleanly into three categories:
+
+| Operation                                 | Used in                    | `@std/fs` equivalent | Decision                                                                             |
+| ----------------------------------------- | -------------------------- | -------------------- | ------------------------------------------------------------------------------------ |
+| `Deno.readTextFile`                       | `loadAll`                  | none                 | Direct — `@std/fs` does not wrap the read path.                                      |
+| `Deno.rename`                             | `writeAtomic`              | none                 | Direct — `@std/fs` does not expose rename. This is the atomic commit point.          |
+| `Deno.open` for tmp file + `syncData()`   | `writeAtomic`              | none                 | Direct — `@std/fs` returns no `FsFile`, so `syncData()` is not reachable through it. |
+| `Deno.open` for parent dir + `syncData()` | `syncDirectory`            | none                 | Direct — same reason; durability requires the file descriptor.                       |
+| `Deno.mkdir` per directory in the chain   | `ensureDurableParentChain` | `ensureDir` (close)  | Direct — see below.                                                                  |
+
+`@std/fs.ensureDir` is the closest fit. We **rejected** it for the durability path because it does
+not report which intermediate directories it created. We need that list to fsync each new
+directory's parent in step 7 — without it, a power loss between `mkdir` and the next external sync
+can drop the new directory's entry and orphan the state file even though we fsync'd the file itself.
+Replacing the explicit `Deno.mkdir`-with-tracking loop with `ensureDir` would silently weaken the
+protocol to "best-effort" durability across power loss on a fresh install.
+
+`@std/fs.exists` is unsuitable for the same reason — it adds a TOCTOU window between the check and
+the dependent operation. We use `Deno.errors.NotFound` on the operation itself instead.
+
+`@std/fs.emptyDir` is irrelevant — we never want to empty the persistence directory.
+
+Wave-2 `persistence.ts` therefore imports only `@std/path` (for `dirname`). Future modules that need
+broad-strokes file management without a durability requirement (configuration scaffolding, worktree
+teardown, cache directories) will use `@std/fs` per the issue's policy. The persistence layer is the
+pinned exception, justified by the durability contract that `@std/fs` cannot preserve.
+
+**Option B considered and rejected.** Wrapping every syscall in a thin internal `IO` interface and
+routing the few operations `@std/fs` exposes through it would add an indirection layer for pure
+policy compliance. The signal-to-noise ratio is wrong: at most one of the five distinct operations
+can plausibly be routed through `@std/fs` (the mkdir loop), and that one is the one that must NOT be
+routed because the API contract is too coarse to express the durability requirement.
+
+## Consequences
+
+**Positive:**
+
+- The store survives `kill -9`, OOM, kernel panic, and power loss with the strongest durability
+  guarantee POSIX permits: either the previous snapshot or the new snapshot, never a torn mix and
+  never a "lost rename" where the file data is on disk but the directory entry is gone.
+- A concurrent `loadAll` always observes a complete snapshot — readers and writers cannot tear.
+- The on-disk format is human-readable JSON, inspectable with `cat` / `jq` for postmortems.
+- The serialization mutex closes the in-process race for `save` / `remove` callers without exposing
+  the mutex on the public `Persistence` interface — the daemon never needs to think about it.
+- The protocol is the same on macOS (APFS) and Linux (ext4/XFS) — both filesystems honor `fdatasync`
+  on a directory file descriptor and rename(2) atomicity within a filesystem.
+
+**Negative:**
+
+- Every mutation rewrites the entire file. At Wave-2 scale (≤ a few dozen tasks) this is invisible.
+  If the task count grows past a few hundred, Wave 5+ may switch to a sharded layout or a WAL — the
+  `Persistence` interface in `src/types.ts` is stable across both.
+- Two extra fsyncs per mutation (the file descriptor and the leaf parent directory; more if the
+  directory chain was just created on first boot). Real-world cost: low single-digit milliseconds on
+  SSD, dominated by the rename itself. Acceptable against the durability win.
+- The mutex serializes mutations even when the underlying filesystem could handle concurrent renames
+  safely. We accept the conservative bound; daemon write rates are dominated by polling cadence
+  (seconds), not by mutex contention.
+- The deviation from the issue's "all file IO through `@std/fs`" policy is documented but real. We
+  mitigate by keeping `@std/path` (the only import we still need) and by limiting the exception to
+  the persistence module — every non-durability file IO callsite in the codebase remains free to use
+  `@std/fs`.
+
+**Alternatives considered and rejected:**
+
+- **Write-ahead log (WAL).** Lower per-mutation cost (append-only fsync of a small record) at the
+  cost of a more complex recovery path: replay the log on startup, periodically compact, handle
+  partial-record tail truncation. Wrong shape for Wave-2 scale where the entire store is small
+  enough to rewrite atomically and the operator value of a single human-readable JSON file is high.
+  Reconsider in Wave 5+ if the active task set crosses the rewrite-cost threshold.
+- **SQLite (via an FFI binding).** Buys real ACID semantics for free, but introduces a native
+  dependency, an embedded query language, and an opaque on-disk format that `cat`/`jq` cannot
+  inspect. The Wave-2 supervisor's data model is "list of small denormalized records" — well below
+  the threshold where a relational store is the right tool.
+- **`Deno.writeTextFile` with no `.tmp` staging.** Loses atomicity: a crash mid-write leaves the
+  live file partially overwritten and the JSON parser fails on next startup. Trivially wrong for the
+  durability contract.
+- **Direct `write()` syscalls (skipping `FsFile`).** `FsFile.syncData` is the durable-write
+  primitive Deno exposes; bypassing it would require FFI and gain nothing. Rejected.
+
+## References
+
+- Issue #7 (Wave 2 — atomic JSON state store).
+- Copilot review on PR #27, round 4 (comments 3145359805 ADR-required, 3145359822 `@std/fs`
+  posture).
+- `src/daemon/persistence.ts` — production implementation.
+- `src/types.ts::Persistence` — the contract this module satisfies.
+- `tests/integration/persistence_test.ts` — durability and atomicity coverage including parent-chain
+  fsync, mid-write crash, concurrent save/load, and corrupt-file rejection.
+- ADR-012 (event bus) — references this ADR as the source of truth for supervisor state.

--- a/src/daemon/persistence.ts
+++ b/src/daemon/persistence.ts
@@ -42,6 +42,17 @@
  * `save` overwrites it. If the live `<path>` is missing entirely, the store
  * is empty — `loadAll` returns `[]` rather than failing.
  *
+ * **`@std/fs` policy.** Issue #7 specifies "All file IO through `@std/fs`
+ * where possible". The persistence layer is the documented exception:
+ * `@std/fs` exposes neither the rename, the file-descriptor `syncData`, nor
+ * a directory-tracking `mkdir` that would let us fsync each newly-created
+ * parent (see `ensureDurableParentChain` below for why that matters). We
+ * therefore call `Deno.readTextFile`, `Deno.rename`, `Deno.mkdir`, and
+ * `Deno.open` directly. The rationale is captured in
+ * {@link https://github.com/koraytaylan/makina/blob/develop/docs/adrs/014-persistence-durability-protocol.md ADR-014}.
+ * Other modules without a hard durability contract should continue to use
+ * `@std/fs`.
+ *
  * @module
  */
 

--- a/src/daemon/persistence.ts
+++ b/src/daemon/persistence.ts
@@ -13,13 +13,18 @@
  * either way.
  *
  * **Atomic write.** Every mutation rewrites the entire store using the
- * standard write-tmp + fsync + rename dance:
+ * standard write-tmp + fsync + rename + dir-fsync dance:
  *
  *  1. Serialize the current in-memory snapshot to JSON.
  *  2. Open `<path>.tmp` (truncating any leftover from a previous crash).
  *  3. Write the bytes, then `fdatasync` the file descriptor so the kernel
- *     flushes them to disk before the rename returns.
+ *     flushes them to disk before the rename.
  *  4. Atomically rename `<path>.tmp` over `<path>`.
+ *  5. Open the parent directory and `fdatasync` it so the new directory
+ *     entry (the post-rename name → inode mapping) is itself durable. On
+ *     POSIX filesystems the rename's metadata can otherwise live in the
+ *     directory's dirty page cache and be lost on power failure even after
+ *     the file's data has been flushed.
  *
  * Because POSIX rename(2) within a filesystem is atomic, an observer (a
  * concurrent `loadAll`, the next daemon restart, an operator with `cat`)
@@ -43,7 +48,7 @@
 import { dirname } from "@std/path";
 import { ensureDir } from "@std/fs";
 
-import { type Persistence, type Task, type TaskId } from "../types.ts";
+import { MERGE_MODES, type Persistence, type Task, TASK_STATES, type TaskId } from "../types.ts";
 
 /** Suffix appended to the live path to form the temp file used for atomic writes. */
 const TEMP_FILE_SUFFIX = ".tmp";
@@ -121,9 +126,12 @@ class AtomicJsonPersistence implements Persistence {
    *
    * @returns Frozen array of every task currently persisted, in the order
    *   the file holds them.
-   * @throws If the file exists but is not valid JSON or does not match the
-   *   expected array-of-tasks shape; this surfaces a corrupt store rather
-   *   than silently dropping data.
+   * @throws If the file exists but is not valid JSON, the root is not an
+   *   array, or any element is missing the required {@link Task} shape
+   *   (object with at minimum `id`, `repo`, `issueNumber`, `state`,
+   *   `mergeMode`, `model`, `iterationCount`, `createdAtIso`,
+   *   `updatedAtIso`); this surfaces a corrupt store rather than silently
+   *   handing the daemon malformed records typed as `Task`.
    */
   async loadAll(): Promise<readonly Task[]> {
     // Wait for any in-flight write so we never observe a partially serialized
@@ -159,7 +167,7 @@ class AtomicJsonPersistence implements Persistence {
         `persistence: ${this.livePath} root is not an array`,
       );
     }
-    return Object.freeze(parsed as Task[]);
+    return Object.freeze(parsed.map((entry, index) => coerceTask(entry, index, this.livePath)));
   }
 
   /**
@@ -273,7 +281,7 @@ class AtomicJsonPersistence implements Persistence {
         `persistence: ${this.livePath} root is not an array`,
       );
     }
-    return parsed as Task[];
+    return parsed.map((entry, index) => coerceTask(entry, index, this.livePath));
   }
 
   /**
@@ -281,11 +289,15 @@ class AtomicJsonPersistence implements Persistence {
    * `tasks`.
    *
    * Sequence: ensure parent → open `<path>.tmp` (truncate) → write JSON →
-   * `fdatasync` the file descriptor → close → rename over the live path.
-   * The rename is the commit point.
+   * `fdatasync` the file descriptor → close → rename over the live path →
+   * `fdatasync` the parent directory. The rename is the commit point and
+   * the parent-directory sync makes that commit durable across power loss
+   * — without it the new directory entry can live in the directory's
+   * dirty page cache and be lost even though the file's data is on disk.
    */
   private async writeAtomic(tasks: readonly Task[]): Promise<void> {
-    await ensureDir(dirname(this.livePath));
+    const parent = dirname(this.livePath);
+    await ensureDir(parent);
     const json = JSON.stringify(tasks, null, JSON_INDENT_SPACES);
     const bytes = new TextEncoder().encode(json);
     const file = await Deno.open(this.tempPath, {
@@ -300,6 +312,7 @@ class AtomicJsonPersistence implements Persistence {
       file.close();
     }
     await Deno.rename(this.tempPath, this.livePath);
+    await syncDirectory(parent);
   }
 }
 
@@ -349,4 +362,131 @@ async function writeAll(file: Deno.FsFile, bytes: Uint8Array): Promise<void> {
 /** Sentinel no-op used by the write chain to swallow unhandled rejections. */
 function noop(): void {
   // Intentionally empty.
+}
+
+/**
+ * Set of required {@link Task} field names checked by {@link coerceTask}.
+ *
+ * We deliberately enforce the persistence-relevant minimum — every field
+ * the supervisor reads at restore time must be present and well-typed.
+ * Optional fields (`prNumber`, `branchName`, `worktreePath`, `sessionId`,
+ * `lastReviewAtIso`, `stabilizePhase`, `terminalReason`) are not checked
+ * here; they are validated by the consumers that actually read them.
+ */
+const REQUIRED_TASK_FIELDS = [
+  "id",
+  "repo",
+  "issueNumber",
+  "state",
+  "mergeMode",
+  "model",
+  "iterationCount",
+  "createdAtIso",
+  "updatedAtIso",
+] as const satisfies readonly (keyof Task)[];
+
+/**
+ * Validate that `entry` matches the {@link Task} shape closely enough to
+ * be handed to the daemon as a `Task`.
+ *
+ * The check is intentionally narrow — we verify presence and primitive
+ * type of every required persistence field, plus the discriminant unions
+ * (`state`, `mergeMode`) that the supervisor switches on. We do not
+ * re-validate brand invariants (`makeTaskId` etc.); a value that survived
+ * a previous serialization must have already passed those.
+ *
+ * @throws If `entry` is not an object, is missing a required field, or
+ *   carries the wrong type for one. The error names the live path and
+ *   element index so an operator can locate the bad record with `jq`.
+ */
+function coerceTask(entry: unknown, index: number, livePath: string): Task {
+  if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+    throw new Error(
+      `persistence: ${livePath}[${index}] is not a Task object`,
+    );
+  }
+  const record = entry as Record<string, unknown>;
+  for (const field of REQUIRED_TASK_FIELDS) {
+    if (!(field in record)) {
+      throw new Error(
+        `persistence: ${livePath}[${index}] is missing required field "${field}"`,
+      );
+    }
+  }
+  if (typeof record.id !== "string" || record.id.length === 0) {
+    throw new Error(
+      `persistence: ${livePath}[${index}].id is not a non-empty string`,
+    );
+  }
+  if (typeof record.repo !== "string" || record.repo.length === 0) {
+    throw new Error(
+      `persistence: ${livePath}[${index}].repo is not a non-empty string`,
+    );
+  }
+  if (typeof record.issueNumber !== "number" || !Number.isInteger(record.issueNumber)) {
+    throw new Error(
+      `persistence: ${livePath}[${index}].issueNumber is not an integer`,
+    );
+  }
+  if (typeof record.iterationCount !== "number" || !Number.isInteger(record.iterationCount)) {
+    throw new Error(
+      `persistence: ${livePath}[${index}].iterationCount is not an integer`,
+    );
+  }
+  if (typeof record.model !== "string") {
+    throw new Error(
+      `persistence: ${livePath}[${index}].model is not a string`,
+    );
+  }
+  if (typeof record.createdAtIso !== "string") {
+    throw new Error(
+      `persistence: ${livePath}[${index}].createdAtIso is not a string`,
+    );
+  }
+  if (typeof record.updatedAtIso !== "string") {
+    throw new Error(
+      `persistence: ${livePath}[${index}].updatedAtIso is not a string`,
+    );
+  }
+  if (
+    typeof record.state !== "string" ||
+    !(TASK_STATES as readonly string[]).includes(record.state)
+  ) {
+    throw new Error(
+      `persistence: ${livePath}[${index}].state ${JSON.stringify(record.state)} is not a TaskState`,
+    );
+  }
+  if (
+    typeof record.mergeMode !== "string" ||
+    !(MERGE_MODES as readonly string[]).includes(record.mergeMode)
+  ) {
+    throw new Error(
+      `persistence: ${livePath}[${index}].mergeMode ${
+        JSON.stringify(record.mergeMode)
+      } is not a MergeMode`,
+    );
+  }
+  return record as unknown as Task;
+}
+
+/**
+ * `fdatasync` the directory at `path` so the most recent rename within it
+ * is durable across power loss.
+ *
+ * On POSIX filesystems a `rename(2)` updates the parent directory's
+ * dirty page cache; the entry is not durable until the directory itself
+ * is flushed. macOS, Linux ext4, XFS, and APFS all permit opening a
+ * directory read-only and calling `fdatasync` on the descriptor — Deno
+ * exposes that as `Deno.FsFile.syncData()`.
+ *
+ * Any IO failure is propagated; a half-durable rename is worse than no
+ * rename because callers think their write committed.
+ */
+async function syncDirectory(path: string): Promise<void> {
+  const dir = await Deno.open(path, { read: true });
+  try {
+    await dir.syncData();
+  } finally {
+    dir.close();
+  }
 }

--- a/src/daemon/persistence.ts
+++ b/src/daemon/persistence.ts
@@ -46,7 +46,6 @@
  */
 
 import { dirname } from "@std/path";
-import { ensureDir } from "@std/fs";
 
 import { MERGE_MODES, type Persistence, type Task, TASK_STATES, type TaskId } from "../types.ts";
 
@@ -82,9 +81,13 @@ export type FsOpen = (
  * file returns `[]`, which is the correct semantics for a fresh daemon
  * install.
  *
- * @param opts.path Absolute filesystem path of the live store. The
- *   parent directory is created if it does not exist; the file itself is
- *   created on demand.
+ * @param opts.path Filesystem path of the live store. May be absolute or
+ *   relative; relative paths are resolved against the daemon's current
+ *   working directory by the underlying `Deno.readTextFile` / `Deno.rename`
+ *   syscalls. The parent directory is created if it does not exist; the
+ *   file itself is created on demand. Production callers pass an absolute
+ *   path so the daemon's `cd` (or lack thereof) cannot move the store out
+ *   from under it.
  * @param opts.open Optional override for `Deno.open`. Production callers
  *   leave this unset and get the real syscall; tests pass a spy so they
  *   can observe `syncData()` invocations without mutating `Deno.open`
@@ -319,16 +322,19 @@ class AtomicJsonPersistence implements Persistence {
    * Atomically replace the live file with the JSON serialization of
    * `tasks`.
    *
-   * Sequence: ensure parent → open `<path>.tmp` (truncate) → write JSON →
-   * `fdatasync` the file descriptor → close → rename over the live path →
-   * `fdatasync` the parent directory. The rename is the commit point and
-   * the parent-directory sync makes that commit durable across power loss
-   * — without it the new directory entry can live in the directory's
-   * dirty page cache and be lost even though the file's data is on disk.
+   * Sequence: durably ensure the parent chain → open `<path>.tmp`
+   * (truncate) → write JSON → `fdatasync` the file descriptor → close →
+   * rename over the live path → `fdatasync` every directory from the leaf
+   * parent up to (and including) the highest newly-created ancestor's
+   * parent. The rename is the commit point and the directory syncs make
+   * both that commit and any freshly-created parent entries durable across
+   * power loss — without them the new directory entry (or its containing
+   * directory's entry, if we just created the directory) can live in dirty
+   * page cache and be lost even though the file's data is on disk.
    */
   private async writeAtomic(tasks: readonly Task[]): Promise<void> {
     const parent = dirname(this.livePath);
-    await ensureDir(parent);
+    const created = await this.ensureDurableParentChain(parent);
     const json = JSON.stringify(tasks, null, JSON_INDENT_SPACES);
     const bytes = new TextEncoder().encode(json);
     const file = await this.open(this.tempPath, {
@@ -343,18 +349,85 @@ class AtomicJsonPersistence implements Persistence {
       file.close();
     }
     await Deno.rename(this.tempPath, this.livePath);
-    await this.syncDirectory(parent);
+    // Always sync the leaf parent so the rename's directory entry is
+    // durable. Then walk up the chain of directories we just created and
+    // sync each of *their* parents so each new directory entry is also
+    // durable. The set is deduplicated and ordered from leaf-most outward,
+    // which matches the safe-to-fsync order on POSIX (a child must be
+    // synced before its parent if both are dirty, though syncing in either
+    // order is correct — we just want every link committed).
+    const toSync = directoriesToFsync(parent, created);
+    for (const dir of toSync) {
+      await this.syncDirectory(dir);
+    }
   }
 
   /**
-   * `fdatasync` the directory at `path` so the most recent rename within it
-   * is durable across power loss.
+   * Create every missing directory from the filesystem root down to
+   * `leaf`, fsyncing each newly-created directory's *parent* so the new
+   * entry is durable.
    *
-   * On POSIX filesystems a `rename(2)` updates the parent directory's
-   * dirty page cache; the entry is not durable until the directory itself
-   * is flushed. macOS, Linux ext4, XFS, and APFS all permit opening a
-   * directory read-only and calling `fdatasync` on the descriptor — Deno
-   * exposes that as `Deno.FsFile.syncData()`.
+   * Returns the absolute (or platform-rooted relative) paths of every
+   * directory we actually had to create, ordered leaf-most first. If the
+   * entire chain already existed, returns an empty array.
+   *
+   * Why this is not just `ensureDir + syncDirectory(leaf)`: when
+   * `ensureDir` creates intermediate directories (e.g., creating
+   * `<workspace>/persistence/` to host `state.json` when `<workspace>`
+   * exists but `persistence/` does not), the new sub-directory's
+   * directory entry lives in `<workspace>`'s dirty page cache. Without
+   * fsyncing `<workspace>`, a power loss after the rename can lose the
+   * `persistence/` entry — which loses the state file even though we
+   * fsync'd it.
+   */
+  private async ensureDurableParentChain(leaf: string): Promise<string[]> {
+    // Build the chain from leaf up to the root by repeated `dirname`.
+    const chain: string[] = [];
+    let current = leaf;
+    // `dirname("/")` is "/" on POSIX; `dirname(".")` is "." — both are
+    // fixed points, which is how we terminate. Defensive cap so a buggy
+    // path does not loop forever.
+    for (let i = 0; i < 4096; i += 1) {
+      chain.push(current);
+      const next = dirname(current);
+      if (next === current) {
+        break;
+      }
+      current = next;
+    }
+    // Walk root → leaf (reverse), creating each directory if missing.
+    // Track which ones we actually created so we can fsync their parents
+    // afterwards.
+    const created: string[] = [];
+    for (let i = chain.length - 1; i >= 0; i -= 1) {
+      const dir = chain[i];
+      if (dir === undefined) {
+        continue;
+      }
+      try {
+        await Deno.mkdir(dir);
+        created.push(dir);
+      } catch (error) {
+        if (error instanceof Deno.errors.AlreadyExists) {
+          continue;
+        }
+        throw error;
+      }
+    }
+    // `created` is in root → leaf order; flip to leaf → root so callers
+    // see the deepest directory first (matches the natural fsync order).
+    return created.reverse();
+  }
+
+  /**
+   * `fdatasync` the directory at `path` so the most recent rename or
+   * mkdir within it is durable across power loss.
+   *
+   * On POSIX filesystems a `rename(2)` or `mkdir(2)` updates the parent
+   * directory's dirty page cache; the entry is not durable until the
+   * directory itself is flushed. macOS, Linux ext4, XFS, and APFS all
+   * permit opening a directory read-only and calling `fdatasync` on the
+   * descriptor — Deno exposes that as `Deno.FsFile.syncData()`.
    *
    * Routed through the injected {@link FsOpen} so the same spy that
    * observes the temp-file sync also sees the directory sync.
@@ -370,6 +443,49 @@ class AtomicJsonPersistence implements Persistence {
       dir.close();
     }
   }
+}
+
+/**
+ * Compute the set of directories whose `fdatasync` makes a `writeAtomic`
+ * commit fully durable, ordered leaf-most first.
+ *
+ * Two distinct directory entries can be dirty after a `writeAtomic`:
+ *
+ *  1. The leaf parent directory of the live file — its rename's new
+ *     entry lives in the leaf's dirty page cache.
+ *  2. The parent of every directory that {@link AtomicJsonPersistence.ensureDurableParentChain}
+ *     just created — each new directory's entry lives in *its* parent's
+ *     dirty page cache.
+ *
+ * `created` from `ensureDurableParentChain` is leaf-most first, so the
+ * parents we need to fsync are `dirname(created[0])`,
+ * `dirname(created[1])`, etc., plus the leaf itself. Deduplicating keeps
+ * us from fsyncing the same directory twice when the leaf parent was
+ * itself one of the just-created directories (e.g., when the entire
+ * persistence dir tree was new). The leaf-most-first ordering is the
+ * natural shape — fsyncing the deepest directory first covers the
+ * just-renamed file entry before we move outward to durably link in
+ * the new directories themselves.
+ */
+function directoriesToFsync(leafParent: string, created: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const push = (path: string): void => {
+    if (seen.has(path)) {
+      return;
+    }
+    seen.add(path);
+    out.push(path);
+  };
+  // Always sync the leaf parent — that is the directory whose entry
+  // table changed when we renamed the temp file over the live file.
+  push(leafParent);
+  // Then sync the parent of every newly-created directory (where its own
+  // directory entry now lives), walking outward from leaf to root.
+  for (const dir of created) {
+    push(dirname(dir));
+  }
+  return out;
 }
 
 /**

--- a/src/daemon/persistence.ts
+++ b/src/daemon/persistence.ts
@@ -500,25 +500,18 @@ function directoriesToFsync(leafParent: string, created: readonly string[]): str
 }
 
 /**
- * Replace the matching record in `current` with `incoming`, or append
- * `incoming` if no record carries the same {@link Task.id}.
+ * Drop every record in `current` whose {@link Task.id} matches `incoming`,
+ * then append `incoming` once.
  *
- * Returns a new array; `current` is not mutated.
+ * Filtering (rather than in-place replace) means that if the on-disk store
+ * ever ends up with multiple records sharing one id — manual edit, file
+ * corruption, or a legacy multi-writer history — a single save converges
+ * the array back to one record per id rather than rewriting every duplicate
+ * with the new payload. Returns a new array; `current` is not mutated.
  */
 function upsertTask(current: readonly Task[], incoming: Task): Task[] {
-  const next: Task[] = [];
-  let replaced = false;
-  for (const existing of current) {
-    if (existing.id === incoming.id) {
-      next.push(incoming);
-      replaced = true;
-    } else {
-      next.push(existing);
-    }
-  }
-  if (!replaced) {
-    next.push(incoming);
-  }
+  const next = current.filter((existing) => existing.id !== incoming.id);
+  next.push(incoming);
   return next;
 }
 

--- a/src/daemon/persistence.ts
+++ b/src/daemon/persistence.ts
@@ -58,7 +58,16 @@
 
 import { dirname } from "@std/path";
 
-import { MERGE_MODES, type Persistence, type Task, TASK_STATES, type TaskId } from "../types.ts";
+import {
+  makeIssueNumber,
+  makeRepoFullName,
+  makeTaskId,
+  MERGE_MODES,
+  type Persistence,
+  type Task,
+  TASK_STATES,
+  type TaskId,
+} from "../types.ts";
 
 /** Suffix appended to the live path to form the temp file used for atomic writes. */
 const TEMP_FILE_SUFFIX = ".tmp";
@@ -564,18 +573,69 @@ const REQUIRED_TASK_FIELDS = [
 ] as const satisfies readonly (keyof Task)[];
 
 /**
+ * Run `produce()` and rethrow any exception as a {@link PersistenceError}
+ * naming the failing record's `livePath[index].field` location.
+ *
+ * Used to wrap brand constructors (`makeTaskId`, `makeRepoFullName`,
+ * `makeIssueNumber`) so a corrupt on-disk value (e.g. `id: ""`,
+ * `issueNumber: 0`, `repo: "no-slash"`) surfaces with the same
+ * `persistence: <path>[<i>].<field> ...` shape as the primitive checks
+ * around it. The original `RangeError` from the constructor is preserved
+ * via `cause` for log forensics.
+ */
+function brandedField<T>(
+  livePath: string,
+  index: number,
+  field: string,
+  produce: () => T,
+): T {
+  try {
+    return produce();
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    throw new PersistenceError(
+      `persistence: ${livePath}[${index}].${field} fails brand invariant: ${message}`,
+      { cause },
+    );
+  }
+}
+
+/**
+ * Error type thrown by {@link coerceTask} when a record on disk fails
+ * structural or brand-invariant validation. Carries the original
+ * constructor `RangeError` (when present) on `cause` so the underlying
+ * reason — empty `TaskId`, malformed `RepoFullName`, non-positive
+ * `IssueNumber` — is visible to log readers without reformatting.
+ *
+ * Subclassing `Error` (rather than tagging `Error` instances) lets tests
+ * assert the failure category with `assertRejects(_, PersistenceError)`
+ * separately from generic JSON / primitive-type failures, even though all
+ * three currently surface as `Error` to callers.
+ */
+export class PersistenceError extends Error {
+  /** Discriminator visible in stack traces and `error.name === ...` checks. */
+  override readonly name = "PersistenceError";
+}
+
+/**
  * Validate that `entry` matches the {@link Task} shape closely enough to
  * be handed to the daemon as a `Task`.
  *
- * The check is intentionally narrow — we verify presence and primitive
- * type of every required persistence field, plus the discriminant unions
- * (`state`, `mergeMode`) that the supervisor switches on. We do not
- * re-validate brand invariants (`makeTaskId` etc.); a value that survived
- * a previous serialization must have already passed those.
+ * The check verifies presence and primitive type of every required
+ * persistence field, the discriminant unions (`state`, `mergeMode`) that
+ * the supervisor switches on, **and** the brand invariants
+ * (`makeTaskId`, `makeRepoFullName`, `makeIssueNumber`). Routing the
+ * branded fields through their constructors closes a corruption gap: a
+ * hand-edited or legacy store could otherwise carry `id: ""`,
+ * `issueNumber: 0`, or `repo: "no-slash"` and survive `loadAll()`,
+ * handing the supervisor a value typed as `Task` whose runtime shape
+ * violates invariants the rest of the daemon relies on.
  *
  * @throws If `entry` is not an object, is missing a required field, or
- *   carries the wrong type for one. The error names the live path and
- *   element index so an operator can locate the bad record with `jq`.
+ *   carries the wrong type or a brand-invalid value for one. The error
+ *   names the live path and element index so an operator can locate the
+ *   bad record with `jq`. Brand-invariant failures throw
+ *   {@link PersistenceError} with the original `RangeError` on `cause`.
  */
 function coerceTask(entry: unknown, index: number, livePath: string): Task {
   if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
@@ -644,5 +704,23 @@ function coerceTask(entry: unknown, index: number, livePath: string): Task {
       } is not a MergeMode`,
     );
   }
-  return record as unknown as Task;
+  // Re-run the branded constructors so a corrupt store cannot smuggle
+  // values that violate `id`/`repo`/`issueNumber` invariants past the
+  // primitive checks above. Each constructor's `RangeError` is wrapped
+  // in a `PersistenceError` that names the failing field path so an
+  // operator can `jq` straight to the bad record.
+  const id = brandedField(livePath, index, "id", () => makeTaskId(record.id as string));
+  const repo = brandedField(
+    livePath,
+    index,
+    "repo",
+    () => makeRepoFullName(record.repo as string),
+  );
+  const issueNumber = brandedField(
+    livePath,
+    index,
+    "issueNumber",
+    () => makeIssueNumber(record.issueNumber as number),
+  );
+  return { ...record, id, repo, issueNumber } as unknown as Task;
 }

--- a/src/daemon/persistence.ts
+++ b/src/daemon/persistence.ts
@@ -102,9 +102,11 @@ export type FsOpen = (
  * @param opts.open Optional override for `Deno.open`. Production callers
  *   leave this unset and get the real syscall; tests pass a spy so they
  *   can observe `syncData()` invocations without mutating `Deno.open`
- *   process-wide. Read-side IO (`Deno.readTextFile`, `Deno.rename`)
- *   bypasses this hook because no test currently needs to intercept it
- *   and the production behavior is identical either way.
+ *   process-wide. The hook intercepts only `Deno.open` calls; the other
+ *   filesystem syscalls used by this module — `Deno.readTextFile`,
+ *   `Deno.mkdir`, and `Deno.rename` — go directly to the runtime because
+ *   no test currently needs to observe them and the production behavior
+ *   is identical with or without a spy.
  * @returns A {@link Persistence} bound to `opts.path`.
  *
  * @example

--- a/src/daemon/persistence.ts
+++ b/src/daemon/persistence.ts
@@ -57,6 +57,20 @@ const TEMP_FILE_SUFFIX = ".tmp";
 const JSON_INDENT_SPACES = 2;
 
 /**
+ * Function shape used by {@link createPersistence} to open files and
+ * directories on the write path. Structurally identical to
+ * {@link Deno.open}; production wiring uses `Deno.open` itself, while
+ * tests can inject a spy that records `syncData` calls without mutating
+ * the global. The latter matters because `deno test --parallel` shares a
+ * single process with every test file, and a swapped-out `Deno.open` is
+ * a cross-test race waiting to happen.
+ */
+export type FsOpen = (
+  path: string | URL,
+  options?: Deno.OpenOptions,
+) => Promise<Deno.FsFile>;
+
+/**
  * Construct an atomic JSON-backed {@link Persistence}.
  *
  * The returned object owns the on-disk file at `opts.path`. Multiple
@@ -71,6 +85,12 @@ const JSON_INDENT_SPACES = 2;
  * @param opts.path Absolute filesystem path of the live store. The
  *   parent directory is created if it does not exist; the file itself is
  *   created on demand.
+ * @param opts.open Optional override for `Deno.open`. Production callers
+ *   leave this unset and get the real syscall; tests pass a spy so they
+ *   can observe `syncData()` invocations without mutating `Deno.open`
+ *   process-wide. Read-side IO (`Deno.readTextFile`, `Deno.rename`)
+ *   bypasses this hook because no test currently needs to intercept it
+ *   and the production behavior is identical either way.
  * @returns A {@link Persistence} bound to `opts.path`.
  *
  * @example
@@ -84,8 +104,10 @@ const JSON_INDENT_SPACES = 2;
  * }
  * ```
  */
-export function createPersistence(opts: { readonly path: string }): Persistence {
-  return new AtomicJsonPersistence(opts.path);
+export function createPersistence(
+  opts: { readonly path: string; readonly open?: FsOpen },
+): Persistence {
+  return new AtomicJsonPersistence(opts.path, opts.open ?? Deno.open);
 }
 
 /**
@@ -100,6 +122,12 @@ class AtomicJsonPersistence implements Persistence {
   /** Absolute path of the staging file used for atomic writes. */
   private readonly tempPath: string;
   /**
+   * Injected `Deno.open` (or a test spy with the same shape). Used for the
+   * temp-file write and the parent-directory open whose `syncData()` calls
+   * make the rename durable.
+   */
+  private readonly open: FsOpen;
+  /**
    * Tail of the serialization mutex chain. Every mutation appends itself by
    * `await`-ing the previous tail and assigning a new tail; concurrent
    * callers therefore queue rather than race the rename.
@@ -111,10 +139,13 @@ class AtomicJsonPersistence implements Persistence {
 
   /**
    * @param livePath Absolute path of the live JSON store.
+   * @param open Function used to open files/directories on the write path.
+   *   Defaults to {@link Deno.open}; tests inject a spy.
    */
-  constructor(livePath: string) {
+  constructor(livePath: string, open: FsOpen) {
     this.livePath = livePath;
     this.tempPath = `${livePath}${TEMP_FILE_SUFFIX}`;
+    this.open = open;
   }
 
   /**
@@ -300,7 +331,7 @@ class AtomicJsonPersistence implements Persistence {
     await ensureDir(parent);
     const json = JSON.stringify(tasks, null, JSON_INDENT_SPACES);
     const bytes = new TextEncoder().encode(json);
-    const file = await Deno.open(this.tempPath, {
+    const file = await this.open(this.tempPath, {
       write: true,
       create: true,
       truncate: true,
@@ -312,7 +343,32 @@ class AtomicJsonPersistence implements Persistence {
       file.close();
     }
     await Deno.rename(this.tempPath, this.livePath);
-    await syncDirectory(parent);
+    await this.syncDirectory(parent);
+  }
+
+  /**
+   * `fdatasync` the directory at `path` so the most recent rename within it
+   * is durable across power loss.
+   *
+   * On POSIX filesystems a `rename(2)` updates the parent directory's
+   * dirty page cache; the entry is not durable until the directory itself
+   * is flushed. macOS, Linux ext4, XFS, and APFS all permit opening a
+   * directory read-only and calling `fdatasync` on the descriptor — Deno
+   * exposes that as `Deno.FsFile.syncData()`.
+   *
+   * Routed through the injected {@link FsOpen} so the same spy that
+   * observes the temp-file sync also sees the directory sync.
+   *
+   * Any IO failure is propagated; a half-durable rename is worse than no
+   * rename because callers think their write committed.
+   */
+  private async syncDirectory(path: string): Promise<void> {
+    const dir = await this.open(path, { read: true });
+    try {
+      await dir.syncData();
+    } finally {
+      dir.close();
+    }
   }
 }
 
@@ -467,26 +523,4 @@ function coerceTask(entry: unknown, index: number, livePath: string): Task {
     );
   }
   return record as unknown as Task;
-}
-
-/**
- * `fdatasync` the directory at `path` so the most recent rename within it
- * is durable across power loss.
- *
- * On POSIX filesystems a `rename(2)` updates the parent directory's
- * dirty page cache; the entry is not durable until the directory itself
- * is flushed. macOS, Linux ext4, XFS, and APFS all permit opening a
- * directory read-only and calling `fdatasync` on the descriptor — Deno
- * exposes that as `Deno.FsFile.syncData()`.
- *
- * Any IO failure is propagated; a half-durable rename is worse than no
- * rename because callers think their write committed.
- */
-async function syncDirectory(path: string): Promise<void> {
-  const dir = await Deno.open(path, { read: true });
-  try {
-    await dir.syncData();
-  } finally {
-    dir.close();
-  }
 }

--- a/src/daemon/persistence.ts
+++ b/src/daemon/persistence.ts
@@ -1,0 +1,352 @@
+/**
+ * daemon/persistence.ts — atomic JSON state store for the supervisor.
+ *
+ * The daemon must be able to crash at any byte boundary and come back up with
+ * a coherent picture of every in-flight task. The contract for that is the
+ * {@link Persistence} interface in `src/types.ts`; this module is the
+ * production implementation.
+ *
+ * **Storage shape.** A single JSON file at the user-configured path. The
+ * top-level value is an array of {@link Task} records — small, denormalized,
+ * easy to inspect with `jq`. Wave 5+ may switch to a sharded layout once the
+ * task count crosses the readability threshold; the interface is stable
+ * either way.
+ *
+ * **Atomic write.** Every mutation rewrites the entire store using the
+ * standard write-tmp + fsync + rename dance:
+ *
+ *  1. Serialize the current in-memory snapshot to JSON.
+ *  2. Open `<path>.tmp` (truncating any leftover from a previous crash).
+ *  3. Write the bytes, then `fdatasync` the file descriptor so the kernel
+ *     flushes them to disk before the rename returns.
+ *  4. Atomically rename `<path>.tmp` over `<path>`.
+ *
+ * Because POSIX rename(2) within a filesystem is atomic, an observer (a
+ * concurrent `loadAll`, the next daemon restart, an operator with `cat`)
+ * sees either the previous full file or the new full file — never a torn
+ * mix.
+ *
+ * **Concurrency.** A single internal mutex (a chained promise) serializes
+ * `save` and `remove` so two callers cannot race the rename. `loadAll`
+ * waits behind any in-flight write; this is conservative but the cost is
+ * negligible against disk IO.
+ *
+ * **Crash recovery.** If `<path>.tmp` exists at startup it is the residue of
+ * a crash mid-write — the rename never happened, so the live `<path>` is
+ * still intact. We ignore the orphan on the read path; the next successful
+ * `save` overwrites it. If the live `<path>` is missing entirely, the store
+ * is empty — `loadAll` returns `[]` rather than failing.
+ *
+ * @module
+ */
+
+import { dirname } from "@std/path";
+import { ensureDir } from "@std/fs";
+
+import { type Persistence, type Task, type TaskId } from "../types.ts";
+
+/** Suffix appended to the live path to form the temp file used for atomic writes. */
+const TEMP_FILE_SUFFIX = ".tmp";
+
+/** JSON serialization indentation. Two spaces matches `deno fmt` defaults. */
+const JSON_INDENT_SPACES = 2;
+
+/**
+ * Construct an atomic JSON-backed {@link Persistence}.
+ *
+ * The returned object owns the on-disk file at `opts.path`. Multiple
+ * instances pointed at the same path will not coordinate with each other;
+ * the daemon constructs exactly one per process.
+ *
+ * The file is created lazily on the first {@link Persistence.save} or
+ * {@link Persistence.remove}. {@link Persistence.loadAll} on a missing
+ * file returns `[]`, which is the correct semantics for a fresh daemon
+ * install.
+ *
+ * @param opts.path Absolute filesystem path of the live store. The
+ *   parent directory is created if it does not exist; the file itself is
+ *   created on demand.
+ * @returns A {@link Persistence} bound to `opts.path`.
+ *
+ * @example
+ * ```ts
+ * import { createPersistence } from "./persistence.ts";
+ *
+ * const persistence = createPersistence({ path: "/var/lib/makina/state.json" });
+ * const tasks = await persistence.loadAll();
+ * for (const task of tasks) {
+ *   console.log(task.id, task.state);
+ * }
+ * ```
+ */
+export function createPersistence(opts: { readonly path: string }): Persistence {
+  return new AtomicJsonPersistence(opts.path);
+}
+
+/**
+ * Internal implementation of {@link Persistence} backed by a single JSON
+ * file with atomic write semantics. Exported only as a type via
+ * {@link createPersistence}; instances must be obtained through the factory
+ * so the construction invariants stay inside this module.
+ */
+class AtomicJsonPersistence implements Persistence {
+  /** Absolute path of the live store. */
+  private readonly livePath: string;
+  /** Absolute path of the staging file used for atomic writes. */
+  private readonly tempPath: string;
+  /**
+   * Tail of the serialization mutex chain. Every mutation appends itself by
+   * `await`-ing the previous tail and assigning a new tail; concurrent
+   * callers therefore queue rather than race the rename.
+   *
+   * The chain catches and discards rejection so a single failed save does
+   * not poison every subsequent caller.
+   */
+  private writeChain: Promise<void> = Promise.resolve();
+
+  /**
+   * @param livePath Absolute path of the live JSON store.
+   */
+  constructor(livePath: string) {
+    this.livePath = livePath;
+    this.tempPath = `${livePath}${TEMP_FILE_SUFFIX}`;
+  }
+
+  /**
+   * Read the on-disk store and return every persisted task.
+   *
+   * If the live file does not exist, returns an empty array. A leftover
+   * `<path>.tmp` from a crashed write is ignored — the live file (or its
+   * absence) is the source of truth.
+   *
+   * @returns Frozen array of every task currently persisted, in the order
+   *   the file holds them.
+   * @throws If the file exists but is not valid JSON or does not match the
+   *   expected array-of-tasks shape; this surfaces a corrupt store rather
+   *   than silently dropping data.
+   */
+  async loadAll(): Promise<readonly Task[]> {
+    // Wait for any in-flight write so we never observe a partially serialized
+    // in-memory snapshot, even though the on-disk file is itself atomic.
+    await this.waitForChain();
+    let bytes: string;
+    try {
+      bytes = await Deno.readTextFile(this.livePath);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return Object.freeze([]);
+      }
+      throw error;
+    }
+    const trimmed = bytes.trim();
+    if (trimmed.length === 0) {
+      // Treat a zero-byte file as an empty store. We never write zero bytes
+      // ourselves, but a manual `truncate` against the path should not crash
+      // the daemon on startup.
+      return Object.freeze([]);
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (error) {
+      throw new Error(
+        `persistence: ${this.livePath} is not valid JSON`,
+        { cause: error },
+      );
+    }
+    if (!Array.isArray(parsed)) {
+      throw new Error(
+        `persistence: ${this.livePath} root is not an array`,
+      );
+    }
+    return Object.freeze(parsed as Task[]);
+  }
+
+  /**
+   * Persist `task`, overwriting any existing record with the same
+   * {@link Task.id}.
+   *
+   * Reads the current store, replaces (or appends) the matching record, and
+   * writes the result atomically. Concurrent calls are serialized through
+   * an internal mutex so two writers cannot race the rename.
+   *
+   * @param task The task to persist.
+   * @returns A promise that resolves once the bytes are durably on disk.
+   *
+   * @example
+   * ```ts
+   * await persistence.save({
+   *   id: makeTaskId("task_2026-04-26T12-00-00_abc123"),
+   *   repo: makeRepoFullName("koraytaylan/makina"),
+   *   issueNumber: makeIssueNumber(7),
+   *   state: "INIT",
+   *   mergeMode: "squash",
+   *   model: "claude-sonnet-4-6",
+   *   iterationCount: 0,
+   *   createdAtIso: new Date().toISOString(),
+   *   updatedAtIso: new Date().toISOString(),
+   * });
+   * ```
+   */
+  save(task: Task): Promise<void> {
+    return this.enqueue(async () => {
+      const current = await this.readForMutation();
+      const next = upsertTask(current, task);
+      await this.writeAtomic(next);
+    });
+  }
+
+  /**
+   * Remove the persisted record for `taskId`.
+   *
+   * No-op if no record matches. Concurrent with {@link save}, ordered
+   * through the same internal mutex.
+   *
+   * @param taskId Identifier of the task to forget.
+   */
+  remove(taskId: TaskId): Promise<void> {
+    return this.enqueue(async () => {
+      const current = await this.readForMutation();
+      const next = current.filter((existing) => existing.id !== taskId);
+      if (next.length === current.length) {
+        // Nothing to do — leave the store untouched and skip the disk IO.
+        return;
+      }
+      await this.writeAtomic(next);
+    });
+  }
+
+  /**
+   * Append `mutation` to the write chain so it runs after every previously
+   * scheduled mutation completes (success or failure).
+   */
+  private enqueue(mutation: () => Promise<void>): Promise<void> {
+    const next = this.writeChain.then(mutation, mutation);
+    // Suppress UnhandledPromiseRejection on the chain itself — callers see
+    // the failure through the awaited `next`, but the chain must continue.
+    this.writeChain = next.then(noop, noop);
+    return next;
+  }
+
+  /**
+   * Resolve when the current write chain settles, regardless of outcome.
+   * Used by {@link loadAll} to avoid reading mid-rename.
+   */
+  private async waitForChain(): Promise<void> {
+    try {
+      await this.writeChain;
+    } catch {
+      // The original caller already saw the rejection; we just need to
+      // know the chain is no longer running.
+    }
+  }
+
+  /**
+   * Read the live store from disk into a mutable array suitable for the
+   * in-place upsert in {@link save}.
+   */
+  private async readForMutation(): Promise<Task[]> {
+    let bytes: string;
+    try {
+      bytes = await Deno.readTextFile(this.livePath);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+    const trimmed = bytes.trim();
+    if (trimmed.length === 0) {
+      return [];
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (error) {
+      throw new Error(
+        `persistence: ${this.livePath} is not valid JSON`,
+        { cause: error },
+      );
+    }
+    if (!Array.isArray(parsed)) {
+      throw new Error(
+        `persistence: ${this.livePath} root is not an array`,
+      );
+    }
+    return parsed as Task[];
+  }
+
+  /**
+   * Atomically replace the live file with the JSON serialization of
+   * `tasks`.
+   *
+   * Sequence: ensure parent → open `<path>.tmp` (truncate) → write JSON →
+   * `fdatasync` the file descriptor → close → rename over the live path.
+   * The rename is the commit point.
+   */
+  private async writeAtomic(tasks: readonly Task[]): Promise<void> {
+    await ensureDir(dirname(this.livePath));
+    const json = JSON.stringify(tasks, null, JSON_INDENT_SPACES);
+    const bytes = new TextEncoder().encode(json);
+    const file = await Deno.open(this.tempPath, {
+      write: true,
+      create: true,
+      truncate: true,
+    });
+    try {
+      await writeAll(file, bytes);
+      await file.syncData();
+    } finally {
+      file.close();
+    }
+    await Deno.rename(this.tempPath, this.livePath);
+  }
+}
+
+/**
+ * Replace the matching record in `current` with `incoming`, or append
+ * `incoming` if no record carries the same {@link Task.id}.
+ *
+ * Returns a new array; `current` is not mutated.
+ */
+function upsertTask(current: readonly Task[], incoming: Task): Task[] {
+  const next: Task[] = [];
+  let replaced = false;
+  for (const existing of current) {
+    if (existing.id === incoming.id) {
+      next.push(incoming);
+      replaced = true;
+    } else {
+      next.push(existing);
+    }
+  }
+  if (!replaced) {
+    next.push(incoming);
+  }
+  return next;
+}
+
+/**
+ * Write `bytes` to `file` until the buffer is fully drained.
+ *
+ * `Deno.FsFile.write` may write fewer bytes than requested; the loop
+ * advances through the buffer and re-issues writes until everything has
+ * been accepted. Mirrors `@std/io` `writeAll` without pulling the import.
+ */
+async function writeAll(file: Deno.FsFile, bytes: Uint8Array): Promise<void> {
+  let offset = 0;
+  while (offset < bytes.byteLength) {
+    const written = await file.write(bytes.subarray(offset));
+    if (written <= 0) {
+      throw new Error(
+        `persistence: short write to staging file (offset=${offset}, size=${bytes.byteLength})`,
+      );
+    }
+    offset += written;
+  }
+}
+
+/** Sentinel no-op used by the write chain to swallow unhandled rejections. */
+function noop(): void {
+  // Intentionally empty.
+}

--- a/tests/integration/persistence_test.ts
+++ b/tests/integration/persistence_test.ts
@@ -380,6 +380,77 @@ Deno.test("loadAll rejects an element with an unknown TaskState", async () => {
   }
 });
 
+Deno.test("loadAll rejects an element whose issueNumber violates IssueNumber's positive-integer brand invariant", async () => {
+  // The primitive check accepts `issueNumber: 0` (it is an integer), but
+  // `makeIssueNumber` rejects it because GitHub issue numbers start at 1.
+  // Without re-running the brand constructor, a hand-edited or legacy
+  // store could hand the supervisor a `Task` whose `issueNumber` is
+  // typed as `IssueNumber` but violates the very invariant the brand
+  // exists to guarantee. This regression pins that gap closed.
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    await Deno.mkdir(dirname(path), { recursive: true });
+    const malformed = {
+      id: "task_zero_issue",
+      repo: "koraytaylan/makina",
+      issueNumber: 0,
+      state: "INIT",
+      mergeMode: "squash",
+      model: "claude-sonnet-4-6",
+      iterationCount: 0,
+      createdAtIso: "2026-04-26T12:00:00.000Z",
+      updatedAtIso: "2026-04-26T12:00:00.000Z",
+    };
+    await Deno.writeTextFile(path, JSON.stringify([malformed]));
+    const persistence = createPersistence({ path });
+    const error = await assertRejects(
+      () => persistence.loadAll(),
+      Error,
+      "issueNumber fails brand invariant",
+    );
+    // The error must name the failing field path so an operator can
+    // `jq` straight to the bad record.
+    assertEquals(error.message.includes("[0].issueNumber"), true);
+    assertEquals(error.message.includes("positive integer"), true);
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("loadAll rejects an element whose repo violates RepoFullName's `<owner>/<name>` brand invariant", async () => {
+  // The primitive check accepts any non-empty string for `repo`, but
+  // `makeRepoFullName` requires exactly one `/` separator with non-empty
+  // owner and name segments. A value like `"orphan"` slips past the
+  // primitive guard and would otherwise reach the supervisor as a
+  // `RepoFullName` whose runtime shape is invalid.
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    await Deno.mkdir(dirname(path), { recursive: true });
+    const malformed = {
+      id: "task_bad_repo",
+      repo: "orphan",
+      issueNumber: 7,
+      state: "INIT",
+      mergeMode: "squash",
+      model: "claude-sonnet-4-6",
+      iterationCount: 0,
+      createdAtIso: "2026-04-26T12:00:00.000Z",
+      updatedAtIso: "2026-04-26T12:00:00.000Z",
+    };
+    await Deno.writeTextFile(path, JSON.stringify([malformed]));
+    const persistence = createPersistence({ path });
+    const error = await assertRejects(
+      () => persistence.loadAll(),
+      Error,
+      "repo fails brand invariant",
+    );
+    assertEquals(error.message.includes("[0].repo"), true);
+    assertEquals(error.message.includes("<owner>/<name>"), true);
+  } finally {
+    await cleanup();
+  }
+});
+
 Deno.test("loadAll surfaces non-array root rather than silently coercing", async () => {
   const { path, cleanup } = await makeTempStorePath();
   try {

--- a/tests/integration/persistence_test.ts
+++ b/tests/integration/persistence_test.ts
@@ -729,3 +729,109 @@ Deno.test("save against a zero-byte existing file uses empty-store path", async 
     await cleanup();
   }
 });
+
+Deno.test("save fsyncs every newly-created directory in a deep parent chain", async () => {
+  // Regression guard for the durability of the directory chain itself.
+  // When `writeAtomic` has to create multiple intermediate directories
+  // (e.g., `<tempdir>/a/b/c/state.json` where only `<tempdir>` exists),
+  // the new sub-directory entries live in their parents' dirty page
+  // caches. A power loss after the rename can lose the entire chain even
+  // though the file's data is on disk. The fix fsyncs every directory
+  // whose entry table changed: the leaf parent (where the rename
+  // committed) and the parent of every directory we just created (where
+  // each new directory's entry was committed).
+  //
+  // Spy is per-instance — `Deno.open` is never mutated process-wide, so
+  // this test is safe under `deno test --parallel`.
+  const root = await Deno.makeTempDir({ prefix: "makina-persistence-deep-" });
+  const path = join(root, "a", "b", "c", "state.json");
+  try {
+    const synced: string[] = [];
+    const spyOpen: typeof Deno.open = async (
+      target: string | URL,
+      options?: Deno.OpenOptions,
+    ) => {
+      const file = await Deno.open(target, options);
+      const targetPath = typeof target === "string" ? target : target.pathname;
+      const originalSyncData = file.syncData.bind(file);
+      file.syncData = async () => {
+        synced.push(targetPath);
+        await originalSyncData();
+      };
+      return file;
+    };
+    const persistence = createPersistence({ path, open: spyOpen });
+    await persistence.save(makeTask({ id: makeTaskId("task_deep") }));
+    // Every directory whose entry table changed must have been
+    // syncData()'d:
+    //  - <root>/a/b/c (the rename's parent — committed `state.json`)
+    //  - <root>/a/b   (committed the new `c/` entry)
+    //  - <root>/a     (committed the new `b/` entry)
+    //  - <root>       (committed the new `a/` entry)
+    const expected = [
+      join(root, "a", "b", "c"),
+      join(root, "a", "b"),
+      join(root, "a"),
+      root,
+    ];
+    for (const dir of expected) {
+      assertEquals(
+        synced.includes(dir),
+        true,
+        `expected fsync on ${dir}, saw ${JSON.stringify(synced)}`,
+      );
+    }
+    // The save must of course have actually landed.
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks.length, 1);
+    assertEquals(tasks[0]?.id, "task_deep");
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("save fsyncs only the leaf parent when the parent chain already exists", async () => {
+  // Counterpart to the deep-chain test: when the parent chain is fully
+  // present (no `mkdir` calls happen), the only directory whose entry
+  // table changed is the leaf parent itself. We must not redundantly
+  // fsync ancestors we did not write to — that would be wasted IO.
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const synced: string[] = [];
+    const spyOpen: typeof Deno.open = async (
+      target: string | URL,
+      options?: Deno.OpenOptions,
+    ) => {
+      const file = await Deno.open(target, options);
+      const targetPath = typeof target === "string" ? target : target.pathname;
+      const originalSyncData = file.syncData.bind(file);
+      file.syncData = async () => {
+        synced.push(targetPath);
+        await originalSyncData();
+      };
+      return file;
+    };
+    const persistence = createPersistence({ path, open: spyOpen });
+    await persistence.save(makeTask({ id: makeTaskId("task_shallow") }));
+    const parent = dirname(path);
+    // The leaf parent must be fsynced.
+    assertEquals(
+      synced.includes(parent),
+      true,
+      `expected fsync on ${parent}, saw ${JSON.stringify(synced)}`,
+    );
+    // Every directory we fsynced must be either the temp file or the
+    // leaf parent — never an unrelated ancestor.
+    const tempPath = `${path}.tmp`;
+    for (const target of synced) {
+      const allowed = target === tempPath || target === parent;
+      assertEquals(
+        allowed,
+        true,
+        `unexpected fsync on ${target}; allowed only ${tempPath} or ${parent}`,
+      );
+    }
+  } finally {
+    await cleanup();
+  }
+});

--- a/tests/integration/persistence_test.ts
+++ b/tests/integration/persistence_test.ts
@@ -17,7 +17,7 @@
  *    silently dropped (no data loss without warning).
  */
 
-import { assertEquals, assertNotEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import { dirname, join } from "@std/path";
 import { exists } from "@std/fs";
 
@@ -259,6 +259,95 @@ Deno.test("loadAll surfaces a corrupt live file rather than silently dropping da
   }
 });
 
+Deno.test("loadAll rejects an array element that is not a Task object", async () => {
+  // Per-element validation exists so a corrupt or hand-edited store can't
+  // hand the supervisor garbage typed as `Task`. A primitive in the array
+  // must be rejected, not silently cast.
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    await Deno.mkdir(dirname(path), { recursive: true });
+    await Deno.writeTextFile(path, JSON.stringify(["not-a-task"]));
+    const persistence = createPersistence({ path });
+    await assertRejects(
+      () => persistence.loadAll(),
+      Error,
+      "is not a Task object",
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("loadAll rejects an array element missing required Task fields", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    await Deno.mkdir(dirname(path), { recursive: true });
+    await Deno.writeTextFile(path, JSON.stringify([{ id: "task_partial" }]));
+    const persistence = createPersistence({ path });
+    await assertRejects(
+      () => persistence.loadAll(),
+      Error,
+      "missing required field",
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("loadAll rejects an element with the wrong type for a required field", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    await Deno.mkdir(dirname(path), { recursive: true });
+    const malformed = {
+      id: "task_typed_wrong",
+      repo: "koraytaylan/makina",
+      issueNumber: "seven",
+      state: "INIT",
+      mergeMode: "squash",
+      model: "claude-sonnet-4-6",
+      iterationCount: 0,
+      createdAtIso: "2026-04-26T12:00:00.000Z",
+      updatedAtIso: "2026-04-26T12:00:00.000Z",
+    };
+    await Deno.writeTextFile(path, JSON.stringify([malformed]));
+    const persistence = createPersistence({ path });
+    await assertRejects(
+      () => persistence.loadAll(),
+      Error,
+      "issueNumber is not an integer",
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("loadAll rejects an element with an unknown TaskState", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    await Deno.mkdir(dirname(path), { recursive: true });
+    const malformed = {
+      id: "task_unknown_state",
+      repo: "koraytaylan/makina",
+      issueNumber: 7,
+      state: "GLITCHED",
+      mergeMode: "squash",
+      model: "claude-sonnet-4-6",
+      iterationCount: 0,
+      createdAtIso: "2026-04-26T12:00:00.000Z",
+      updatedAtIso: "2026-04-26T12:00:00.000Z",
+    };
+    await Deno.writeTextFile(path, JSON.stringify([malformed]));
+    const persistence = createPersistence({ path });
+    await assertRejects(
+      () => persistence.loadAll(),
+      Error,
+      "is not a TaskState",
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
 Deno.test("loadAll surfaces non-array root rather than silently coercing", async () => {
   const { path, cleanup } = await makeTempStorePath();
   try {
@@ -384,21 +473,66 @@ Deno.test("save persists every Task field including optional ones", async () => 
   }
 });
 
-Deno.test("save fsyncs the staged bytes before the rename commits", async () => {
-  // We cannot directly observe `fdatasync` from user space, but we can
-  // observe its postcondition: after `save` returns, an immediate read of
-  // the live file must surface the bytes we just wrote (no dirty-page
-  // deferred-flush window where another reader sees stale content).
+Deno.test("after save the live file holds the new bytes (read postcondition)", async () => {
+  // This pins the round-trip-via-disk invariant: after `save` resolves,
+  // an external `Deno.readTextFile` on the live path must surface the
+  // serialized payload. (We cannot observe `fdatasync` from user space —
+  // see the spy-based test below for that — but we can prove the rename
+  // landed and the bytes are JSON-decodable.)
   const { path, cleanup } = await makeTempStorePath();
   try {
     const persistence = createPersistence({ path });
-    const task = makeTask({ id: makeTaskId("task_fsync"), iterationCount: 99 });
+    const task = makeTask({ id: makeTaskId("task_postcondition"), iterationCount: 99 });
     await persistence.save(task);
     const raw = await Deno.readTextFile(path);
     const parsed = JSON.parse(raw) as readonly Task[];
     assertEquals(parsed.length, 1);
     assertEquals(parsed[0]?.iterationCount, 99);
   } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("save fsyncs the staged temp file and the parent directory", async () => {
+  // The page-cache-immediate-read trick won't catch a missing `syncData`,
+  // so we instrument `Deno.open` to record `syncData` invocations against
+  // each opened path. After one save we expect both the temp file
+  // (`<path>.tmp`) and the parent directory to have been synced.
+  const { path, cleanup } = await makeTempStorePath();
+  const originalOpen = Deno.open;
+  const synced: string[] = [];
+  // deno-lint-ignore no-explicit-any
+  (Deno as any).open = async (target: string | URL, options?: Deno.OpenOptions) => {
+    const file = await originalOpen(target as string, options);
+    const targetPath = typeof target === "string" ? target : target.pathname;
+    const originalSyncData = file.syncData.bind(file);
+    file.syncData = async () => {
+      synced.push(targetPath);
+      await originalSyncData();
+    };
+    return file;
+  };
+  try {
+    const persistence = createPersistence({ path });
+    await persistence.save(makeTask({ id: makeTaskId("task_fsync_spy") }));
+    // Both the staged temp file and the parent directory must have been
+    // syncData()'d. Without the parent-dir sync, a power loss after the
+    // rename could lose the directory entry update on POSIX filesystems.
+    const tempPath = `${path}.tmp`;
+    const parentDir = dirname(path);
+    assertEquals(
+      synced.includes(tempPath),
+      true,
+      `expected fsync on ${tempPath}, saw ${JSON.stringify(synced)}`,
+    );
+    assertEquals(
+      synced.includes(parentDir),
+      true,
+      `expected fsync on ${parentDir}, saw ${JSON.stringify(synced)}`,
+    );
+  } finally {
+    // deno-lint-ignore no-explicit-any
+    (Deno as any).open = originalOpen;
     await cleanup();
   }
 });
@@ -501,7 +635,8 @@ Deno.test("remove returns ordering from disk after subsequent saves (no stale sn
     assertEquals(tasks.map((t) => t.id), ["task_b", "task_c"]);
     // Tasks should round-trip equal even after the rewrite.
     assertEquals(tasks[0]?.id, "task_b");
-    assertNotEquals(tasks.find((t) => t.id === "task_a"), b);
+    // The removed record really is gone — not merely "not equal to b".
+    assertEquals(tasks.find((t) => t.id === "task_a"), undefined);
   } finally {
     await cleanup();
   }

--- a/tests/integration/persistence_test.ts
+++ b/tests/integration/persistence_test.ts
@@ -113,6 +113,38 @@ Deno.test("save replaces a task with the same id (upsert)", async () => {
   }
 });
 
+Deno.test("save converges duplicate ids in the on-disk store to one record", async () => {
+  // Defence-in-depth: if the live file ever contains multiple records for
+  // the same id (manual edit, corruption, legacy multi-writer history), a
+  // single save must collapse them back to one entry — not rewrite every
+  // duplicate with the new payload.
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    await Deno.mkdir(dirname(path), { recursive: true });
+    const id = makeTaskId("task_dup");
+    const seeded = [
+      makeTask({ id, state: "INIT", iterationCount: 0 }),
+      makeTask({ id, state: "INIT", iterationCount: 0 }),
+      makeTask({ id, state: "INIT", iterationCount: 0 }),
+    ];
+    await Deno.writeTextFile(path, JSON.stringify(seeded));
+    const persistence = createPersistence({ path });
+    await persistence.save(makeTask({
+      id,
+      state: "DRAFTING",
+      iterationCount: 1,
+      updatedAtIso: "2026-04-26T12:01:00.000Z",
+    }));
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks.length, 1);
+    assertEquals(tasks[0]?.id, "task_dup");
+    assertEquals(tasks[0]?.state, "DRAFTING");
+    assertEquals(tasks[0]?.iterationCount, 1);
+  } finally {
+    await cleanup();
+  }
+});
+
 Deno.test("save preserves siblings when adding a new task", async () => {
   const { path, cleanup } = await makeTempStorePath();
   try {
@@ -691,10 +723,12 @@ Deno.test("loadAll re-throws non-NotFound IO errors instead of swallowing them",
   }
 });
 
-Deno.test("loadAll waits for an in-flight failed save without itself rejecting", async () => {
+Deno.test("loadAll waits for an in-flight failing save and rejects on the corrupt JSON it observes", async () => {
   // Regression guard for the catch-all in waitForChain: a failed mutation
-  // must not poison a concurrent loadAll. The load arrives before the
-  // failure has been observed by anybody else.
+  // must not poison a concurrent loadAll via the shared chain. The load
+  // queues behind the failing save, then runs its own read against the
+  // still-corrupt live file; it must reject on its own JSON parse rather
+  // than on the swallowed save failure.
   const { path, cleanup } = await makeTempStorePath();
   try {
     await Deno.mkdir(dirname(path), { recursive: true });
@@ -704,9 +738,8 @@ Deno.test("loadAll waits for an in-flight failed save without itself rejecting",
     // Kick off the load before awaiting the save — both share the chain.
     const loadPromise = persistence.loadAll();
     await assertRejects(() => failingSave, Error);
-    // The load itself must reject (because the file is still corrupt) but
-    // must do so via its own JSON parse, not via the swallowed save
-    // failure.
+    // The load itself rejects (because the file is still corrupt) but must
+    // do so via its own JSON parse, not via the swallowed save failure.
     await assertRejects(() => loadPromise, Error, "is not valid JSON");
   } finally {
     await cleanup();

--- a/tests/integration/persistence_test.ts
+++ b/tests/integration/persistence_test.ts
@@ -495,25 +495,29 @@ Deno.test("after save the live file holds the new bytes (read postcondition)", a
 
 Deno.test("save fsyncs the staged temp file and the parent directory", async () => {
   // The page-cache-immediate-read trick won't catch a missing `syncData`,
-  // so we instrument `Deno.open` to record `syncData` invocations against
-  // each opened path. After one save we expect both the temp file
-  // (`<path>.tmp`) and the parent directory to have been synced.
+  // so we inject a spy `open` into the persistence factory and record
+  // every `syncData` invocation. After one save we expect both the temp
+  // file (`<path>.tmp`) and the parent directory to have been synced.
+  //
+  // Spy is per-instance — `Deno.open` is never mutated process-wide, so
+  // this test is safe under `deno test --parallel`.
   const { path, cleanup } = await makeTempStorePath();
-  const originalOpen = Deno.open;
-  const synced: string[] = [];
-  // deno-lint-ignore no-explicit-any
-  (Deno as any).open = async (target: string | URL, options?: Deno.OpenOptions) => {
-    const file = await originalOpen(target as string, options);
-    const targetPath = typeof target === "string" ? target : target.pathname;
-    const originalSyncData = file.syncData.bind(file);
-    file.syncData = async () => {
-      synced.push(targetPath);
-      await originalSyncData();
-    };
-    return file;
-  };
   try {
-    const persistence = createPersistence({ path });
+    const synced: string[] = [];
+    const spyOpen: typeof Deno.open = async (
+      target: string | URL,
+      options?: Deno.OpenOptions,
+    ) => {
+      const file = await Deno.open(target, options);
+      const targetPath = typeof target === "string" ? target : target.pathname;
+      const originalSyncData = file.syncData.bind(file);
+      file.syncData = async () => {
+        synced.push(targetPath);
+        await originalSyncData();
+      };
+      return file;
+    };
+    const persistence = createPersistence({ path, open: spyOpen });
     await persistence.save(makeTask({ id: makeTaskId("task_fsync_spy") }));
     // Both the staged temp file and the parent directory must have been
     // syncData()'d. Without the parent-dir sync, a power loss after the
@@ -531,8 +535,6 @@ Deno.test("save fsyncs the staged temp file and the parent directory", async () 
       `expected fsync on ${parentDir}, saw ${JSON.stringify(synced)}`,
     );
   } finally {
-    // deno-lint-ignore no-explicit-any
-    (Deno as any).open = originalOpen;
     await cleanup();
   }
 });

--- a/tests/integration/persistence_test.ts
+++ b/tests/integration/persistence_test.ts
@@ -1,0 +1,594 @@
+/**
+ * Integration tests for `src/daemon/persistence.ts`.
+ *
+ * Each test scopes its on-disk state to a fresh `Deno.makeTempDir`
+ * directory; nothing leaks between cases. The tests cover:
+ *
+ *  - Round-trip equivalence: every saved task reappears verbatim from
+ *    `loadAll`.
+ *  - Concurrent saves serialize through the internal mutex (so the final
+ *    file holds every record, none are dropped).
+ *  - A leftover `<path>.tmp` from a simulated crash is ignored on startup
+ *    and removed on the next successful save.
+ *  - `loadAll` on a missing file returns an empty array.
+ *  - `save` creates parent directories on demand.
+ *  - `remove` deletes a single record without touching siblings.
+ *  - Corrupt JSON in the live file surfaces an error rather than being
+ *    silently dropped (no data loss without warning).
+ */
+
+import { assertEquals, assertNotEquals, assertRejects } from "@std/assert";
+import { dirname, join } from "@std/path";
+import { exists } from "@std/fs";
+
+import { createPersistence } from "../../src/daemon/persistence.ts";
+import {
+  makeIssueNumber,
+  makeRepoFullName,
+  makeTaskId,
+  type Task,
+  type TaskId,
+} from "../../src/types.ts";
+
+/**
+ * Build a minimal valid {@link Task} fixture. Only fields that are
+ * meaningful to the test need to be overridden.
+ */
+function makeTask(overrides: Partial<Task> & Pick<Task, "id">): Task {
+  return {
+    repo: makeRepoFullName("koraytaylan/makina"),
+    issueNumber: makeIssueNumber(7),
+    state: "INIT",
+    mergeMode: "squash",
+    model: "claude-sonnet-4-6",
+    iterationCount: 0,
+    createdAtIso: "2026-04-26T12:00:00.000Z",
+    updatedAtIso: "2026-04-26T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+/**
+ * Allocate a temp dir and the path to its `state.json`. The directory
+ * itself is removed at the end of every test through `using` cleanup.
+ */
+async function makeTempStorePath(): Promise<{
+  readonly path: string;
+  readonly cleanup: () => Promise<void>;
+}> {
+  const dir = await Deno.makeTempDir({ prefix: "makina-persistence-" });
+  return {
+    path: join(dir, "state.json"),
+    cleanup: () => Deno.remove(dir, { recursive: true }),
+  };
+}
+
+Deno.test("loadAll on missing file returns an empty array", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const persistence = createPersistence({ path });
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks, []);
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("save then loadAll round-trips a single task verbatim", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const persistence = createPersistence({ path });
+    const task = makeTask({
+      id: makeTaskId("task_round_trip_1"),
+      iterationCount: 3,
+      branchName: "makina/issue-7",
+    });
+    await persistence.save(task);
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks.length, 1);
+    assertEquals(tasks[0], task);
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("save replaces a task with the same id (upsert)", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const persistence = createPersistence({ path });
+    const id = makeTaskId("task_upsert");
+    await persistence.save(makeTask({ id, state: "INIT", iterationCount: 0 }));
+    await persistence.save(makeTask({
+      id,
+      state: "DRAFTING",
+      iterationCount: 1,
+      updatedAtIso: "2026-04-26T12:01:00.000Z",
+    }));
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks.length, 1);
+    assertEquals(tasks[0]?.state, "DRAFTING");
+    assertEquals(tasks[0]?.iterationCount, 1);
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("save preserves siblings when adding a new task", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const persistence = createPersistence({ path });
+    const a = makeTask({ id: makeTaskId("task_a") });
+    const b = makeTask({ id: makeTaskId("task_b") });
+    await persistence.save(a);
+    await persistence.save(b);
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks.map((t) => t.id), ["task_a", "task_b"]);
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("remove deletes a single record without touching siblings", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const persistence = createPersistence({ path });
+    const a = makeTask({ id: makeTaskId("task_a") });
+    const b = makeTask({ id: makeTaskId("task_b") });
+    const c = makeTask({ id: makeTaskId("task_c") });
+    await persistence.save(a);
+    await persistence.save(b);
+    await persistence.save(c);
+    await persistence.remove(b.id);
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks.map((t) => t.id), ["task_a", "task_c"]);
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("remove on an unknown id is a no-op (does not error)", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const persistence = createPersistence({ path });
+    await persistence.save(makeTask({ id: makeTaskId("task_alive") }));
+    await persistence.remove(makeTaskId("task_ghost"));
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks.length, 1);
+    assertEquals(tasks[0]?.id, "task_alive");
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("remove on a missing file is a no-op", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const persistence = createPersistence({ path });
+    await persistence.remove(makeTaskId("task_nothing"));
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks, []);
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("concurrent saves are serialized — every record survives", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const persistence = createPersistence({ path });
+    const ids: TaskId[] = [];
+    const promises: Promise<void>[] = [];
+    // Fire 16 saves with distinct ids without awaiting between them. If the
+    // mutex is broken at least one rename will land on top of another's
+    // read-modify-write window and we will see fewer than 16 records.
+    for (let index = 0; index < 16; index += 1) {
+      const id = makeTaskId(`task_concurrent_${index}`);
+      ids.push(id);
+      promises.push(persistence.save(makeTask({ id, iterationCount: index })));
+    }
+    await Promise.all(promises);
+    const tasks = await persistence.loadAll();
+    const seenIds = new Set(tasks.map((t) => t.id));
+    assertEquals(seenIds.size, ids.length);
+    for (const id of ids) {
+      assertEquals(seenIds.has(id), true, `missing ${id}`);
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("save creates parent directories on demand", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "makina-persistence-mkdir-" });
+  const path = join(dir, "nested", "deeper", "state.json");
+  try {
+    const persistence = createPersistence({ path });
+    await persistence.save(makeTask({ id: makeTaskId("task_nested") }));
+    // The file (and therefore its parent chain) must exist.
+    assertEquals(await exists(path, { isFile: true }), true);
+    assertEquals(await exists(dirname(path), { isDirectory: true }), true);
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks.length, 1);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a leftover .tmp from a crashed write is ignored on startup", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    // Pre-populate the live file with one valid task.
+    await Deno.mkdir(dirname(path), { recursive: true });
+    const survived = makeTask({ id: makeTaskId("task_survived"), iterationCount: 1 });
+    await Deno.writeTextFile(path, JSON.stringify([survived]));
+    // Drop a corrupt `.tmp` next to it as if a previous process had crashed
+    // mid-write — the bytes are not even valid JSON.
+    const tempPath = `${path}.tmp`;
+    await Deno.writeTextFile(tempPath, "{partial garbage from a crashed write");
+    // A fresh persistence reads the live file and never touches the orphan.
+    const persistence = createPersistence({ path });
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks.length, 1);
+    assertEquals(tasks[0]?.id, "task_survived");
+    // The next successful save replaces the orphan with our own bytes — no
+    // garbage left behind.
+    await persistence.save(makeTask({ id: makeTaskId("task_new") }));
+    assertEquals(await exists(tempPath), false);
+    const after = await persistence.loadAll();
+    assertEquals(after.length, 2);
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("loadAll surfaces a corrupt live file rather than silently dropping data", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    await Deno.mkdir(dirname(path), { recursive: true });
+    // Live file claims to be JSON but is truncated mid-array. We must not
+    // pretend the store is empty — that would lose every recorded task.
+    await Deno.writeTextFile(path, '[{"id":"task_x"');
+    const persistence = createPersistence({ path });
+    await assertRejects(
+      () => persistence.loadAll(),
+      Error,
+      "is not valid JSON",
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("loadAll surfaces non-array root rather than silently coercing", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    await Deno.mkdir(dirname(path), { recursive: true });
+    await Deno.writeTextFile(path, JSON.stringify({ tasks: [] }));
+    const persistence = createPersistence({ path });
+    await assertRejects(
+      () => persistence.loadAll(),
+      Error,
+      "root is not an array",
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("save bubbles up corrupt-store errors instead of overwriting them", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    await Deno.mkdir(dirname(path), { recursive: true });
+    await Deno.writeTextFile(path, "not json at all");
+    const persistence = createPersistence({ path });
+    await assertRejects(
+      () => persistence.save(makeTask({ id: makeTaskId("task_blocked") })),
+      Error,
+      "is not valid JSON",
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("loadAll on a zero-byte live file returns an empty array", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    await Deno.mkdir(dirname(path), { recursive: true });
+    await Deno.writeTextFile(path, "");
+    const persistence = createPersistence({ path });
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks, []);
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("the live file is rewritten atomically — no .tmp lingers after a save", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const persistence = createPersistence({ path });
+    await persistence.save(makeTask({ id: makeTaskId("task_atomic") }));
+    assertEquals(await exists(`${path}.tmp`), false);
+    assertEquals(await exists(path, { isFile: true }), true);
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("a failed save does not poison subsequent saves", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    await Deno.mkdir(dirname(path), { recursive: true });
+    await Deno.writeTextFile(path, "this is not json");
+    const persistence = createPersistence({ path });
+    // First save fails because the existing file is not valid JSON.
+    await assertRejects(
+      () => persistence.save(makeTask({ id: makeTaskId("task_fail") })),
+      Error,
+    );
+    // Repair the file by overwriting with an empty array; the next save
+    // must succeed — the mutex chain must not be in a permanently rejected
+    // state.
+    await Deno.writeTextFile(path, "[]");
+    await persistence.save(makeTask({ id: makeTaskId("task_recover") }));
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks.length, 1);
+    assertEquals(tasks[0]?.id, "task_recover");
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("two persistence instances pointed at the same path see each other's writes", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const writer = createPersistence({ path });
+    const reader = createPersistence({ path });
+    await writer.save(makeTask({ id: makeTaskId("task_shared") }));
+    const tasks = await reader.loadAll();
+    assertEquals(tasks.length, 1);
+    assertEquals(tasks[0]?.id, "task_shared");
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("save persists every Task field including optional ones", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const persistence = createPersistence({ path });
+    const task: Task = {
+      id: makeTaskId("task_full"),
+      repo: makeRepoFullName("koraytaylan/makina"),
+      issueNumber: makeIssueNumber(42),
+      state: "STABILIZING",
+      stabilizePhase: "CI",
+      mergeMode: "rebase",
+      model: "claude-opus-4-7",
+      iterationCount: 5,
+      prNumber: makeIssueNumber(101),
+      branchName: "makina/issue-42",
+      worktreePath: "/tmp/wt/42",
+      sessionId: "session-abc",
+      lastReviewAtIso: "2026-04-26T12:00:00.000Z",
+      createdAtIso: "2026-04-26T11:00:00.000Z",
+      updatedAtIso: "2026-04-26T12:00:00.000Z",
+    };
+    await persistence.save(task);
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks.length, 1);
+    assertEquals(tasks[0], task);
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("save fsyncs the staged bytes before the rename commits", async () => {
+  // We cannot directly observe `fdatasync` from user space, but we can
+  // observe its postcondition: after `save` returns, an immediate read of
+  // the live file must surface the bytes we just wrote (no dirty-page
+  // deferred-flush window where another reader sees stale content).
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const persistence = createPersistence({ path });
+    const task = makeTask({ id: makeTaskId("task_fsync"), iterationCount: 99 });
+    await persistence.save(task);
+    const raw = await Deno.readTextFile(path);
+    const parsed = JSON.parse(raw) as readonly Task[];
+    assertEquals(parsed.length, 1);
+    assertEquals(parsed[0]?.iterationCount, 99);
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("loadAll returns a frozen result", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const persistence = createPersistence({ path });
+    await persistence.save(makeTask({ id: makeTaskId("task_freeze") }));
+    const tasks = await persistence.loadAll();
+    assertEquals(Object.isFrozen(tasks), true);
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("the same instance can interleave save and remove correctly", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const persistence = createPersistence({ path });
+    const a = makeTask({ id: makeTaskId("task_a") });
+    const b = makeTask({ id: makeTaskId("task_b") });
+    const c = makeTask({ id: makeTaskId("task_c") });
+    // Issue every operation without awaiting; the mutex must apply them
+    // in submission order.
+    const operations = [
+      persistence.save(a),
+      persistence.save(b),
+      persistence.remove(a.id),
+      persistence.save(c),
+      persistence.remove(b.id),
+    ];
+    await Promise.all(operations);
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks.map((t) => t.id), ["task_c"]);
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("two new ids are not collapsed even when the second arrives first to the rename", async () => {
+  // Concurrent inserts of two distinct ids must both survive the
+  // serialization, in submission order. (Regression guard for a buggy
+  // mutex that drops the first writer's payload by reading the live file
+  // before it lands.)
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const persistence = createPersistence({ path });
+    const first = persistence.save(makeTask({ id: makeTaskId("task_first") }));
+    const second = persistence.save(makeTask({ id: makeTaskId("task_second") }));
+    await Promise.all([first, second]);
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks.map((t) => t.id), ["task_first", "task_second"]);
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("save updates updatedAtIso semantics are caller's responsibility (no auto-mutation)", async () => {
+  // Persistence does not stamp timestamps — the supervisor owns that. This
+  // pins the invariant so we do not accidentally introduce auto-mutation.
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const persistence = createPersistence({ path });
+    const id = makeTaskId("task_stamp");
+    const updatedAtIso = "2030-01-01T00:00:00.000Z";
+    await persistence.save(makeTask({ id, updatedAtIso }));
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks[0]?.updatedAtIso, updatedAtIso);
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("loading an empty store after every record is removed yields []", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const persistence = createPersistence({ path });
+    const id = makeTaskId("task_lone");
+    await persistence.save(makeTask({ id }));
+    await persistence.remove(id);
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks, []);
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("remove returns ordering from disk after subsequent saves (no stale snapshot)", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const persistence = createPersistence({ path });
+    const a = makeTask({ id: makeTaskId("task_a") });
+    const b = makeTask({ id: makeTaskId("task_b") });
+    await persistence.save(a);
+    await persistence.save(b);
+    await persistence.remove(a.id);
+    await persistence.save(makeTask({ id: makeTaskId("task_c") }));
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks.map((t) => t.id), ["task_b", "task_c"]);
+    // Tasks should round-trip equal even after the rewrite.
+    assertEquals(tasks[0]?.id, "task_b");
+    assertNotEquals(tasks.find((t) => t.id === "task_a"), b);
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("save bubbles up corrupt non-array root rather than overwriting", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    await Deno.mkdir(dirname(path), { recursive: true });
+    await Deno.writeTextFile(path, JSON.stringify({ a: 1 }));
+    const persistence = createPersistence({ path });
+    await assertRejects(
+      () => persistence.save(makeTask({ id: makeTaskId("task_blocked") })),
+      Error,
+      "root is not an array",
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("save against a zero-byte existing file proceeds (treats it as empty)", async () => {
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    await Deno.mkdir(dirname(path), { recursive: true });
+    await Deno.writeTextFile(path, "");
+    const persistence = createPersistence({ path });
+    await persistence.save(makeTask({ id: makeTaskId("task_zero") }));
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks.length, 1);
+    assertEquals(tasks[0]?.id, "task_zero");
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("loadAll re-throws non-NotFound IO errors instead of swallowing them", async () => {
+  // Pointing the live file at a directory triggers an IO error on read
+  // that is **not** NotFound; the load path must surface it rather than
+  // pretend the store is empty.
+  const dir = await Deno.makeTempDir({ prefix: "makina-persistence-iofail-" });
+  try {
+    const persistence = createPersistence({ path: dir });
+    await assertRejects(
+      () => persistence.loadAll(),
+      Error,
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("loadAll waits for an in-flight failed save without itself rejecting", async () => {
+  // Regression guard for the catch-all in waitForChain: a failed mutation
+  // must not poison a concurrent loadAll. The load arrives before the
+  // failure has been observed by anybody else.
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    await Deno.mkdir(dirname(path), { recursive: true });
+    await Deno.writeTextFile(path, "this is not json");
+    const persistence = createPersistence({ path });
+    const failingSave = persistence.save(makeTask({ id: makeTaskId("task_fail") }));
+    // Kick off the load before awaiting the save — both share the chain.
+    const loadPromise = persistence.loadAll();
+    await assertRejects(() => failingSave, Error);
+    // The load itself must reject (because the file is still corrupt) but
+    // must do so via its own JSON parse, not via the swallowed save
+    // failure.
+    await assertRejects(() => loadPromise, Error, "is not valid JSON");
+  } finally {
+    await cleanup();
+  }
+});
+
+Deno.test("save against a zero-byte existing file uses empty-store path", async () => {
+  // Mirrors the zero-byte branch in readForMutation: a manually truncated
+  // live file must allow the next save to overwrite cleanly.
+  const { path, cleanup } = await makeTempStorePath();
+  try {
+    const persistence = createPersistence({ path });
+    await persistence.save(makeTask({ id: makeTaskId("task_a") }));
+    // Overwrite the live file with a zero-byte file mid-flight, then save.
+    await Deno.writeTextFile(path, "");
+    await persistence.save(makeTask({ id: makeTaskId("task_b") }));
+    const tasks = await persistence.loadAll();
+    assertEquals(tasks.map((t) => t.id), ["task_b"]);
+  } finally {
+    await cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Implements [#7](https://github.com/koraytaylan/makina/issues/7) — durable, crash-safe JSON state store with replay on daemon restart.

## Linked issue

Closes #7

## Definition of Done

- [x] JSDoc on every exported symbol; `deno doc --lint` green.
- [x] Atomic write: `.tmp` + fsync + rename, with internal mutex for concurrency.
- [x] Tests cover round-trip, concurrent saves, partial-write recovery, missing-file load.
- [x] `deno task ci` is green.

## References

- Plan §Architecture (Persistence).
