### PR TITLE
feat(#3): config loader and setup wizard

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,47 +1,29 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@std/assert@1": "1.0.19",
-    "jsr:@std/assert@^1.0.19": "1.0.19",
-    "jsr:@std/async@1": "1.3.0",
-    "jsr:@std/cli@1": "1.0.29",
     "jsr:@std/fmt@^1.0.5": "1.0.10",
+    "jsr:@std/fs@1": "1.0.23",
     "jsr:@std/fs@^1.0.11": "1.0.23",
-    "jsr:@std/fs@^1.0.23": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.13",
-    "jsr:@std/internal@^1.0.13": "1.0.13",
     "jsr:@std/io@~0.225.2": "0.225.3",
+    "jsr:@std/json@^1.0.2": "1.1.0",
+    "jsr:@std/jsonc@1": "1.0.2",
     "jsr:@std/log@0.224": "0.224.14",
     "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
-    "jsr:@std/testing@1": "1.0.18",
-    "npm:@anthropic-ai/claude-agent-sdk@*": "0.2.119_zod@3.25.76",
-    "npm:@octokit/auth-app@7": "7.2.2",
-    "npm:@octokit/core@5": "5.2.2",
     "npm:@types/react@18": "18.3.28",
     "npm:ink@5": "5.2.1_@types+react@18.3.28_react@18.3.1",
     "npm:react@18": "18.3.1",
     "npm:zod@3": "3.25.76"
   },
   "jsr": {
-    "@std/assert@1.0.19": {
-      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
-      "dependencies": [
-        "jsr:@std/internal@^1.0.12"
-      ]
-    },
-    "@std/async@1.3.0": {
-      "integrity": "80485538a4f7baaa46bfe2246168069e02ed142b9f9079cd164f43bb060ad9e9"
-    },
-    "@std/cli@1.0.29": {
-      "integrity": "fa4ef29130baa834d8a13b7d138240c3a2fcfba740bfb7afa646a360a15ec84f"
-    },
     "@std/fmt@1.0.10": {
       "integrity": "90dfba288802ac6de82fb31d0917eb9e4450b9925b954d5e51fc29ac07419db5"
     },
     "@std/fs@1.0.23": {
       "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
       "dependencies": [
+        "jsr:@std/internal",
         "jsr:@std/path@^1.1.4"
       ]
     },
@@ -50,6 +32,15 @@
     },
     "@std/io@0.225.3": {
       "integrity": "27b07b591384d12d7b568f39e61dff966b8230559122df1e9fd11cc068f7ddd1"
+    },
+    "@std/json@1.1.0": {
+      "integrity": "93330d3ed4054d6b1ffe54b075432c80a5f671be77277b978931e018014cb1cc"
+    },
+    "@std/jsonc@1.0.2": {
+      "integrity": "909605dae3af22bd75b1cbda8d64a32cf1fd2cf6efa3f9e224aba6d22c0f44c7",
+      "dependencies": [
+        "jsr:@std/json"
+      ]
     },
     "@std/log@0.224.14": {
       "integrity": "257f7adceee3b53bb2bc86c7242e7d1bc59729e57d4981c4a7e5b876c808f05e",
@@ -62,16 +53,7 @@
     "@std/path@1.1.4": {
       "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
-        "jsr:@std/internal@^1.0.12"
-      ]
-    },
-    "@std/testing@1.0.18": {
-      "integrity": "d3152f57b11666bf6358d0e127c7e3488e91178b0c2d8fbf0793e1c53cd13cb1",
-      "dependencies": [
-        "jsr:@std/assert@^1.0.19",
-        "jsr:@std/fs@^1.0.23",
-        "jsr:@std/internal@^1.0.13",
-        "jsr:@std/path@^1.1.4"
+        "jsr:@std/internal"
       ]
     }
   },
@@ -83,248 +65,6 @@
         "is-fullwidth-code-point@4.0.0"
       ]
     },
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.119": {
-      "integrity": "sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw==",
-      "os": ["darwin"],
-      "cpu": ["arm64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.119": {
-      "integrity": "sha512-9Aj8g3ELsmZuOFg17TCkikeg/Wt2ucVT8hOOPQUatzLd7BKhydrHLA0RP42nBpWECO1B/n/mPdQ4iS/LS3s2Fg==",
-      "os": ["darwin"],
-      "cpu": ["x64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.119": {
-      "integrity": "sha512-IPGWgtz+gGnD7fxKAvSf913EUT/lYBTBE8EZ7lh3+x5ZP2859LWLmrCm053Lf3nMWo/CWikZsVPwkDVwpz6tIQ==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.119": {
-      "integrity": "sha512-v3o464XkiYehp/OKidQQirxdVb+aGSvdJvHF2zH9p33W8M/NC21zwwh4dhwDnKsyrtBIgkt2CcMwzIl30r0OtA==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.119": {
-      "integrity": "sha512-QYxFNAe4FFridPkKhGlNcNBJ0TaIygWYyvfI9g4kX0i+RVbresUWuZVkWY06ioJ0fXoixFJ+HNQBMB7dLrIp8Q==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-linux-x64@0.2.119": {
-      "integrity": "sha512-9ePt4ZN+hsqDw4AgS4KtcWIGKfL9Oq28kwkrTER/QAcSrVKxiLonp81cCLzg7Ok/IUJu4Cfd71GZbFv/WE54zw==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.119": {
-      "integrity": "sha512-p/TjcKQvkCYtXGPlR+mdyNwqCmvRcQL34Wtq0yUZ+iqmI/eyCe59IJ3AZrE0EZoqmiAevEYzatPIt9sncC9uxw==",
-      "os": ["win32"],
-      "cpu": ["arm64"]
-    },
-    "@anthropic-ai/claude-agent-sdk-win32-x64@0.2.119": {
-      "integrity": "sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA==",
-      "os": ["win32"],
-      "cpu": ["x64"]
-    },
-    "@anthropic-ai/claude-agent-sdk@0.2.119_zod@3.25.76": {
-      "integrity": "sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA==",
-      "dependencies": [
-        "@anthropic-ai/sdk",
-        "@modelcontextprotocol/sdk",
-        "zod"
-      ],
-      "optionalDependencies": [
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl",
-        "@anthropic-ai/claude-agent-sdk-linux-x64",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64",
-        "@anthropic-ai/claude-agent-sdk-win32-x64"
-      ]
-    },
-    "@anthropic-ai/sdk@0.81.0_zod@3.25.76": {
-      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
-      "dependencies": [
-        "json-schema-to-ts",
-        "zod"
-      ],
-      "optionalPeers": [
-        "zod"
-      ],
-      "bin": true
-    },
-    "@babel/runtime@7.29.2": {
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
-    },
-    "@hono/node-server@1.19.14_hono@4.12.15": {
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
-      "dependencies": [
-        "hono"
-      ]
-    },
-    "@modelcontextprotocol/sdk@1.29.0_zod@3.25.76": {
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
-      "dependencies": [
-        "@hono/node-server",
-        "ajv",
-        "ajv-formats",
-        "content-type",
-        "cors",
-        "cross-spawn",
-        "eventsource",
-        "eventsource-parser",
-        "express",
-        "express-rate-limit",
-        "hono",
-        "jose",
-        "json-schema-typed",
-        "pkce-challenge",
-        "raw-body",
-        "zod",
-        "zod-to-json-schema"
-      ]
-    },
-    "@octokit/auth-app@7.2.2": {
-      "integrity": "sha512-p6hJtEyQDCJEPN9ijjhEC/kpFHMHN4Gca9r+8S0S8EJi7NaWftaEmexjxxpT1DFBeJpN4u/5RE22ArnyypupJw==",
-      "dependencies": [
-        "@octokit/auth-oauth-app",
-        "@octokit/auth-oauth-user",
-        "@octokit/request@9.2.4",
-        "@octokit/request-error@6.1.8",
-        "@octokit/types@14.1.0",
-        "toad-cache",
-        "universal-github-app-jwt",
-        "universal-user-agent@7.0.3"
-      ]
-    },
-    "@octokit/auth-oauth-app@8.1.4": {
-      "integrity": "sha512-71iBa5SflSXcclk/OL3lJzdt4iFs56OJdpBGEBl1wULp7C58uiswZLV6TdRaiAzHP1LT8ezpbHlKuxADb+4NkQ==",
-      "dependencies": [
-        "@octokit/auth-oauth-device",
-        "@octokit/auth-oauth-user",
-        "@octokit/request@9.2.4",
-        "@octokit/types@14.1.0",
-        "universal-user-agent@7.0.3"
-      ]
-    },
-    "@octokit/auth-oauth-device@7.1.5": {
-      "integrity": "sha512-lR00+k7+N6xeECj0JuXeULQ2TSBB/zjTAmNF2+vyGPDEFx1dgk1hTDmL13MjbSmzusuAmuJD8Pu39rjp9jH6yw==",
-      "dependencies": [
-        "@octokit/oauth-methods",
-        "@octokit/request@9.2.4",
-        "@octokit/types@14.1.0",
-        "universal-user-agent@7.0.3"
-      ]
-    },
-    "@octokit/auth-oauth-user@5.1.6": {
-      "integrity": "sha512-/R8vgeoulp7rJs+wfJ2LtXEVC7pjQTIqDab7wPKwVG6+2v/lUnCOub6vaHmysQBbb45FknM3tbHW8TOVqYHxCw==",
-      "dependencies": [
-        "@octokit/auth-oauth-device",
-        "@octokit/oauth-methods",
-        "@octokit/request@9.2.4",
-        "@octokit/types@14.1.0",
-        "universal-user-agent@7.0.3"
-      ]
-    },
-    "@octokit/auth-token@4.0.0": {
-      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="
-    },
-    "@octokit/core@5.2.2": {
-      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
-      "dependencies": [
-        "@octokit/auth-token",
-        "@octokit/graphql",
-        "@octokit/request@8.4.1",
-        "@octokit/request-error@5.1.1",
-        "@octokit/types@13.10.0",
-        "before-after-hook",
-        "universal-user-agent@6.0.1"
-      ]
-    },
-    "@octokit/endpoint@10.1.4": {
-      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
-      "dependencies": [
-        "@octokit/types@14.1.0",
-        "universal-user-agent@7.0.3"
-      ]
-    },
-    "@octokit/endpoint@9.0.6": {
-      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
-      "dependencies": [
-        "@octokit/types@13.10.0",
-        "universal-user-agent@6.0.1"
-      ]
-    },
-    "@octokit/graphql@7.1.1": {
-      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
-      "dependencies": [
-        "@octokit/request@8.4.1",
-        "@octokit/types@13.10.0",
-        "universal-user-agent@6.0.1"
-      ]
-    },
-    "@octokit/oauth-authorization-url@7.1.1": {
-      "integrity": "sha512-ooXV8GBSabSWyhLUowlMIVd9l1s2nsOGQdlP2SQ4LnkEsGXzeCvbSbCPdZThXhEFzleGPwbapT0Sb+YhXRyjCA=="
-    },
-    "@octokit/oauth-methods@5.1.5": {
-      "integrity": "sha512-Ev7K8bkYrYLhoOSZGVAGsLEscZQyq7XQONCBBAl2JdMg7IT3PQn/y8P0KjloPoYpI5UylqYrLeUcScaYWXwDvw==",
-      "dependencies": [
-        "@octokit/oauth-authorization-url",
-        "@octokit/request@9.2.4",
-        "@octokit/request-error@6.1.8",
-        "@octokit/types@14.1.0"
-      ]
-    },
-    "@octokit/openapi-types@24.2.0": {
-      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="
-    },
-    "@octokit/openapi-types@25.1.0": {
-      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA=="
-    },
-    "@octokit/request-error@5.1.1": {
-      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
-      "dependencies": [
-        "@octokit/types@13.10.0",
-        "deprecation",
-        "once"
-      ]
-    },
-    "@octokit/request-error@6.1.8": {
-      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
-      "dependencies": [
-        "@octokit/types@14.1.0"
-      ]
-    },
-    "@octokit/request@8.4.1": {
-      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
-      "dependencies": [
-        "@octokit/endpoint@9.0.6",
-        "@octokit/request-error@5.1.1",
-        "@octokit/types@13.10.0",
-        "universal-user-agent@6.0.1"
-      ]
-    },
-    "@octokit/request@9.2.4": {
-      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
-      "dependencies": [
-        "@octokit/endpoint@10.1.4",
-        "@octokit/request-error@6.1.8",
-        "@octokit/types@14.1.0",
-        "fast-content-type-parse",
-        "universal-user-agent@7.0.3"
-      ]
-    },
-    "@octokit/types@13.10.0": {
-      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
-      "dependencies": [
-        "@octokit/openapi-types@24.2.0"
-      ]
-    },
-    "@octokit/types@14.1.0": {
-      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
-      "dependencies": [
-        "@octokit/openapi-types@25.1.0"
-      ]
-    },
     "@types/prop-types@15.7.15": {
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="
     },
@@ -333,31 +73,6 @@
       "dependencies": [
         "@types/prop-types",
         "csstype"
-      ]
-    },
-    "accepts@2.0.0": {
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "dependencies": [
-        "mime-types",
-        "negotiator"
-      ]
-    },
-    "ajv-formats@3.0.1_ajv@8.20.0": {
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dependencies": [
-        "ajv"
-      ],
-      "optionalPeers": [
-        "ajv"
-      ]
-    },
-    "ajv@8.20.0": {
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dependencies": [
-        "fast-deep-equal",
-        "fast-uri",
-        "json-schema-traverse",
-        "require-from-string"
       ]
     },
     "ansi-escapes@7.3.0": {
@@ -374,40 +89,6 @@
     },
     "auto-bind@5.0.1": {
       "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="
-    },
-    "before-after-hook@2.2.3": {
-      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
-    },
-    "body-parser@2.2.2": {
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
-      "dependencies": [
-        "bytes",
-        "content-type",
-        "debug",
-        "http-errors",
-        "iconv-lite",
-        "on-finished",
-        "qs",
-        "raw-body",
-        "type-is"
-      ]
-    },
-    "bytes@3.1.2": {
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
-    },
-    "call-bind-apply-helpers@1.0.2": {
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dependencies": [
-        "es-errors",
-        "function-bind"
-      ]
-    },
-    "call-bound@1.0.4": {
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dependencies": [
-        "call-bind-apply-helpers",
-        "get-intrinsic"
-      ]
     },
     "chalk@5.6.2": {
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
@@ -434,234 +115,29 @@
         "convert-to-spaces"
       ]
     },
-    "content-disposition@1.1.0": {
-      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="
-    },
-    "content-type@1.0.5": {
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
-    },
     "convert-to-spaces@2.0.1": {
       "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="
-    },
-    "cookie-signature@1.2.2": {
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
-    },
-    "cookie@0.7.2": {
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
-    },
-    "cors@2.8.6": {
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "dependencies": [
-        "object-assign",
-        "vary"
-      ]
-    },
-    "cross-spawn@7.0.6": {
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dependencies": [
-        "path-key",
-        "shebang-command",
-        "which"
-      ]
     },
     "csstype@3.2.3": {
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
-    "debug@4.4.3": {
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dependencies": [
-        "ms"
-      ]
-    },
-    "depd@2.0.0": {
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-    },
-    "deprecation@2.3.1": {
-      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
-    },
-    "dunder-proto@1.0.1": {
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dependencies": [
-        "call-bind-apply-helpers",
-        "es-errors",
-        "gopd"
-      ]
-    },
-    "ee-first@1.1.1": {
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
-    },
     "emoji-regex@10.6.0": {
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
-    },
-    "encodeurl@2.0.0": {
-      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
     },
     "environment@1.1.0": {
       "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="
     },
-    "es-define-property@1.0.1": {
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
-    },
-    "es-errors@1.3.0": {
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-    },
-    "es-object-atoms@1.1.1": {
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dependencies": [
-        "es-errors"
-      ]
-    },
     "es-toolkit@1.46.0": {
       "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA=="
-    },
-    "escape-html@1.0.3": {
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "escape-string-regexp@2.0.0": {
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
     },
-    "etag@1.8.1": {
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
-    },
-    "eventsource-parser@3.0.8": {
-      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="
-    },
-    "eventsource@3.0.7": {
-      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-      "dependencies": [
-        "eventsource-parser"
-      ]
-    },
-    "express-rate-limit@8.4.1_express@5.2.1": {
-      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
-      "dependencies": [
-        "express",
-        "ip-address"
-      ]
-    },
-    "express@5.2.1": {
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "dependencies": [
-        "accepts",
-        "body-parser",
-        "content-disposition",
-        "content-type",
-        "cookie",
-        "cookie-signature",
-        "debug",
-        "depd",
-        "encodeurl",
-        "escape-html",
-        "etag",
-        "finalhandler",
-        "fresh",
-        "http-errors",
-        "merge-descriptors",
-        "mime-types",
-        "on-finished",
-        "once",
-        "parseurl",
-        "proxy-addr",
-        "qs",
-        "range-parser",
-        "router",
-        "send",
-        "serve-static",
-        "statuses",
-        "type-is",
-        "vary"
-      ]
-    },
-    "fast-content-type-parse@2.0.1": {
-      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q=="
-    },
-    "fast-deep-equal@3.1.3": {
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "fast-uri@3.1.0": {
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
-    },
-    "finalhandler@2.1.1": {
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "dependencies": [
-        "debug",
-        "encodeurl",
-        "escape-html",
-        "on-finished",
-        "parseurl",
-        "statuses"
-      ]
-    },
-    "forwarded@0.2.0": {
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
-    },
-    "fresh@2.0.0": {
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="
-    },
-    "function-bind@1.1.2": {
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-    },
     "get-east-asian-width@1.5.0": {
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="
     },
-    "get-intrinsic@1.3.0": {
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dependencies": [
-        "call-bind-apply-helpers",
-        "es-define-property",
-        "es-errors",
-        "es-object-atoms",
-        "function-bind",
-        "get-proto",
-        "gopd",
-        "has-symbols",
-        "hasown",
-        "math-intrinsics"
-      ]
-    },
-    "get-proto@1.0.1": {
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dependencies": [
-        "dunder-proto",
-        "es-object-atoms"
-      ]
-    },
-    "gopd@1.2.0": {
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
-    },
-    "has-symbols@1.1.0": {
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
-    },
-    "hasown@2.0.3": {
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "dependencies": [
-        "function-bind"
-      ]
-    },
-    "hono@4.12.15": {
-      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg=="
-    },
-    "http-errors@2.0.1": {
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "dependencies": [
-        "depd",
-        "inherits",
-        "setprototypeof",
-        "statuses",
-        "toidentifier"
-      ]
-    },
-    "iconv-lite@0.7.2": {
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "dependencies": [
-        "safer-buffer"
-      ]
-    },
     "indent-string@5.0.0": {
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
-    },
-    "inherits@2.0.4": {
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ink@5.2.1_@types+react@18.3.28_react@18.3.1": {
       "integrity": "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==",
@@ -697,12 +173,6 @@
         "@types/react"
       ]
     },
-    "ip-address@10.1.0": {
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="
-    },
-    "ipaddr.js@1.9.1": {
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
-    },
     "is-fullwidth-code-point@4.0.0": {
       "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="
     },
@@ -716,30 +186,8 @@
       "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
       "bin": true
     },
-    "is-promise@4.0.0": {
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
-    },
-    "isexe@2.0.0": {
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-    },
-    "jose@6.2.2": {
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="
-    },
     "js-tokens@4.0.0": {
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
-    "json-schema-to-ts@3.1.1": {
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "dependencies": [
-        "@babel/runtime",
-        "ts-algebra"
-      ]
-    },
-    "json-schema-traverse@1.0.0": {
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "json-schema-typed@8.0.2": {
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
     },
     "loose-envify@1.4.0": {
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
@@ -748,50 +196,8 @@
       ],
       "bin": true
     },
-    "math-intrinsics@1.1.0": {
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
-    },
-    "media-typer@1.1.0": {
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
-    },
-    "merge-descriptors@2.0.0": {
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="
-    },
-    "mime-db@1.54.0": {
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
-    },
-    "mime-types@3.0.2": {
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "dependencies": [
-        "mime-db"
-      ]
-    },
     "mimic-fn@2.1.0": {
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
-    },
-    "ms@2.1.3": {
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "negotiator@1.0.0": {
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
-    },
-    "object-assign@4.1.1": {
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
-    },
-    "object-inspect@1.13.4": {
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
-    },
-    "on-finished@2.4.1": {
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "dependencies": [
-        "ee-first"
-      ]
-    },
-    "once@1.4.0": {
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dependencies": [
-        "wrappy"
-      ]
     },
     "onetime@5.1.2": {
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
@@ -799,45 +205,8 @@
         "mimic-fn"
       ]
     },
-    "parseurl@1.3.3": {
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-    },
     "patch-console@2.0.0": {
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="
-    },
-    "path-key@3.1.1": {
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-    },
-    "path-to-regexp@8.4.2": {
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="
-    },
-    "pkce-challenge@5.0.1": {
-      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="
-    },
-    "proxy-addr@2.0.7": {
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "dependencies": [
-        "forwarded",
-        "ipaddr.js"
-      ]
-    },
-    "qs@6.15.1": {
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "dependencies": [
-        "side-channel"
-      ]
-    },
-    "range-parser@1.2.1": {
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-    },
-    "raw-body@3.0.2": {
-      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "dependencies": [
-        "bytes",
-        "http-errors",
-        "iconv-lite",
-        "unpipe"
-      ]
     },
     "react-reconciler@0.29.2_react@18.3.1": {
       "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
@@ -853,9 +222,6 @@
         "loose-envify"
       ]
     },
-    "require-from-string@2.0.2": {
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
-    },
     "restore-cursor@4.0.0": {
       "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
       "dependencies": [
@@ -863,96 +229,10 @@
         "signal-exit"
       ]
     },
-    "router@2.2.0": {
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "dependencies": [
-        "debug",
-        "depd",
-        "is-promise",
-        "parseurl",
-        "path-to-regexp"
-      ]
-    },
-    "safer-buffer@2.1.2": {
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "scheduler@0.23.2": {
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dependencies": [
         "loose-envify"
-      ]
-    },
-    "send@1.2.1": {
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "dependencies": [
-        "debug",
-        "encodeurl",
-        "escape-html",
-        "etag",
-        "fresh",
-        "http-errors",
-        "mime-types",
-        "ms",
-        "on-finished",
-        "range-parser",
-        "statuses"
-      ]
-    },
-    "serve-static@2.2.1": {
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "dependencies": [
-        "encodeurl",
-        "escape-html",
-        "parseurl",
-        "send"
-      ]
-    },
-    "setprototypeof@1.2.0": {
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
-    },
-    "shebang-command@2.0.0": {
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dependencies": [
-        "shebang-regex"
-      ]
-    },
-    "shebang-regex@3.0.0": {
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-    },
-    "side-channel-list@1.0.1": {
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "dependencies": [
-        "es-errors",
-        "object-inspect"
-      ]
-    },
-    "side-channel-map@1.0.1": {
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dependencies": [
-        "call-bound",
-        "es-errors",
-        "get-intrinsic",
-        "object-inspect"
-      ]
-    },
-    "side-channel-weakmap@1.0.2": {
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dependencies": [
-        "call-bound",
-        "es-errors",
-        "get-intrinsic",
-        "object-inspect",
-        "side-channel-map"
-      ]
-    },
-    "side-channel@1.1.0": {
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dependencies": [
-        "es-errors",
-        "object-inspect",
-        "side-channel-list",
-        "side-channel-map",
-        "side-channel-weakmap"
       ]
     },
     "signal-exit@3.0.7": {
@@ -978,9 +258,6 @@
         "escape-string-regexp"
       ]
     },
-    "statuses@2.0.2": {
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
-    },
     "string-width@7.2.0": {
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dependencies": [
@@ -995,47 +272,8 @@
         "ansi-regex"
       ]
     },
-    "toad-cache@3.7.0": {
-      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="
-    },
-    "toidentifier@1.0.1": {
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
-    },
-    "ts-algebra@2.0.0": {
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="
-    },
     "type-fest@4.41.0": {
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="
-    },
-    "type-is@2.0.1": {
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-      "dependencies": [
-        "content-type",
-        "media-typer",
-        "mime-types"
-      ]
-    },
-    "universal-github-app-jwt@2.2.2": {
-      "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw=="
-    },
-    "universal-user-agent@6.0.1": {
-      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
-    },
-    "universal-user-agent@7.0.3": {
-      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="
-    },
-    "unpipe@1.0.0": {
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
-    },
-    "vary@1.1.2": {
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
-    },
-    "which@2.0.2": {
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dependencies": [
-        "isexe"
-      ],
-      "bin": true
     },
     "widest-line@5.0.0": {
       "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
@@ -1051,20 +289,11 @@
         "strip-ansi"
       ]
     },
-    "wrappy@1.0.2": {
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
     "ws@8.20.0": {
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="
     },
     "yoga-layout@3.2.1": {
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="
-    },
-    "zod-to-json-schema@3.25.2_zod@3.25.76": {
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "dependencies": [
-        "zod"
-      ]
     },
     "zod@3.25.76": {
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="

--- a/deno.lock
+++ b/deno.lock
@@ -1,29 +1,51 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/async@1": "1.3.0",
+    "jsr:@std/cli@1": "1.0.29",
     "jsr:@std/fmt@^1.0.5": "1.0.10",
     "jsr:@std/fs@1": "1.0.23",
     "jsr:@std/fs@^1.0.11": "1.0.23",
+    "jsr:@std/fs@^1.0.23": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.13",
+    "jsr:@std/internal@^1.0.13": "1.0.13",
     "jsr:@std/io@~0.225.2": "0.225.3",
     "jsr:@std/json@^1.0.2": "1.1.0",
     "jsr:@std/jsonc@1": "1.0.2",
     "jsr:@std/log@0.224": "0.224.14",
     "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
+    "jsr:@std/testing@1": "1.0.18",
+    "npm:@anthropic-ai/claude-agent-sdk@*": "0.2.119_zod@3.25.76",
+    "npm:@octokit/auth-app@7": "7.2.2",
+    "npm:@octokit/core@5": "5.2.2",
     "npm:@types/react@18": "18.3.28",
     "npm:ink@5": "5.2.1_@types+react@18.3.28_react@18.3.1",
     "npm:react@18": "18.3.1",
     "npm:zod@3": "3.25.76"
   },
   "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/async@1.3.0": {
+      "integrity": "80485538a4f7baaa46bfe2246168069e02ed142b9f9079cd164f43bb060ad9e9"
+    },
+    "@std/cli@1.0.29": {
+      "integrity": "fa4ef29130baa834d8a13b7d138240c3a2fcfba740bfb7afa646a360a15ec84f"
+    },
     "@std/fmt@1.0.10": {
       "integrity": "90dfba288802ac6de82fb31d0917eb9e4450b9925b954d5e51fc29ac07419db5"
     },
     "@std/fs@1.0.23": {
       "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
       "dependencies": [
-        "jsr:@std/internal",
+        "jsr:@std/internal@^1.0.12",
         "jsr:@std/path@^1.1.4"
       ]
     },
@@ -53,7 +75,16 @@
     "@std/path@1.1.4": {
       "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/testing@1.0.18": {
+      "integrity": "d3152f57b11666bf6358d0e127c7e3488e91178b0c2d8fbf0793e1c53cd13cb1",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.19",
+        "jsr:@std/fs@^1.0.23",
+        "jsr:@std/internal@^1.0.13",
+        "jsr:@std/path@^1.1.4"
       ]
     }
   },
@@ -65,6 +96,248 @@
         "is-fullwidth-code-point@4.0.0"
       ]
     },
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.119": {
+      "integrity": "sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.119": {
+      "integrity": "sha512-9Aj8g3ELsmZuOFg17TCkikeg/Wt2ucVT8hOOPQUatzLd7BKhydrHLA0RP42nBpWECO1B/n/mPdQ4iS/LS3s2Fg==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.119": {
+      "integrity": "sha512-IPGWgtz+gGnD7fxKAvSf913EUT/lYBTBE8EZ7lh3+x5ZP2859LWLmrCm053Lf3nMWo/CWikZsVPwkDVwpz6tIQ==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.119": {
+      "integrity": "sha512-v3o464XkiYehp/OKidQQirxdVb+aGSvdJvHF2zH9p33W8M/NC21zwwh4dhwDnKsyrtBIgkt2CcMwzIl30r0OtA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.119": {
+      "integrity": "sha512-QYxFNAe4FFridPkKhGlNcNBJ0TaIygWYyvfI9g4kX0i+RVbresUWuZVkWY06ioJ0fXoixFJ+HNQBMB7dLrIp8Q==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-linux-x64@0.2.119": {
+      "integrity": "sha512-9ePt4ZN+hsqDw4AgS4KtcWIGKfL9Oq28kwkrTER/QAcSrVKxiLonp81cCLzg7Ok/IUJu4Cfd71GZbFv/WE54zw==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.119": {
+      "integrity": "sha512-p/TjcKQvkCYtXGPlR+mdyNwqCmvRcQL34Wtq0yUZ+iqmI/eyCe59IJ3AZrE0EZoqmiAevEYzatPIt9sncC9uxw==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@anthropic-ai/claude-agent-sdk-win32-x64@0.2.119": {
+      "integrity": "sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@anthropic-ai/claude-agent-sdk@0.2.119_zod@3.25.76": {
+      "integrity": "sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA==",
+      "dependencies": [
+        "@anthropic-ai/sdk",
+        "@modelcontextprotocol/sdk",
+        "zod"
+      ],
+      "optionalDependencies": [
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl",
+        "@anthropic-ai/claude-agent-sdk-linux-x64",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64",
+        "@anthropic-ai/claude-agent-sdk-win32-x64"
+      ]
+    },
+    "@anthropic-ai/sdk@0.81.0_zod@3.25.76": {
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
+      "dependencies": [
+        "json-schema-to-ts",
+        "zod"
+      ],
+      "optionalPeers": [
+        "zod"
+      ],
+      "bin": true
+    },
+    "@babel/runtime@7.29.2": {
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
+    },
+    "@hono/node-server@1.19.14_hono@4.12.15": {
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dependencies": [
+        "hono"
+      ]
+    },
+    "@modelcontextprotocol/sdk@1.29.0_zod@3.25.76": {
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dependencies": [
+        "@hono/node-server",
+        "ajv",
+        "ajv-formats",
+        "content-type",
+        "cors",
+        "cross-spawn",
+        "eventsource",
+        "eventsource-parser",
+        "express",
+        "express-rate-limit",
+        "hono",
+        "jose",
+        "json-schema-typed",
+        "pkce-challenge",
+        "raw-body",
+        "zod",
+        "zod-to-json-schema"
+      ]
+    },
+    "@octokit/auth-app@7.2.2": {
+      "integrity": "sha512-p6hJtEyQDCJEPN9ijjhEC/kpFHMHN4Gca9r+8S0S8EJi7NaWftaEmexjxxpT1DFBeJpN4u/5RE22ArnyypupJw==",
+      "dependencies": [
+        "@octokit/auth-oauth-app",
+        "@octokit/auth-oauth-user",
+        "@octokit/request@9.2.4",
+        "@octokit/request-error@6.1.8",
+        "@octokit/types@14.1.0",
+        "toad-cache",
+        "universal-github-app-jwt",
+        "universal-user-agent@7.0.3"
+      ]
+    },
+    "@octokit/auth-oauth-app@8.1.4": {
+      "integrity": "sha512-71iBa5SflSXcclk/OL3lJzdt4iFs56OJdpBGEBl1wULp7C58uiswZLV6TdRaiAzHP1LT8ezpbHlKuxADb+4NkQ==",
+      "dependencies": [
+        "@octokit/auth-oauth-device",
+        "@octokit/auth-oauth-user",
+        "@octokit/request@9.2.4",
+        "@octokit/types@14.1.0",
+        "universal-user-agent@7.0.3"
+      ]
+    },
+    "@octokit/auth-oauth-device@7.1.5": {
+      "integrity": "sha512-lR00+k7+N6xeECj0JuXeULQ2TSBB/zjTAmNF2+vyGPDEFx1dgk1hTDmL13MjbSmzusuAmuJD8Pu39rjp9jH6yw==",
+      "dependencies": [
+        "@octokit/oauth-methods",
+        "@octokit/request@9.2.4",
+        "@octokit/types@14.1.0",
+        "universal-user-agent@7.0.3"
+      ]
+    },
+    "@octokit/auth-oauth-user@5.1.6": {
+      "integrity": "sha512-/R8vgeoulp7rJs+wfJ2LtXEVC7pjQTIqDab7wPKwVG6+2v/lUnCOub6vaHmysQBbb45FknM3tbHW8TOVqYHxCw==",
+      "dependencies": [
+        "@octokit/auth-oauth-device",
+        "@octokit/oauth-methods",
+        "@octokit/request@9.2.4",
+        "@octokit/types@14.1.0",
+        "universal-user-agent@7.0.3"
+      ]
+    },
+    "@octokit/auth-token@4.0.0": {
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="
+    },
+    "@octokit/core@5.2.2": {
+      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+      "dependencies": [
+        "@octokit/auth-token",
+        "@octokit/graphql",
+        "@octokit/request@8.4.1",
+        "@octokit/request-error@5.1.1",
+        "@octokit/types@13.10.0",
+        "before-after-hook",
+        "universal-user-agent@6.0.1"
+      ]
+    },
+    "@octokit/endpoint@10.1.4": {
+      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
+      "dependencies": [
+        "@octokit/types@14.1.0",
+        "universal-user-agent@7.0.3"
+      ]
+    },
+    "@octokit/endpoint@9.0.6": {
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "dependencies": [
+        "@octokit/types@13.10.0",
+        "universal-user-agent@6.0.1"
+      ]
+    },
+    "@octokit/graphql@7.1.1": {
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "dependencies": [
+        "@octokit/request@8.4.1",
+        "@octokit/types@13.10.0",
+        "universal-user-agent@6.0.1"
+      ]
+    },
+    "@octokit/oauth-authorization-url@7.1.1": {
+      "integrity": "sha512-ooXV8GBSabSWyhLUowlMIVd9l1s2nsOGQdlP2SQ4LnkEsGXzeCvbSbCPdZThXhEFzleGPwbapT0Sb+YhXRyjCA=="
+    },
+    "@octokit/oauth-methods@5.1.5": {
+      "integrity": "sha512-Ev7K8bkYrYLhoOSZGVAGsLEscZQyq7XQONCBBAl2JdMg7IT3PQn/y8P0KjloPoYpI5UylqYrLeUcScaYWXwDvw==",
+      "dependencies": [
+        "@octokit/oauth-authorization-url",
+        "@octokit/request@9.2.4",
+        "@octokit/request-error@6.1.8",
+        "@octokit/types@14.1.0"
+      ]
+    },
+    "@octokit/openapi-types@24.2.0": {
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="
+    },
+    "@octokit/openapi-types@25.1.0": {
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA=="
+    },
+    "@octokit/request-error@5.1.1": {
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "dependencies": [
+        "@octokit/types@13.10.0",
+        "deprecation",
+        "once"
+      ]
+    },
+    "@octokit/request-error@6.1.8": {
+      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
+      "dependencies": [
+        "@octokit/types@14.1.0"
+      ]
+    },
+    "@octokit/request@8.4.1": {
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "dependencies": [
+        "@octokit/endpoint@9.0.6",
+        "@octokit/request-error@5.1.1",
+        "@octokit/types@13.10.0",
+        "universal-user-agent@6.0.1"
+      ]
+    },
+    "@octokit/request@9.2.4": {
+      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
+      "dependencies": [
+        "@octokit/endpoint@10.1.4",
+        "@octokit/request-error@6.1.8",
+        "@octokit/types@14.1.0",
+        "fast-content-type-parse",
+        "universal-user-agent@7.0.3"
+      ]
+    },
+    "@octokit/types@13.10.0": {
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dependencies": [
+        "@octokit/openapi-types@24.2.0"
+      ]
+    },
+    "@octokit/types@14.1.0": {
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "dependencies": [
+        "@octokit/openapi-types@25.1.0"
+      ]
+    },
     "@types/prop-types@15.7.15": {
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="
     },
@@ -73,6 +346,31 @@
       "dependencies": [
         "@types/prop-types",
         "csstype"
+      ]
+    },
+    "accepts@2.0.0": {
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dependencies": [
+        "mime-types",
+        "negotiator"
+      ]
+    },
+    "ajv-formats@3.0.1_ajv@8.20.0": {
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dependencies": [
+        "ajv"
+      ],
+      "optionalPeers": [
+        "ajv"
+      ]
+    },
+    "ajv@8.20.0": {
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dependencies": [
+        "fast-deep-equal",
+        "fast-uri",
+        "json-schema-traverse",
+        "require-from-string"
       ]
     },
     "ansi-escapes@7.3.0": {
@@ -89,6 +387,40 @@
     },
     "auto-bind@5.0.1": {
       "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="
+    },
+    "before-after-hook@2.2.3": {
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+    },
+    "body-parser@2.2.2": {
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dependencies": [
+        "bytes",
+        "content-type",
+        "debug",
+        "http-errors",
+        "iconv-lite",
+        "on-finished",
+        "qs",
+        "raw-body",
+        "type-is"
+      ]
+    },
+    "bytes@3.1.2": {
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+    },
+    "call-bind-apply-helpers@1.0.2": {
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": [
+        "es-errors",
+        "function-bind"
+      ]
+    },
+    "call-bound@1.0.4": {
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "get-intrinsic"
+      ]
     },
     "chalk@5.6.2": {
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
@@ -115,29 +447,234 @@
         "convert-to-spaces"
       ]
     },
+    "content-disposition@1.1.0": {
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="
+    },
+    "content-type@1.0.5": {
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
+    },
     "convert-to-spaces@2.0.1": {
       "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="
+    },
+    "cookie-signature@1.2.2": {
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
+    },
+    "cookie@0.7.2": {
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
+    },
+    "cors@2.8.6": {
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dependencies": [
+        "object-assign",
+        "vary"
+      ]
+    },
+    "cross-spawn@7.0.6": {
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dependencies": [
+        "path-key",
+        "shebang-command",
+        "which"
+      ]
     },
     "csstype@3.2.3": {
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
+    "debug@4.4.3": {
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "depd@2.0.0": {
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+    },
+    "deprecation@2.3.1": {
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "dunder-proto@1.0.1": {
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-errors",
+        "gopd"
+      ]
+    },
+    "ee-first@1.1.1": {
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
     "emoji-regex@10.6.0": {
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
+    },
+    "encodeurl@2.0.0": {
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
     },
     "environment@1.1.0": {
       "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="
     },
+    "es-define-property@1.0.1": {
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors@1.3.0": {
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms@1.1.1": {
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": [
+        "es-errors"
+      ]
+    },
     "es-toolkit@1.46.0": {
       "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA=="
+    },
+    "escape-html@1.0.3": {
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "escape-string-regexp@2.0.0": {
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
     },
+    "etag@1.8.1": {
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+    },
+    "eventsource-parser@3.0.8": {
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="
+    },
+    "eventsource@3.0.7": {
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dependencies": [
+        "eventsource-parser"
+      ]
+    },
+    "express-rate-limit@8.4.1_express@5.2.1": {
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "dependencies": [
+        "express",
+        "ip-address"
+      ]
+    },
+    "express@5.2.1": {
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dependencies": [
+        "accepts",
+        "body-parser",
+        "content-disposition",
+        "content-type",
+        "cookie",
+        "cookie-signature",
+        "debug",
+        "depd",
+        "encodeurl",
+        "escape-html",
+        "etag",
+        "finalhandler",
+        "fresh",
+        "http-errors",
+        "merge-descriptors",
+        "mime-types",
+        "on-finished",
+        "once",
+        "parseurl",
+        "proxy-addr",
+        "qs",
+        "range-parser",
+        "router",
+        "send",
+        "serve-static",
+        "statuses",
+        "type-is",
+        "vary"
+      ]
+    },
+    "fast-content-type-parse@2.0.1": {
+      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q=="
+    },
+    "fast-deep-equal@3.1.3": {
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-uri@3.1.0": {
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
+    },
+    "finalhandler@2.1.1": {
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dependencies": [
+        "debug",
+        "encodeurl",
+        "escape-html",
+        "on-finished",
+        "parseurl",
+        "statuses"
+      ]
+    },
+    "forwarded@0.2.0": {
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
+    "fresh@2.0.0": {
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="
+    },
+    "function-bind@1.1.2": {
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
     "get-east-asian-width@1.5.0": {
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="
     },
+    "get-intrinsic@1.3.0": {
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "es-errors",
+        "es-object-atoms",
+        "function-bind",
+        "get-proto",
+        "gopd",
+        "has-symbols",
+        "hasown",
+        "math-intrinsics"
+      ]
+    },
+    "get-proto@1.0.1": {
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": [
+        "dunder-proto",
+        "es-object-atoms"
+      ]
+    },
+    "gopd@1.2.0": {
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-symbols@1.1.0": {
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "hasown@2.0.3": {
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dependencies": [
+        "function-bind"
+      ]
+    },
+    "hono@4.12.15": {
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg=="
+    },
+    "http-errors@2.0.1": {
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dependencies": [
+        "depd",
+        "inherits",
+        "setprototypeof",
+        "statuses",
+        "toidentifier"
+      ]
+    },
+    "iconv-lite@0.7.2": {
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dependencies": [
+        "safer-buffer"
+      ]
+    },
     "indent-string@5.0.0": {
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
+    },
+    "inherits@2.0.4": {
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ink@5.2.1_@types+react@18.3.28_react@18.3.1": {
       "integrity": "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==",
@@ -173,6 +710,12 @@
         "@types/react"
       ]
     },
+    "ip-address@10.1.0": {
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="
+    },
+    "ipaddr.js@1.9.1": {
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
     "is-fullwidth-code-point@4.0.0": {
       "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="
     },
@@ -186,8 +729,30 @@
       "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
       "bin": true
     },
+    "is-promise@4.0.0": {
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+    },
+    "isexe@2.0.0": {
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "jose@6.2.2": {
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="
+    },
     "js-tokens@4.0.0": {
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "json-schema-to-ts@3.1.1": {
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dependencies": [
+        "@babel/runtime",
+        "ts-algebra"
+      ]
+    },
+    "json-schema-traverse@1.0.0": {
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "json-schema-typed@8.0.2": {
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
     },
     "loose-envify@1.4.0": {
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
@@ -196,8 +761,50 @@
       ],
       "bin": true
     },
+    "math-intrinsics@1.1.0": {
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "media-typer@1.1.0": {
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
+    },
+    "merge-descriptors@2.0.0": {
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="
+    },
+    "mime-db@1.54.0": {
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+    },
+    "mime-types@3.0.2": {
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dependencies": [
+        "mime-db"
+      ]
+    },
     "mimic-fn@2.1.0": {
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "negotiator@1.0.0": {
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
+    },
+    "object-assign@4.1.1": {
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
+    "object-inspect@1.13.4": {
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
+    },
+    "on-finished@2.4.1": {
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": [
+        "ee-first"
+      ]
+    },
+    "once@1.4.0": {
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": [
+        "wrappy"
+      ]
     },
     "onetime@5.1.2": {
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
@@ -205,8 +812,45 @@
         "mimic-fn"
       ]
     },
+    "parseurl@1.3.3": {
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
     "patch-console@2.0.0": {
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="
+    },
+    "path-key@3.1.1": {
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
+    "path-to-regexp@8.4.2": {
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="
+    },
+    "pkce-challenge@5.0.1": {
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="
+    },
+    "proxy-addr@2.0.7": {
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": [
+        "forwarded",
+        "ipaddr.js"
+      ]
+    },
+    "qs@6.15.1": {
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dependencies": [
+        "side-channel"
+      ]
+    },
+    "range-parser@1.2.1": {
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body@3.0.2": {
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dependencies": [
+        "bytes",
+        "http-errors",
+        "iconv-lite",
+        "unpipe"
+      ]
     },
     "react-reconciler@0.29.2_react@18.3.1": {
       "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
@@ -222,6 +866,9 @@
         "loose-envify"
       ]
     },
+    "require-from-string@2.0.2": {
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "restore-cursor@4.0.0": {
       "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
       "dependencies": [
@@ -229,10 +876,96 @@
         "signal-exit"
       ]
     },
+    "router@2.2.0": {
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dependencies": [
+        "debug",
+        "depd",
+        "is-promise",
+        "parseurl",
+        "path-to-regexp"
+      ]
+    },
+    "safer-buffer@2.1.2": {
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "scheduler@0.23.2": {
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dependencies": [
         "loose-envify"
+      ]
+    },
+    "send@1.2.1": {
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dependencies": [
+        "debug",
+        "encodeurl",
+        "escape-html",
+        "etag",
+        "fresh",
+        "http-errors",
+        "mime-types",
+        "ms",
+        "on-finished",
+        "range-parser",
+        "statuses"
+      ]
+    },
+    "serve-static@2.2.1": {
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dependencies": [
+        "encodeurl",
+        "escape-html",
+        "parseurl",
+        "send"
+      ]
+    },
+    "setprototypeof@1.2.0": {
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "shebang-command@2.0.0": {
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": [
+        "shebang-regex"
+      ]
+    },
+    "shebang-regex@3.0.0": {
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+    },
+    "side-channel-list@1.0.1": {
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dependencies": [
+        "es-errors",
+        "object-inspect"
+      ]
+    },
+    "side-channel-map@1.0.1": {
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "get-intrinsic",
+        "object-inspect"
+      ]
+    },
+    "side-channel-weakmap@1.0.2": {
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "get-intrinsic",
+        "object-inspect",
+        "side-channel-map"
+      ]
+    },
+    "side-channel@1.1.0": {
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dependencies": [
+        "es-errors",
+        "object-inspect",
+        "side-channel-list",
+        "side-channel-map",
+        "side-channel-weakmap"
       ]
     },
     "signal-exit@3.0.7": {
@@ -258,6 +991,9 @@
         "escape-string-regexp"
       ]
     },
+    "statuses@2.0.2": {
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
+    },
     "string-width@7.2.0": {
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dependencies": [
@@ -272,8 +1008,47 @@
         "ansi-regex"
       ]
     },
+    "toad-cache@3.7.0": {
+      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="
+    },
+    "toidentifier@1.0.1": {
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+    },
+    "ts-algebra@2.0.0": {
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="
+    },
     "type-fest@4.41.0": {
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="
+    },
+    "type-is@2.0.1": {
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dependencies": [
+        "content-type",
+        "media-typer",
+        "mime-types"
+      ]
+    },
+    "universal-github-app-jwt@2.2.2": {
+      "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw=="
+    },
+    "universal-user-agent@6.0.1": {
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
+    },
+    "universal-user-agent@7.0.3": {
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="
+    },
+    "unpipe@1.0.0": {
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
+    },
+    "vary@1.1.2": {
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    },
+    "which@2.0.2": {
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": [
+        "isexe"
+      ],
+      "bin": true
     },
     "widest-line@5.0.0": {
       "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
@@ -289,11 +1064,20 @@
         "strip-ansi"
       ]
     },
+    "wrappy@1.0.2": {
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
     "ws@8.20.0": {
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="
     },
     "yoga-layout@3.2.1": {
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="
+    },
+    "zod-to-json-schema@3.25.2_zod@3.25.76": {
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dependencies": [
+        "zod"
+      ]
     },
     "zod@3.25.76": {
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,3 +57,15 @@ makina setup
 
 Walks through the App ID, private-key path, installation discovery, and default repo. See
 `docs/setup-github-app.md` for App creation.
+
+## Loader behavior
+
+`src/config/load.ts` is the only place the daemon and TUI read the file. It expands a single leading
+`~/` against `$HOME` (falling back to `%USERPROFILE%`) and then parses the file as JSONC, so
+`// line comments`, `/* block comments */`, and trailing commas are tolerated. Validation goes
+through the same `parseConfig` the W1 schema exposes; failures raise a `ConfigLoadError` whose
+`message` embeds the failing field path (e.g. `github.installations["owner/repo"]`) and whose `kind`
+discriminates `not-found`, `read-failed`, `invalid-json`, and `invalid-schema` so callers can branch
+(the daemon prints "run `makina setup` first" on `not-found`, for example). Other path fields inside
+the config (`github.privateKeyPath`, `daemon.socketPath`, `workspace`) keep their original
+`~/`-prefixed form; each consumer expands them at the boundary it cares about.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,14 +58,23 @@ makina setup
 Walks through the App ID, private-key path, installation discovery, and default repo. See
 `docs/setup-github-app.md` for App creation.
 
+> **Status (this PR):** the wizard's interactive flow is implemented but the GitHub App client used
+> for installation discovery lands with `[W2-github-app-auth]` (#4). Until then, `makina setup`
+> exits immediately with a pointer to issue #4. Set `MAKINA_ALLOW_WIZARD_STUB=1` to dry-run the
+> prompts; the discovery step will fail with a clear "App client not yet wired" message.
+
 ## Loader behavior
 
 `src/config/load.ts` is the only place the daemon and TUI read the file. It expands a single leading
-`~/` against `$HOME` (falling back to `%USERPROFILE%`) and then parses the file as JSONC, so
-`// line comments`, `/* block comments */`, and trailing commas are tolerated. Validation goes
-through the same `parseConfig` the W1 schema exposes; failures raise a `ConfigLoadError` whose
-`message` embeds the failing field path (e.g. `github.installations["owner/repo"]`) and whose `kind`
-discriminates `not-found`, `read-failed`, `invalid-json`, and `invalid-schema` so callers can branch
-(the daemon prints "run `makina setup` first" on `not-found`, for example). Other path fields inside
-the config (`github.privateKeyPath`, `daemon.socketPath`, `workspace`) keep their original
-`~/`-prefixed form; each consumer expands them at the boundary it cares about.
+`~/` against `$HOME` and then parses the file as JSONC, so `// line comments`,
+`/* block comments */`, and trailing commas are tolerated. Validation goes through the same
+`parseConfig` the W1 schema exposes; failures raise a `ConfigLoadError` whose `message` embeds the
+failing field path (e.g. `github.installations["owner/repo"]`) and whose `kind` discriminates
+`not-found`, `read-failed`, `invalid-json`, and `invalid-schema` so callers can branch (the daemon
+prints "run `makina setup` first" on `not-found`, for example). Other path fields inside the config
+(`github.privateKeyPath`, `daemon.socketPath`, `workspace`) keep their original `~/`-prefixed form;
+each consumer expands them at the boundary it cares about.
+
+Per ADR-008 (Windows deferred to a later wave), only POSIX `$HOME` is honored. WSL2 and other
+POSIX-like environments work out of the box; native Windows is not yet supported and therefore not
+emulated via `%USERPROFILE%`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,10 +58,10 @@ makina setup
 Walks through the App ID, private-key path, installation discovery, and default repo. See
 `docs/setup-github-app.md` for App creation.
 
-> **Status (this PR):** the wizard's interactive flow is implemented but the GitHub App client used
-> for installation discovery lands with `[W2-github-app-auth]` (#4). Until then, `makina setup`
-> exits immediately with a pointer to issue #4. Set `MAKINA_ALLOW_WIZARD_STUB=1` to dry-run the
-> prompts; the discovery step will fail with a clear "App client not yet wired" message.
+> **Status (this PR):** the wizard's interactive flow is implemented and runs unconditionally. The
+> GitHub App client used for installation discovery lands with `[W2-github-app-auth]` (#4); until
+> then, `makina setup` fails at the discovery step with a clear "GitHub App auth not yet implemented
+> (#4)" error (after the App ID and private-key path have been collected).
 
 ## Loader behavior
 

--- a/docs/setup-github-app.md
+++ b/docs/setup-github-app.md
@@ -1,7 +1,8 @@
 # Setting up the GitHub App
 
-> Wave 2's `setup` wizard now drives steps 3.2 onwards. Steps 1 and 2 are still manual GitHub
-> Actions taken in your browser; the wizard handles everything after the App is installed.
+> Wave 2's `setup` wizard will drive steps 3.2 onwards once `[W2-github-app-auth]` (#4) wires the
+> GitHub App client. Steps 1 and 2 are manual GitHub actions taken in your browser; the wizard
+> handles everything after the App is installed. See section 3 for the current `makina setup` gate.
 
 makina authenticates to GitHub as a GitHub App (rather than a personal access token). This is
 ADR-003: it gives us higher rate limits, fine-grained per-repo permissions, and a clean bot identity
@@ -30,14 +31,22 @@ On the App page → **Install App** → choose the account → choose specific r
 ## 3. Wire up makina
 
 1. Save the `.pem` somewhere private — e.g. `~/.config/makina/app-private-key.pem` with mode `0600`.
-2. Run `makina setup`. Provide the App ID (top of the App page) and the private-key path. The wizard
-   then queries the App's installations endpoint to discover which repos you can target and asks you
-   to pick a default.
+2. Run `makina setup`. Once the App-level client lands (issue #4 — `[W2-github-app-auth]`), the
+   wizard will ask for the App ID, private-key path, query the App's installations endpoint to
+   discover which repos you can target, and write the resulting `config.json` to the
+   platform-appropriate location (see `docs/configuration.md`).
 
-The wizard validates the private-key path against the filesystem before calling GitHub, prints the
-list of reachable repositories with one-based numbers, and writes the resulting `config.json` to the
-platform-appropriate location (see `docs/configuration.md`). On EOF or invalid input the wizard
-exits with a one-line summary; rerun `makina setup` to start over.
+> **Status (this PR):** the wizard's prompts, validation, and config-writing are implemented, but
+> the GitHub App client used for installation discovery is wired in `[W2-github-app-auth]` (#4).
+> Until that lands, `makina setup` exits immediately with a pointer instead of prompting; set the
+> `MAKINA_ALLOW_WIZARD_STUB=1` env var to dry-run the prompts (the discovery step will then surface
+> a clear "GitHub App client not yet wired" error). When the App client lands the gate goes away in
+> the same PR.
+
+When usable, the wizard validates the private-key path against the filesystem before calling GitHub,
+prints the list of reachable repositories with one-based numbers, and writes the resulting
+`config.json`. On EOF or invalid input the wizard exits with a one-line summary; rerun the command
+to start over.
 
 ## Copilot review
 

--- a/docs/setup-github-app.md
+++ b/docs/setup-github-app.md
@@ -1,6 +1,7 @@
 # Setting up the GitHub App
 
-> Wave 0 stub. Concrete steps will be revised when Wave 2's `setup` wizard lands.
+> Wave 2's `setup` wizard now drives steps 3.2 onwards. Steps 1 and 2 are still manual GitHub
+> Actions taken in your browser; the wizard handles everything after the App is installed.
 
 makina authenticates to GitHub as a GitHub App (rather than a personal access token). This is
 ADR-003: it gives us higher rate limits, fine-grained per-repo permissions, and a clean bot identity
@@ -32,6 +33,11 @@ On the App page → **Install App** → choose the account → choose specific r
 2. Run `makina setup`. Provide the App ID (top of the App page) and the private-key path. The wizard
    then queries the App's installations endpoint to discover which repos you can target and asks you
    to pick a default.
+
+The wizard validates the private-key path against the filesystem before calling GitHub, prints the
+list of reachable repositories with one-based numbers, and writes the resulting `config.json` to the
+platform-appropriate location (see `docs/configuration.md`). On EOF or invalid input the wizard
+exits with a one-line summary; rerun `makina setup` to start over.
 
 ## Copilot review
 

--- a/docs/setup-github-app.md
+++ b/docs/setup-github-app.md
@@ -1,8 +1,9 @@
 # Setting up the GitHub App
 
-> Wave 2's `setup` wizard will drive steps 3.2 onwards once `[W2-github-app-auth]` (#4) wires the
-> GitHub App client. Steps 1 and 2 are manual GitHub actions taken in your browser; the wizard
-> handles everything after the App is installed. See section 3 for the current `makina setup` gate.
+> Wave 2's `setup` wizard drives steps 3.2 onwards. Steps 1 and 2 are manual GitHub actions taken in
+> your browser; the wizard handles everything after the App is installed. The wizard runs end-to-end
+> except for installation discovery, which lands with `[W2-github-app-auth]` (#4) — until then the
+> wizard exits with a clear "not yet implemented" message at that step.
 
 makina authenticates to GitHub as a GitHub App (rather than a personal access token). This is
 ADR-003: it gives us higher rate limits, fine-grained per-repo permissions, and a clean bot identity
@@ -36,17 +37,16 @@ On the App page → **Install App** → choose the account → choose specific r
    discover which repos you can target, and write the resulting `config.json` to the
    platform-appropriate location (see `docs/configuration.md`).
 
-> **Status (this PR):** the wizard's prompts, validation, and config-writing are implemented, but
-> the GitHub App client used for installation discovery is wired in `[W2-github-app-auth]` (#4).
-> Until that lands, `makina setup` exits immediately with a pointer instead of prompting; set the
-> `MAKINA_ALLOW_WIZARD_STUB=1` env var to dry-run the prompts (the discovery step will then surface
-> a clear "GitHub App client not yet wired" error). When the App client lands the gate goes away in
-> the same PR.
+> **Status (this PR):** the wizard's prompts, validation, and config-writing are implemented and run
+> unconditionally. The GitHub App client used for installation discovery is wired in
+> `[W2-github-app-auth]` (#4); until that lands, `makina setup` will fail with a clear "GitHub App
+> auth not yet implemented (#4)" error at the discovery step (after the App ID and private-key path
+> have been collected). When the App client lands the wizard completes end-to-end with no further
+> changes here.
 
-When usable, the wizard validates the private-key path against the filesystem before calling GitHub,
-prints the list of reachable repositories with one-based numbers, and writes the resulting
-`config.json`. On EOF or invalid input the wizard exits with a one-line summary; rerun the command
-to start over.
+The wizard validates the private-key path against the filesystem before calling GitHub, prints the
+list of reachable repositories with one-based numbers, and writes the resulting `config.json`. On
+EOF or invalid input the wizard exits with a one-line summary; rerun the command to start over.
 
 ## Copilot review
 

--- a/main.ts
+++ b/main.ts
@@ -16,7 +16,7 @@ import { ensureDir } from "@std/fs";
 import { dirname } from "@std/path";
 
 import { MAKINA_VERSION } from "./src/constants.ts";
-import { expandHome, loadConfig } from "./src/config/load.ts";
+import { ConfigLoadError, expandHome, loadConfig } from "./src/config/load.ts";
 import { startDaemon } from "./src/daemon/server.ts";
 import {
   createStdioWizardIo,
@@ -68,12 +68,18 @@ if (subcommand === "daemon") {
     // expands it before reading. The wizard writes to the same path, so
     // a successful `makina setup` is what populates this file.
     const config = await loadConfig(defaultConfigPath());
-    socketPath = config.daemon.socketPath;
+    // Per the loader's path-expansion contract, nested path fields
+    // (including `daemon.socketPath`) are returned verbatim — each
+    // consumer is responsible for expanding `~/` at its own boundary.
+    // This is that boundary: `Deno.listen({ transport: "unix", path })`
+    // would otherwise bind a literal `~/...` string.
+    socketPath = expandHome(config.daemon.socketPath);
   } catch (error) {
-    // `kind === "not-found"` is the "no setup yet" path; everything else
-    // is a real misconfiguration the operator must fix.
-    const kind = (error as { kind?: unknown }).kind;
-    if (kind === "not-found") {
+    // The "not-found" branch is the "no setup yet" path; everything
+    // else is a real misconfiguration the operator must fix. Narrow on
+    // `ConfigLoadError` first so an unrelated error that happens to
+    // expose a `kind` field cannot masquerade as a missing file.
+    if (error instanceof ConfigLoadError && error.kind === "not-found") {
       console.error(
         `[daemon] note: no config.json yet (run \`makina setup\`); using fallback socket ${socketPath}`,
       );

--- a/main.ts
+++ b/main.ts
@@ -117,10 +117,29 @@ if (subcommand === "daemon") {
   Deno.addSignalListener("SIGINT", shutdown);
   Deno.addSignalListener("SIGTERM", shutdown);
 } else if (subcommand === "setup") {
-  // Until [W2-github-app-auth] lands the real implementation, the wizard
-  // uses a stub that surfaces a clear "not yet implemented" message if
-  // the user hits this in production. The wizard's tests inject their
-  // own client; this stub never runs in tests.
+  // The interactive wizard is fully implemented; what is **not** yet
+  // wired in this PR is the App-level GitHub client that lists reachable
+  // installations. That client lands with [W2-github-app-auth] (issue #4)
+  // and the wizard already accepts it via injection. To avoid a UX where
+  // the user types the App ID and key path only to hit a "not
+  // implemented" error mid-flow, the subcommand gates itself behind the
+  // `MAKINA_ALLOW_WIZARD_STUB=1` env var until #4 lands. Without the
+  // flag we exit immediately with a pointer; with the flag the wizard
+  // runs and the stub surfaces a clear failure on the discovery step.
+  const allowStub = Deno.env.get("MAKINA_ALLOW_WIZARD_STUB") === "1";
+  if (!allowStub) {
+    console.error(
+      "makina setup is not yet usable: the GitHub App client is wired in #4.",
+    );
+    console.error(
+      "Track issue #4 ([W2-github-app-auth]); set MAKINA_ALLOW_WIZARD_STUB=1 to dry-run the wizard.",
+    );
+    Deno.exit(2);
+  }
+  // Stub used only for the `MAKINA_ALLOW_WIZARD_STUB=1` dry-run path. It
+  // throws on the discovery step so contributors can exercise the
+  // prompts without a real App client; the wizard's own tests inject
+  // their own client and never touch this code.
   const stubClient: WizardGitHubClient = {
     getInstallations(): Promise<readonly WizardInstallation[]> {
       throw new Error(

--- a/main.ts
+++ b/main.ts
@@ -16,7 +16,7 @@ import { ensureDir } from "@std/fs";
 import { dirname } from "@std/path";
 
 import { MAKINA_VERSION } from "./src/constants.ts";
-import { expandHome } from "./src/config/load.ts";
+import { expandHome, loadConfig } from "./src/config/load.ts";
 import { startDaemon } from "./src/daemon/server.ts";
 import {
   createStdioWizardIo,
@@ -37,46 +37,45 @@ const subcommand = Deno.args[0];
 if (subcommand === "daemon") {
   // Defensive wiring for the Wave 2 daemon subcommand.
   //
-  // The real config loader (#3) and EventBus (#8) may or may not be on
-  // `develop` when this branch lands; both are loaded via dynamic
-  // `import()` so a still-missing sibling does not block the daemon
-  // from starting. We carefully distinguish two outcomes:
+  // The config loader is now a direct import (this PR lands it). The
+  // EventBus (#8) is still loaded via dynamic `import()` because we
+  // distinguish two outcomes for *that* sibling:
   //
   //  1. **Module not found** (`ERR_MODULE_NOT_FOUND`): the sibling has
-  //     not landed yet. Log a single `note:` line so operators know we
-  //     fell back, then continue with:
-  //       - a hardcoded `${TMPDIR:-/tmp}/makina.sock` socket path so
-  //         the binary can boot for smoke-testing;
-  //       - no event bus, which makes `subscribe` envelopes ack with
-  //         `{ ok: false, error: "unimplemented" }` until #8 lands.
+  //     not landed yet. Log a single `note:` line and continue with no
+  //     event bus, which makes `subscribe` envelopes ack with
+  //     `{ ok: false, error: "unimplemented" }`.
   //  2. **Anything else** (parse failure, permission error, throwing
   //     constructor, …): a real misconfiguration. Print the diagnostic
   //     to stderr and exit non-zero. Silently swallowing these would
   //     mean a typo'd `config.json` boots a daemon on `/tmp/makina.sock`
   //     and the operator has no signal that anything went wrong.
   //
-  // TODO(#3): once #3 lands, the loadConfig branch is the only path —
-  // drop the module-missing fallback.
-  // TODO(#8): once #8 lands, the same applies to the event bus branch.
+  // For the loader, a missing user `config.json` is also a benign signal
+  // ("user has not run `makina setup` yet") — we log a one-liner and
+  // fall back to `${TMPDIR:-/tmp}/makina.sock` so the binary still boots
+  // for smoke-testing. Any other config failure (permissions, malformed
+  // JSON, schema-invalid) exits non-zero with the loader's diagnostic.
+  //
+  // TODO(#8): once #8 lands, the event-bus branch becomes a direct
+  // import and the module-missing fallback can be dropped.
   const tmpDir = Deno.env.get("TMPDIR") ?? "/tmp";
   const fallbackSocketPath = `${tmpDir.replace(/\/$/, "")}/makina.sock`;
 
   let socketPath = fallbackSocketPath;
   try {
-    const configModule = await import("./src/config/load.ts");
-    if (
-      typeof (configModule as { loadConfig?: unknown }).loadConfig === "function"
-    ) {
-      const loadConfig = (configModule as {
-        loadConfig: () => Promise<{ daemon: { socketPath: string } }>;
-      }).loadConfig;
-      const config = await loadConfig();
-      socketPath = config.daemon.socketPath;
-    }
+    // `defaultConfigPath()` returns a `~/`-prefixed string; the loader
+    // expands it before reading. The wizard writes to the same path, so
+    // a successful `makina setup` is what populates this file.
+    const config = await loadConfig(defaultConfigPath());
+    socketPath = config.daemon.socketPath;
   } catch (error) {
-    if (isModuleNotFoundError(error)) {
+    // `kind === "not-found"` is the "no setup yet" path; everything else
+    // is a real misconfiguration the operator must fix.
+    const kind = (error as { kind?: unknown }).kind;
+    if (kind === "not-found") {
       console.error(
-        `[daemon] note: src/config/load.ts not found; using fallback socket ${socketPath}`,
+        `[daemon] note: no config.json yet (run \`makina setup\`); using fallback socket ${socketPath}`,
       );
     } else {
       console.error(`[daemon] failed to load configuration: ${formatError(error)}`);
@@ -117,33 +116,21 @@ if (subcommand === "daemon") {
   Deno.addSignalListener("SIGINT", shutdown);
   Deno.addSignalListener("SIGTERM", shutdown);
 } else if (subcommand === "setup") {
-  // The interactive wizard is fully implemented; what is **not** yet
-  // wired in this PR is the App-level GitHub client that lists reachable
-  // installations. That client lands with [W2-github-app-auth] (issue #4)
-  // and the wizard already accepts it via injection. To avoid a UX where
-  // the user types the App ID and key path only to hit a "not
-  // implemented" error mid-flow, the subcommand gates itself behind the
-  // `MAKINA_ALLOW_WIZARD_STUB=1` env var until #4 lands. Without the
-  // flag we exit immediately with a pointer; with the flag the wizard
-  // runs and the stub surfaces a clear failure on the discovery step.
-  const allowStub = Deno.env.get("MAKINA_ALLOW_WIZARD_STUB") === "1";
-  if (!allowStub) {
-    console.error(
-      "makina setup is not yet usable: the GitHub App client is wired in #4.",
-    );
-    console.error(
-      "Track issue #4 ([W2-github-app-auth]); set MAKINA_ALLOW_WIZARD_STUB=1 to dry-run the wizard.",
-    );
-    Deno.exit(2);
-  }
-  // Stub used only for the `MAKINA_ALLOW_WIZARD_STUB=1` dry-run path. It
-  // throws on the discovery step so contributors can exercise the
-  // prompts without a real App client; the wizard's own tests inject
-  // their own client and never touch this code.
+  // The interactive wizard is fully implemented and runs unconditionally.
+  // What is **not** yet wired in this PR is the App-level GitHub client
+  // that lists reachable installations; that lands with
+  // [W2-github-app-auth] (issue #4). Until then, the wizard fails with a
+  // clear "not yet implemented" message at the discovery step — the user
+  // has typed their App ID and key path, but they get a single-line
+  // diagnostic pointing at #4 rather than a stack trace.
+  //
+  // The wizard's own tests inject their own `WizardGitHubClient` and
+  // never touch this code path; the in-memory doubles are isolated from
+  // production wiring by design.
   const stubClient: WizardGitHubClient = {
     getInstallations(): Promise<readonly WizardInstallation[]> {
       throw new Error(
-        "Real GitHub App client is not yet wired. Track [W2-github-app-auth] (issue #4).",
+        "GitHub App auth not yet implemented (#4 — [W2-github-app-auth]).",
       );
     },
   };

--- a/main.ts
+++ b/main.ts
@@ -6,16 +6,26 @@
  * Wave 2 branches land:
  *
  * - `daemon` — long-running supervisor (#9), already on develop.
- * - `setup` — first-run GitHub-App configuration wizard (#3), still in
- *   review on `feature/w2-config-loader`. Until that lands, the
- *   subcommand prints a notice instead of falling through to the TUI.
+ * - `setup` — first-run GitHub-App configuration wizard (#3), this PR.
  * - default → launch the Ink TUI (#10).
  *
  * The version constant is the single source of truth in `src/constants.ts`.
  */
 
+import { ensureDir } from "@std/fs";
+import { dirname } from "@std/path";
+
 import { MAKINA_VERSION } from "./src/constants.ts";
+import { expandHome } from "./src/config/load.ts";
 import { startDaemon } from "./src/daemon/server.ts";
+import {
+  createStdioWizardIo,
+  defaultConfigPath,
+  runSetupWizard,
+  SetupWizardError,
+  type WizardGitHubClient,
+  type WizardInstallation,
+} from "./src/config/setup-wizard.ts";
 
 if (Deno.args.includes("--version")) {
   console.log(MAKINA_VERSION);
@@ -107,11 +117,31 @@ if (subcommand === "daemon") {
   Deno.addSignalListener("SIGINT", shutdown);
   Deno.addSignalListener("SIGTERM", shutdown);
 } else if (subcommand === "setup") {
-  // Owned by the `feature/w2-config-loader` branch (#3); still in review.
-  // Until it merges, the subcommand prints a notice instead of falling
-  // through to the TUI launch path.
-  console.log("`setup` subcommand is not yet wired on develop (tracked in #3).");
-  Deno.exit(0);
+  // Until [W2-github-app-auth] lands the real implementation, the wizard
+  // uses a stub that surfaces a clear "not yet implemented" message if
+  // the user hits this in production. The wizard's tests inject their
+  // own client; this stub never runs in tests.
+  const stubClient: WizardGitHubClient = {
+    getInstallations(): Promise<readonly WizardInstallation[]> {
+      throw new Error(
+        "Real GitHub App client is not yet wired. Track [W2-github-app-auth] (issue #4).",
+      );
+    },
+  };
+  try {
+    const config = await runSetupWizard(createStdioWizardIo(stubClient));
+    const targetPath = expandHome(defaultConfigPath());
+    await ensureDir(dirname(targetPath));
+    await Deno.writeTextFile(targetPath, `${JSON.stringify(config, null, 2)}\n`);
+    console.log(`Wrote ${targetPath}.`);
+    Deno.exit(0);
+  } catch (error) {
+    if (error instanceof SetupWizardError) {
+      console.error(`setup failed: ${error.message}`);
+      Deno.exit(1);
+    }
+    throw error;
+  }
 } else {
   // Default branch → launch the Ink-based TUI.
   await import("./src/tui/App.tsx").then((module) => module.launch());

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -73,6 +73,8 @@ export class ConfigLoadError extends Error {
   readonly issues: readonly ConfigValidationIssue[];
 
   /**
+   * Construct a config-load error.
+   *
    * @param kind Failure mode discriminator.
    * @param resolvedPath The path the loader actually tried to read.
    * @param message Human-readable summary; rendered verbatim by the

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -21,15 +21,23 @@
  *
  * The loader expands `~/` **only on the path it is asked to read**. The
  * other path fields inside the config (`github.privateKeyPath`,
- * `daemon.socketPath`, `workspace`) are returned **verbatim**. Each
- * consumer is responsible for calling {@link expandHome} at the
- * boundary it cares about (the daemon expands `socketPath` before
- * binding; the GitHub App client will expand `privateKeyPath` before
- * opening the file; the wizard expands `privateKeyPath` for an
- * existence check before persisting). This keeps `config.json`
- * portable across machines belonging to the same user, even when
- * `$HOME` differs. `src/config/schema.ts`'s field-level docs reflect
- * this contract.
+ * `daemon.socketPath`, `workspace`) are returned **verbatim**. Any
+ * code that consumes those nested path fields must decide at its own
+ * boundary whether to call {@link expandHome} before using them.
+ * Concretely, in this repo:
+ *
+ *  - `main.ts`'s `daemon` branch calls {@link expandHome} on
+ *    `config.daemon.socketPath` before passing it to `startDaemon` so
+ *    `Deno.listen` never sees a literal `~/` path.
+ *  - The wizard expands `github.privateKeyPath` for an existence check
+ *    but persists the raw `~/`-prefixed string the user typed so the
+ *    on-disk `config.json` stays portable across machines.
+ *  - The production `WizardGitHubClient` (#4) and the future
+ *    `workspace` consumer (#7) expand at their own boundaries.
+ *
+ * This keeps `config.json` portable across machines belonging to the
+ * same user, even when `$HOME` differs. `src/config/schema.ts`'s
+ * field-level docs reflect this contract.
  *
  * @module
  */

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -1,0 +1,241 @@
+/**
+ * config/load.ts — file IO and validation for the user's `config.json`.
+ *
+ * Wave 1's `src/config/schema.ts` froze the typed shape; this module is
+ * the only place Wave 2+ reads the file from disk. The loader:
+ *
+ * 1. Expands a single leading `~/` to the user's home directory.
+ * 2. Reads the file (UTF-8, JSON-with-comments tolerant via
+ *    {@link "@std/jsonc"}).
+ * 3. Pipes the parsed value through {@link parseConfig} so the caller
+ *    receives the typed {@link Config}.
+ *
+ * Errors are surfaced as a {@link ConfigLoadError} whose `message`
+ * embeds the failing field path (`github.appId`, `lifecycle.mergeMode`,
+ * …) so the daemon and the TUI can render them verbatim. The error
+ * exposes structured `issues` for callers that want to render their own
+ * formatting.
+ *
+ * The loader intentionally does **not** expand `~/` recursively or
+ * touch other paths inside the config (e.g. `github.privateKeyPath`,
+ * `daemon.socketPath`, `workspace`). Each consumer expands the paths
+ * relevant to it; the convention keeps config text human-readable.
+ *
+ * @module
+ */
+
+import * as jsonc from "@std/jsonc";
+
+import { type Config, type ConfigValidationIssue, parseConfig } from "./schema.ts";
+
+/**
+ * Reason a {@link loadConfig} call failed.
+ *
+ * - `not-found`: the file at the resolved path does not exist.
+ * - `read-failed`: the file exists but could not be read (permissions,
+ *   IO error, …).
+ * - `invalid-json`: the file exists but is not valid JSONC.
+ * - `invalid-schema`: parsed JSON did not satisfy the
+ *   {@link Config} schema; `issues` carries the per-field problems.
+ */
+export type ConfigLoadFailureKind =
+  | "not-found"
+  | "read-failed"
+  | "invalid-json"
+  | "invalid-schema";
+
+/**
+ * Error thrown by {@link loadConfig} when the file cannot be loaded.
+ *
+ * `message` always begins with the resolved path, then a one-line
+ * summary, and (for `invalid-schema`) lists every failing field as
+ * `<path>: <message>`. Catch sites can read `kind` to branch.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   const config = await loadConfig("~/.config/makina/config.json");
+ * } catch (error) {
+ *   if (error instanceof ConfigLoadError && error.kind === "not-found") {
+ *     console.error("No config; run `makina setup` first.");
+ *     Deno.exit(1);
+ *   }
+ *   throw error;
+ * }
+ * ```
+ */
+export class ConfigLoadError extends Error {
+  /** Discriminator for the failure mode. */
+  readonly kind: ConfigLoadFailureKind;
+  /** Filesystem path the loader attempted to read (post-`~/` expansion). */
+  readonly resolvedPath: string;
+  /** Per-field validation problems, when `kind === "invalid-schema"`. */
+  readonly issues: readonly ConfigValidationIssue[];
+
+  /**
+   * @param kind Failure mode discriminator.
+   * @param resolvedPath The path the loader actually tried to read.
+   * @param message Human-readable summary; rendered verbatim by the
+   *   TUI / daemon.
+   * @param issues Field-level validation problems
+   *   (empty unless `kind === "invalid-schema"`).
+   */
+  constructor(
+    kind: ConfigLoadFailureKind,
+    resolvedPath: string,
+    message: string,
+    issues: readonly ConfigValidationIssue[] = [],
+  ) {
+    super(message);
+    this.name = "ConfigLoadError";
+    this.kind = kind;
+    this.resolvedPath = resolvedPath;
+    this.issues = issues;
+  }
+}
+
+/**
+ * Expand a single leading `~/` into the user's home directory.
+ *
+ * Mirrors POSIX shell behavior: `~` (alone) and `~/` resolve to
+ * `$HOME`. Anything else (`./foo`, `/abs`, `~user/...`) is returned
+ * unchanged — Wave 1 does not promise to expand `~user`.
+ *
+ * Throws when the input begins with `~/` but no home directory can be
+ * resolved (the loader callers all have a home, so this manifests only
+ * in misconfigured environments).
+ *
+ * @param path Candidate path, possibly beginning with `~/`.
+ * @returns The expanded path.
+ * @throws Error when `~/` cannot be expanded because no home directory is
+ *   configured.
+ *
+ * @example
+ * ```ts
+ * expandHome("~/.config/makina/config.json"); // → "/Users/me/.config/makina/config.json"
+ * expandHome("/etc/makina/config.json");      // → "/etc/makina/config.json"
+ * ```
+ */
+export function expandHome(path: string): string {
+  if (path === "~") {
+    return resolveHome();
+  }
+  if (path.startsWith("~/")) {
+    return joinHome(path.slice(2));
+  }
+  return path;
+}
+
+function resolveHome(): string {
+  const home = Deno.env.get("HOME") ?? Deno.env.get("USERPROFILE");
+  if (home === undefined || home.length === 0) {
+    throw new Error(
+      "cannot expand ~/: neither $HOME nor %USERPROFILE% is set",
+    );
+  }
+  return home;
+}
+
+function joinHome(rest: string): string {
+  const home = resolveHome();
+  // The home dir typically lacks a trailing slash. Strip a leading slash
+  // from `rest` before joining so we never produce `//`.
+  const trimmedRest = rest.startsWith("/") ? rest.slice(1) : rest;
+  return home.endsWith("/") ? `${home}${trimmedRest}` : `${home}/${trimmedRest}`;
+}
+
+/**
+ * Read, parse, and validate the user's `config.json`.
+ *
+ * The loader reads the file at `path` (after expanding a single leading
+ * `~/`), parses it as JSONC (so `// line comments` and trailing commas
+ * are tolerated), and passes the resulting value through
+ * {@link parseConfig}. On failure it raises a {@link ConfigLoadError}
+ * whose `kind` lets callers branch (missing-file vs. malformed-JSON vs.
+ * schema-invalid).
+ *
+ * @param path The config file path. May begin with `~/`.
+ * @returns The validated, typed {@link Config}.
+ * @throws {ConfigLoadError} for any failure to load.
+ *
+ * @example
+ * ```ts
+ * const config = await loadConfig("~/.config/makina/config.json");
+ * console.log(config.github.defaultRepo);
+ * ```
+ */
+export async function loadConfig(path: string): Promise<Config> {
+  const resolvedPath = expandHome(path);
+
+  let text: string;
+  try {
+    text = await Deno.readTextFile(resolvedPath);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      throw new ConfigLoadError(
+        "not-found",
+        resolvedPath,
+        `config file not found: ${resolvedPath}`,
+      );
+    }
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new ConfigLoadError(
+      "read-failed",
+      resolvedPath,
+      `failed to read config file ${resolvedPath}: ${reason}`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = jsonc.parse(text);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new ConfigLoadError(
+      "invalid-json",
+      resolvedPath,
+      `config file ${resolvedPath} is not valid JSON/JSONC: ${reason}`,
+    );
+  }
+
+  const result = parseConfig(parsed);
+  if (!result.success) {
+    const summary = result.issues
+      .map((issue) => `  - ${formatIssuePath(issue.path)}: ${issue.message}`)
+      .join("\n");
+    throw new ConfigLoadError(
+      "invalid-schema",
+      resolvedPath,
+      `config file ${resolvedPath} failed validation:\n${summary}`,
+      result.issues,
+    );
+  }
+
+  return result.data;
+}
+
+/**
+ * Render a zod path as a dotted string, falling back to bracketed
+ * notation for numeric indices.
+ *
+ * @param path The zod issue path.
+ * @returns A human-readable rendering, e.g. `github.installations["a/b"]`.
+ */
+function formatIssuePath(path: readonly (string | number)[]): string {
+  if (path.length === 0) {
+    return "<root>";
+  }
+  let rendered = "";
+  for (const segment of path) {
+    if (typeof segment === "number") {
+      rendered += `[${segment}]`;
+    } else if (rendered.length === 0) {
+      rendered = segment;
+    } else if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(segment)) {
+      rendered += `.${segment}`;
+    } else {
+      rendered += `[${JSON.stringify(segment)}]`;
+    }
+  }
+  return rendered;
+}

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -4,7 +4,8 @@
  * Wave 1's `src/config/schema.ts` froze the typed shape; this module is
  * the only place Wave 2+ reads the file from disk. The loader:
  *
- * 1. Expands a single leading `~/` to the user's home directory.
+ * 1. Expands a single leading `~/` on the **config path argument** to
+ *    {@link loadConfig} so callers can pass `~/.config/makina/...`.
  * 2. Reads the file (UTF-8, JSON-with-comments tolerant via
  *    {@link "@std/jsonc"}).
  * 3. Pipes the parsed value through {@link parseConfig} so the caller
@@ -16,10 +17,19 @@
  * exposes structured `issues` for callers that want to render their own
  * formatting.
  *
- * The loader intentionally does **not** expand `~/` recursively or
- * touch other paths inside the config (e.g. `github.privateKeyPath`,
- * `daemon.socketPath`, `workspace`). Each consumer expands the paths
- * relevant to it; the convention keeps config text human-readable.
+ * ## Path-expansion contract
+ *
+ * The loader expands `~/` **only on the path it is asked to read**. The
+ * other path fields inside the config (`github.privateKeyPath`,
+ * `daemon.socketPath`, `workspace`) are returned **verbatim**. Each
+ * consumer is responsible for calling {@link expandHome} at the
+ * boundary it cares about (the daemon expands `socketPath` before
+ * binding; the GitHub App client will expand `privateKeyPath` before
+ * opening the file; the wizard expands `privateKeyPath` for an
+ * existence check before persisting). This keeps `config.json`
+ * portable across machines belonging to the same user, even when
+ * `$HOME` differs. `src/config/schema.ts`'s field-level docs reflect
+ * this contract.
  *
  * @module
  */
@@ -27,6 +37,26 @@
 import * as jsonc from "@std/jsonc";
 
 import { type Config, type ConfigValidationIssue, parseConfig } from "./schema.ts";
+import { HOME_PREFIX } from "../constants.ts";
+
+/**
+ * Read a single environment variable.
+ *
+ * Tests inject a custom `EnvLookup` (typically backed by a per-test
+ * `Map`) so the suite can run with `--parallel` without mutating
+ * `Deno.env` and racing with sibling tests. Production code passes
+ * {@link defaultEnvLookup}, which delegates to `Deno.env.get`.
+ */
+export type EnvLookup = (name: string) => string | undefined;
+
+/**
+ * Production-time {@link EnvLookup}. Reads through to `Deno.env.get`.
+ *
+ * Exported so tests that need to scope env access for a single call can
+ * compose against it, but most callers (including {@link loadConfig} and
+ * {@link expandHome}) accept this as the implicit default.
+ */
+export const defaultEnvLookup: EnvLookup = (name: string): string | undefined => Deno.env.get(name);
 
 /**
  * Reason a {@link loadConfig} call failed.
@@ -47,9 +77,11 @@ export type ConfigLoadFailureKind =
 /**
  * Error thrown by {@link loadConfig} when the file cannot be loaded.
  *
- * `message` always begins with the resolved path, then a one-line
- * summary, and (for `invalid-schema`) lists every failing field as
- * `<path>: <message>`. Catch sites can read `kind` to branch.
+ * The `message` is a single-line summary that **embeds the resolved
+ * path** (e.g. `"config file /home/u/.config/makina/config.json not
+ * found"`) and, for `invalid-schema`, then lists every failing field as
+ * `  - <path>: <message>` on subsequent lines. Catch sites can read
+ * `kind` to branch and `resolvedPath` for a clean unformatted path.
  *
  * @example
  * ```ts
@@ -108,6 +140,11 @@ export class ConfigLoadError extends Error {
  * in misconfigured environments).
  *
  * @param path Candidate path, possibly beginning with `~/`.
+ * @param envLookup Optional env reader for `$HOME`. Tests pass a
+ *   per-test stub so they can run with `deno test --parallel` without
+ *   mutating `Deno.env` and racing with sibling tests; production
+ *   callers omit the argument and the function falls back to
+ *   {@link defaultEnvLookup} (a thin wrapper around `Deno.env.get`).
  * @returns The expanded path.
  * @throws Error when `~/` cannot be expanded because no home directory is
  *   configured.
@@ -118,20 +155,23 @@ export class ConfigLoadError extends Error {
  * expandHome("/etc/makina/config.json");      // → "/etc/makina/config.json"
  * ```
  */
-export function expandHome(path: string): string {
+export function expandHome(
+  path: string,
+  envLookup: EnvLookup = defaultEnvLookup,
+): string {
   if (path === "~") {
-    return resolveHome();
+    return resolveHome(envLookup);
   }
-  if (path.startsWith("~/")) {
-    return joinHome(path.slice(2));
+  if (path.startsWith(HOME_PREFIX)) {
+    return joinHome(path.slice(HOME_PREFIX.length), envLookup);
   }
   return path;
 }
 
-function resolveHome(): string {
+function resolveHome(envLookup: EnvLookup): string {
   // ADR-008 defers Windows: only POSIX `$HOME` is supported. WSL2 users
   // have a `$HOME` like any other Linux env, so this still covers them.
-  const home = Deno.env.get("HOME");
+  const home = envLookup("HOME");
   if (home === undefined || home.length === 0) {
     throw new Error(
       "cannot expand ~/: $HOME is not set",
@@ -140,8 +180,8 @@ function resolveHome(): string {
   return home;
 }
 
-function joinHome(rest: string): string {
-  const home = resolveHome();
+function joinHome(rest: string, envLookup: EnvLookup): string {
+  const home = resolveHome(envLookup);
   // The home dir typically lacks a trailing slash. Strip a leading slash
   // from `rest` before joining so we never produce `//`.
   const trimmedRest = rest.startsWith("/") ? rest.slice(1) : rest;
@@ -159,6 +199,9 @@ function joinHome(rest: string): string {
  * schema-invalid).
  *
  * @param path The config file path. May begin with `~/`.
+ * @param envLookup Optional env reader for `$HOME`. Tests pass a
+ *   per-test stub; production callers omit the argument and the loader
+ *   falls back to `Deno.env.get`.
  * @returns The validated, typed {@link Config}.
  * @throws {ConfigLoadError} for any failure to load.
  *
@@ -168,8 +211,11 @@ function joinHome(rest: string): string {
  * console.log(config.github.defaultRepo);
  * ```
  */
-export async function loadConfig(path: string): Promise<Config> {
-  const resolvedPath = expandHome(path);
+export async function loadConfig(
+  path: string,
+  envLookup: EnvLookup = defaultEnvLookup,
+): Promise<Config> {
+  const resolvedPath = expandHome(path, envLookup);
 
   let text: string;
   try {

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -129,10 +129,12 @@ export function expandHome(path: string): string {
 }
 
 function resolveHome(): string {
-  const home = Deno.env.get("HOME") ?? Deno.env.get("USERPROFILE");
+  // ADR-008 defers Windows: only POSIX `$HOME` is supported. WSL2 users
+  // have a `$HOME` like any other Linux env, so this still covers them.
+  const home = Deno.env.get("HOME");
   if (home === undefined || home.length === 0) {
     throw new Error(
-      "cannot expand ~/: neither $HOME nor %USERPROFILE% is set",
+      "cannot expand ~/: $HOME is not set",
     );
   }
   return home;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -55,7 +55,10 @@ export interface GitHubConfig {
   readonly appId: number;
   /**
    * Filesystem path to the App's downloaded private key (PEM). May begin
-   * with `~/`; expansion happens in the loader.
+   * with `~/`; expansion happens at the consumer boundary (the GitHub
+   * App client expands before opening the file). The loader returns
+   * this string verbatim — see `src/config/load.ts` for the
+   * path-expansion contract.
    */
   readonly privateKeyPath: string;
   /**
@@ -113,7 +116,9 @@ export interface LifecycleConfig {
 export interface DaemonConfig {
   /**
    * Filesystem path of the Unix-domain socket. May begin with `~/`;
-   * expansion happens in the loader.
+   * expansion happens at the consumer boundary (the daemon expands
+   * before binding). The loader returns this string verbatim — see
+   * `src/config/load.ts` for the path-expansion contract.
    */
   readonly socketPath: string;
   /**
@@ -155,8 +160,10 @@ export interface Config {
   readonly lifecycle: LifecycleConfig;
   /**
    * Filesystem path under which makina creates per-repo bare clones and
-   * per-task worktrees. May begin with `~/`; expansion happens in the
-   * loader.
+   * per-task worktrees. May begin with `~/`; expansion happens at the
+   * consumer boundary (the worktree manager expands before creating
+   * directories). The loader returns this string verbatim — see
+   * `src/config/load.ts` for the path-expansion contract.
    */
   readonly workspace: string;
   /** Daemon process. */

--- a/src/config/setup-wizard.ts
+++ b/src/config/setup-wizard.ts
@@ -1,0 +1,498 @@
+/**
+ * config/setup-wizard.ts — interactive `makina setup` wizard.
+ *
+ * Walks a first-time user through the four pieces of state that cannot
+ * be defaulted: the GitHub App id, the path to its private key, the
+ * installation ids granting access to each repository, and which
+ * repository is the default. The remaining config is filled with the
+ * documented defaults from {@link "../constants.ts"}.
+ *
+ * The wizard's collaborators (stdin reader, stdout writer, and the
+ * narrow GitHub client used for installation discovery) are
+ * **injected** so the integration test in
+ * `tests/integration/setup_wizard_test.ts` can drive a scripted
+ * conversation against the in-memory GitHub client without touching a
+ * real terminal or real network. `runSetupWizard` is therefore a pure
+ * orchestrator over `io`; the production `setup` subcommand assembles
+ * an `io` from `Deno.stdin`, `Deno.stdout`, and the real GitHub App
+ * client.
+ *
+ * Side-effects the wizard intentionally avoids:
+ *   - It does **not** write the resulting config to disk; the caller
+ *     decides where (the `setup` subcommand in `main.ts` writes to the
+ *     platform-appropriate path).
+ *   - It does **not** authenticate to GitHub. App-auth is `[W2-github-app-auth]`;
+ *     the wizard only invokes the App-level installation listing, which
+ *     `src/github/app-auth.ts` will eventually expose to it.
+ *
+ * @module
+ */
+
+import { exists } from "@std/fs";
+
+import { type Config, type GitHubConfig, parseConfig } from "./schema.ts";
+import { expandHome } from "./load.ts";
+import {
+  MAX_TASK_ITERATIONS,
+  POLL_INTERVAL_MILLISECONDS,
+  SETTLING_WINDOW_MILLISECONDS,
+} from "../constants.ts";
+
+/**
+ * One installation reachable from the GitHub App.
+ *
+ * Returned by {@link WizardGitHubClient.getInstallations}. The fields
+ * mirror what the wizard needs to render a numbered picker: the
+ * `installationId` is the integer the API uses to mint installation
+ * tokens, and `repositories` is the set of `<owner/repo>` slugs the
+ * installation grants access to.
+ */
+export interface WizardInstallation {
+  /** The numeric installation id used by `POST /app/installations/{id}/access_tokens`. */
+  readonly installationId: number;
+  /** The repositories this installation can act on, as `<owner>/<name>` strings. */
+  readonly repositories: readonly string[];
+}
+
+/**
+ * Narrow, wizard-only GitHub client surface.
+ *
+ * The full {@link "../types.ts".GitHubClient} contract is per-installation
+ * (it expects an installation token); the wizard runs **before** any
+ * installation is selected, so it needs an App-level call to discover
+ * installations. We declare a separate one-method surface here rather
+ * than widen the consumer-facing client.
+ *
+ * Wave 2's `src/github/app-auth.ts` (issue `[W2-github-app-auth]`)
+ * provides the production implementation against the GitHub App's
+ * `GET /app/installations` endpoint. The wizard's tests stub this
+ * directly.
+ */
+export interface WizardGitHubClient {
+  /**
+   * List every installation reachable from the configured App.
+   *
+   * @param args App credentials needed to mint the App JWT.
+   * @returns Every reachable installation along with the repositories it
+   *   grants access to. Returns an empty array if the App is not
+   *   installed anywhere.
+   */
+  getInstallations(args: {
+    readonly appId: number;
+    readonly privateKeyPath: string;
+  }): Promise<readonly WizardInstallation[]>;
+}
+
+/**
+ * Read one logical line of input.
+ *
+ * Returns the line **without** the trailing newline. A return of
+ * `null` is treated as EOF and aborts the wizard with a helpful
+ * message; production code wires this to a `TextLineStream`-backed
+ * reader.
+ */
+export type ReadLine = () => Promise<string | null>;
+
+/** Write one chunk of output (a prompt or a status line). */
+export type WriteLine = (text: string) => Promise<void> | void;
+
+/**
+ * Injected collaborators for {@link runSetupWizard}.
+ *
+ * Tests pass scripted readers and a mock GitHub client; production
+ * code wires `Deno.stdin`, `Deno.stdout`, and the real App client.
+ */
+export interface SetupWizardIo {
+  /** Read one line from the user (no trailing newline). */
+  readonly readLine: ReadLine;
+  /** Write one chunk of output (the wizard adds its own newline). */
+  readonly writeLine: WriteLine;
+  /** GitHub client for App-level installation discovery. */
+  readonly githubClient: WizardGitHubClient;
+}
+
+/**
+ * Error raised when the wizard cannot complete.
+ *
+ * Distinguished from generic `Error` so the `setup` subcommand can
+ * print a tidy single-line summary instead of a stack trace.
+ */
+export class SetupWizardError extends Error {
+  /**
+   * @param message Human-readable description of the failure.
+   */
+  constructor(message: string) {
+    super(message);
+    this.name = "SetupWizardError";
+  }
+}
+
+/**
+ * Run the interactive `setup` wizard against the supplied IO.
+ *
+ * Sequence:
+ *   1. Prompt for the App ID (positive integer).
+ *   2. Prompt for the private-key path (must exist on disk; `~/`
+ *      expansion happens here so the user can paste the literal path
+ *      they kept the file at).
+ *   3. Call `githubClient.getInstallations(...)`.
+ *   4. Render every accessible repository with a number; prompt for the
+ *      default repo selection.
+ *   5. Build a {@link Config} from the answers + defaults and revalidate
+ *      it through {@link parseConfig} so the returned object is
+ *      indistinguishable from one loaded from disk.
+ *
+ * @param io Injected collaborators. Tests pass scripted versions; the
+ *   `setup` subcommand wires real stdin/stdout and the App client.
+ * @returns The validated {@link Config}. The caller is responsible for
+ *   writing it to the platform-appropriate path.
+ * @throws {SetupWizardError} on user error (bad input, missing key, no
+ *   installations, EOF on stdin).
+ *
+ * @example
+ * ```ts
+ * const config = await runSetupWizard({
+ *   readLine: scriptedLines(["1234567", "/tmp/key.pem", "1"]),
+ *   writeLine: (text) => { capturedOutput.push(text); },
+ *   githubClient: stubClient,
+ * });
+ * await Deno.writeTextFile(configPath, JSON.stringify(config, null, 2));
+ * ```
+ */
+export async function runSetupWizard(io: SetupWizardIo): Promise<Config> {
+  await io.writeLine("makina setup — first-run configuration wizard");
+  await io.writeLine("");
+  await io.writeLine(
+    "This walks through the GitHub App connection. See docs/setup-github-app.md",
+  );
+  await io.writeLine("for details on creating the App itself.");
+  await io.writeLine("");
+
+  const appId = await promptAppId(io);
+  const privateKeyPath = await promptPrivateKeyPath(io);
+  const installations = await fetchInstallations(io, appId, privateKeyPath);
+  const repoChoices = collectRepositoryChoices(installations);
+  if (repoChoices.length === 0) {
+    throw new SetupWizardError(
+      "no repositories reachable: install the App on at least one repo (see docs/setup-github-app.md) and rerun `makina setup`.",
+    );
+  }
+  const defaultRepo = await promptDefaultRepo(io, repoChoices);
+
+  const installationsRecord = repoChoicesToRecord(repoChoices);
+  const candidate = buildConfig({
+    appId,
+    privateKeyPath,
+    installations: installationsRecord,
+    defaultRepo,
+  });
+
+  const parsed = parseConfig(candidate);
+  if (!parsed.success) {
+    const summary = parsed.issues
+      .map((issue) => `  - ${issue.path.join(".")}: ${issue.message}`)
+      .join("\n");
+    throw new SetupWizardError(
+      `internal error: wizard produced an invalid config:\n${summary}`,
+    );
+  }
+
+  await io.writeLine("");
+  await io.writeLine(
+    `Done. Default repo: ${defaultRepo}; ${repoChoices.length} repository(ies) wired up.`,
+  );
+  return parsed.data;
+}
+
+/**
+ * Build the production-time {@link SetupWizardIo} backed by `Deno.stdin`,
+ * `Deno.stdout`, and the supplied GitHub client.
+ *
+ * Kept separate from {@link runSetupWizard} so tests never import a
+ * stdin-touching helper; the `setup` subcommand assembles its `io`
+ * here.
+ *
+ * @param githubClient The wizard-only GitHub client (typically backed by
+ *   `src/github/app-auth.ts`).
+ * @returns A live IO bundle suitable for {@link runSetupWizard}.
+ */
+export function createStdioWizardIo(
+  githubClient: WizardGitHubClient,
+): SetupWizardIo {
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let buffer = "";
+  let eof = false;
+  const readChunkBytes = 1_024;
+
+  const readLine: ReadLine = async () => {
+    while (true) {
+      const newlineIndex = buffer.indexOf("\n");
+      if (newlineIndex !== -1) {
+        const line = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        // Strip a trailing CR so Windows-style stdin behaves like *nix.
+        return line.endsWith("\r") ? line.slice(0, -1) : line;
+      }
+      if (eof) {
+        if (buffer.length === 0) {
+          return null;
+        }
+        const remainder = buffer;
+        buffer = "";
+        return remainder.endsWith("\r") ? remainder.slice(0, -1) : remainder;
+      }
+      const chunk = new Uint8Array(readChunkBytes);
+      const bytesRead = await Deno.stdin.read(chunk);
+      if (bytesRead === null) {
+        eof = true;
+        continue;
+      }
+      buffer += decoder.decode(chunk.subarray(0, bytesRead), { stream: true });
+    }
+  };
+
+  const writeLine: WriteLine = async (text: string) => {
+    await Deno.stdout.write(encoder.encode(`${text}\n`));
+  };
+
+  return { readLine, writeLine, githubClient };
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+async function promptAppId(io: SetupWizardIo): Promise<number> {
+  await io.writeLine("GitHub App ID (integer printed at the top of the App settings page):");
+  const raw = await readRequiredLine(io, "App ID");
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed < 1 || `${parsed}` !== raw) {
+    throw new SetupWizardError(
+      `invalid App ID ${JSON.stringify(raw)}: expected a positive integer`,
+    );
+  }
+  return parsed;
+}
+
+async function promptPrivateKeyPath(io: SetupWizardIo): Promise<string> {
+  await io.writeLine("");
+  await io.writeLine("Path to the App's private key (PEM). May begin with ~/.");
+  const raw = await readRequiredLine(io, "Private-key path");
+  const expanded = expandHome(raw);
+  const found = await exists(expanded, { isFile: true });
+  if (!found) {
+    throw new SetupWizardError(
+      `private key not found at ${expanded}. Re-run after saving the .pem there.`,
+    );
+  }
+  // Persist the user-provided form (still possibly containing ~/) so the
+  // file stays portable across machines.
+  return raw;
+}
+
+async function fetchInstallations(
+  io: SetupWizardIo,
+  appId: number,
+  privateKeyPath: string,
+): Promise<readonly WizardInstallation[]> {
+  await io.writeLine("");
+  await io.writeLine("Discovering installations...");
+  let installations: readonly WizardInstallation[];
+  try {
+    installations = await io.githubClient.getInstallations({
+      appId,
+      privateKeyPath,
+    });
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new SetupWizardError(
+      `failed to list installations: ${reason}`,
+    );
+  }
+  if (installations.length === 0) {
+    throw new SetupWizardError(
+      "the App is not installed anywhere. Install it on at least one repo (see docs/setup-github-app.md) and rerun `makina setup`.",
+    );
+  }
+  return installations;
+}
+
+interface RepoChoice {
+  readonly repo: string;
+  readonly installationId: number;
+}
+
+function collectRepositoryChoices(
+  installations: readonly WizardInstallation[],
+): readonly RepoChoice[] {
+  // Flatten installation × repository into a single picker. If the same
+  // repo appears under multiple installations the first one wins; the
+  // wizard logs a note rather than failing because that mostly happens
+  // when a personal install and an org install overlap.
+  const seen = new Set<string>();
+  const choices: RepoChoice[] = [];
+  for (const installation of installations) {
+    for (const repo of installation.repositories) {
+      if (seen.has(repo)) {
+        continue;
+      }
+      seen.add(repo);
+      choices.push({ repo, installationId: installation.installationId });
+    }
+  }
+  return choices;
+}
+
+function repoChoicesToRecord(
+  choices: readonly RepoChoice[],
+): Record<string, number> {
+  const record: Record<string, number> = {};
+  for (const choice of choices) {
+    record[choice.repo] = choice.installationId;
+  }
+  return record;
+}
+
+async function promptDefaultRepo(
+  io: SetupWizardIo,
+  choices: readonly RepoChoice[],
+): Promise<string> {
+  await io.writeLine("");
+  await io.writeLine("Reachable repositories:");
+  choices.forEach((choice, index) => {
+    // Wizard picker numbers are one-based — easier to type at a prompt.
+    const label = `  ${index + 1}. ${choice.repo}`;
+    void io.writeLine(label);
+  });
+  await io.writeLine("");
+  await io.writeLine(
+    `Pick the default repository (1-${choices.length}). Slash commands without an explicit [owner/repo] target this one.`,
+  );
+  const raw = await readRequiredLine(io, "Default repo");
+  const numeric = Number.parseInt(raw, 10);
+  if (!Number.isInteger(numeric) || `${numeric}` !== raw) {
+    throw new SetupWizardError(
+      `invalid choice ${JSON.stringify(raw)}: expected a number between 1 and ${choices.length}.`,
+    );
+  }
+  if (numeric < 1 || numeric > choices.length) {
+    throw new SetupWizardError(
+      `choice ${numeric} is out of range; pick between 1 and ${choices.length}.`,
+    );
+  }
+  // numeric is 1..choices.length so the lookup is safe; the helper exists
+  // to satisfy noUncheckedIndexedAccess.
+  const chosen = choices[numeric - 1];
+  if (chosen === undefined) {
+    throw new SetupWizardError("internal error: out-of-range repository choice");
+  }
+  return chosen.repo;
+}
+
+async function readRequiredLine(io: SetupWizardIo, label: string): Promise<string> {
+  await io.writeLine("> ");
+  const line = await io.readLine();
+  if (line === null) {
+    throw new SetupWizardError(
+      `unexpected end of input while reading ${label}; aborting.`,
+    );
+  }
+  const trimmed = line.trim();
+  if (trimmed.length === 0) {
+    throw new SetupWizardError(`${label} cannot be empty.`);
+  }
+  return trimmed;
+}
+
+interface ConfigSeeds {
+  readonly appId: number;
+  readonly privateKeyPath: string;
+  readonly installations: Record<string, number>;
+  readonly defaultRepo: string;
+}
+
+function buildConfig(seeds: ConfigSeeds): unknown {
+  const github: GitHubConfig = {
+    appId: seeds.appId,
+    privateKeyPath: seeds.privateKeyPath,
+    installations: seeds.installations,
+    defaultRepo: seeds.defaultRepo,
+  };
+  return {
+    github,
+    agent: {
+      model: "claude-sonnet-4-6",
+      permissionMode: "acceptEdits",
+      maxIterationsPerTask: MAX_TASK_ITERATIONS,
+    },
+    lifecycle: {
+      mergeMode: "squash",
+      settlingWindowMilliseconds: SETTLING_WINDOW_MILLISECONDS,
+      pollIntervalMilliseconds: POLL_INTERVAL_MILLISECONDS,
+      preserveWorktreeOnMerge: false,
+    },
+    workspace: defaultWorkspacePath(),
+    daemon: {
+      socketPath: defaultSocketPath(),
+      autoStart: true,
+    },
+    tui: {
+      keybindings: { commandPalette: "ctrl+p", taskSwitcher: "ctrl+g" },
+    },
+  };
+}
+
+/**
+ * Resolve the platform-appropriate default workspace path.
+ *
+ * Returned as a `~/`-prefixed string so `config.json` stays portable
+ * across machines belonging to the same user.
+ *
+ * @returns The default workspace path expressed with a leading `~/`.
+ */
+function defaultWorkspacePath(): string {
+  if (Deno.build.os === "darwin") {
+    return "~/Library/Application Support/makina/workspace";
+  }
+  return "~/.local/share/makina/workspace";
+}
+
+/**
+ * Resolve the platform-appropriate default daemon socket path.
+ *
+ * @returns The default socket path expressed with a leading `~/`.
+ */
+function defaultSocketPath(): string {
+  if (Deno.build.os === "darwin") {
+    return "~/Library/Application Support/makina/daemon.sock";
+  }
+  return "~/.local/share/makina/daemon.sock";
+}
+
+/**
+ * Resolve the platform-appropriate path the `setup` subcommand should
+ * write the produced {@link Config} to.
+ *
+ * macOS uses the Apple-defined Application Support directory; Linux
+ * follows the XDG Base Directory specification (`~/.config/...`). The
+ * path is `~/`-prefixed so callers can pass it straight to
+ * {@link expandHome}.
+ *
+ * @returns The default config-file path with a leading `~/`.
+ *
+ * @example
+ * ```ts
+ * import { expandHome } from "./load.ts";
+ * import { defaultConfigPath } from "./setup-wizard.ts";
+ *
+ * const path = expandHome(defaultConfigPath());
+ * await Deno.writeTextFile(path, JSON.stringify(config, null, 2));
+ * ```
+ */
+export function defaultConfigPath(): string {
+  if (Deno.build.os === "darwin") {
+    return "~/Library/Application Support/makina/config.json";
+  }
+  return "~/.config/makina/config.json";
+}

--- a/src/config/setup-wizard.ts
+++ b/src/config/setup-wizard.ts
@@ -31,11 +31,13 @@
 import { exists } from "@std/fs";
 
 import { type Config, type GitHubConfig, parseConfig } from "./schema.ts";
-import { expandHome } from "./load.ts";
+import { defaultEnvLookup, type EnvLookup, expandHome } from "./load.ts";
 import {
   MAX_TASK_ITERATIONS,
   POLL_INTERVAL_MILLISECONDS,
+  RADIX_DECIMAL,
   SETTLING_WINDOW_MILLISECONDS,
+  WIZARD_READ_CHUNK_BYTES,
 } from "../constants.ts";
 
 /**
@@ -109,6 +111,14 @@ export interface SetupWizardIo {
   readonly writeLine: WriteLine;
   /** GitHub client for App-level installation discovery. */
   readonly githubClient: WizardGitHubClient;
+  /**
+   * Env reader the wizard uses for `$HOME` lookups (currently the
+   * private-key-path existence check). Optional — tests inject a
+   * per-test stub so they can run with `deno test --parallel` without
+   * mutating `Deno.env` and racing with sibling tests; production
+   * callers omit the field and the wizard falls back to `Deno.env.get`.
+   */
+  readonly envLookup?: EnvLookup;
 }
 
 /**
@@ -170,8 +180,9 @@ export async function runSetupWizard(io: SetupWizardIo): Promise<Config> {
   await io.writeLine("for details on creating the App itself.");
   await io.writeLine("");
 
+  const envLookup = io.envLookup ?? defaultEnvLookup;
   const appId = await promptAppId(io);
-  const privateKeyPath = await promptPrivateKeyPath(io);
+  const privateKeyPath = await promptPrivateKeyPath(io, envLookup);
   const installations = await fetchInstallations(io, appId, privateKeyPath);
   const repoChoices = collectRepositoryChoices(installations);
   if (repoChoices.length === 0) {
@@ -243,26 +254,32 @@ export interface ByteWriter {
  * Build a {@link SetupWizardIo} backed by an arbitrary byte reader and
  * writer. The reader is decoded as UTF-8 and split on `\n` (a trailing
  * `\r` is stripped so Windows-style stdin Just Works). The writer
- * receives `${text}\n` per call.
+ * receives `${text}\n` per call, looping over partial writes until the
+ * buffer drains.
  *
- * Tests use this with `Deno.Buffer`-backed reader/writer pairs;
- * production code goes through {@link createStdioWizardIo}.
+ * Tests pass custom `ByteReader` / `ByteWriter` implementations
+ * (`StringReader`, `CapturingWriter` in the integration suite — see
+ * `tests/integration/setup_wizard_test.ts`); production code goes
+ * through {@link createStdioWizardIo}.
  *
  * @param reader Byte source (typically `Deno.stdin`).
  * @param writer Byte sink (typically `Deno.stdout`).
  * @param githubClient Wizard-only GitHub client.
+ * @param envLookup Optional env reader for `$HOME`. Tests inject a
+ *   per-test stub to avoid mutating `Deno.env`; production callers omit
+ *   the argument and the wizard uses `Deno.env.get`.
  * @returns An IO bundle suitable for {@link runSetupWizard}.
  */
 export function createWizardIo(
   reader: ByteReader,
   writer: ByteWriter,
   githubClient: WizardGitHubClient,
+  envLookup?: EnvLookup,
 ): SetupWizardIo {
   const decoder = new TextDecoder();
   const encoder = new TextEncoder();
   let buffer = "";
   let eof = false;
-  const readChunkBytes = 1_024;
 
   const readLine: ReadLine = async () => {
     while (true) {
@@ -281,10 +298,14 @@ export function createWizardIo(
         buffer = "";
         return remainder.endsWith("\r") ? remainder.slice(0, -1) : remainder;
       }
-      const chunk = new Uint8Array(readChunkBytes);
+      const chunk = new Uint8Array(WIZARD_READ_CHUNK_BYTES);
       const bytesRead = await reader.read(chunk);
       if (bytesRead === null) {
         eof = true;
+        // Flush the streaming decoder so a partial multi-byte UTF-8
+        // sequence at end-of-stream surfaces as the replacement
+        // character rather than getting silently dropped.
+        buffer += decoder.decode();
         continue;
       }
       buffer += decoder.decode(chunk.subarray(0, bytesRead), { stream: true });
@@ -292,10 +313,31 @@ export function createWizardIo(
   };
 
   const writeLine: WriteLine = async (text: string) => {
-    await writer.write(encoder.encode(`${text}\n`));
+    // Deno's `Writer`-style API permits partial writes — `writer.write`
+    // is allowed to return a value smaller than `buffer.length`. Loop
+    // until every byte drains so a slow sink cannot truncate prompts.
+    let pending = encoder.encode(`${text}\n`);
+    while (pending.length > 0) {
+      const written = await writer.write(pending);
+      if (written <= 0) {
+        // A non-positive return indicates the sink will not make
+        // progress; failing fast here surfaces it instead of looping
+        // forever on a half-closed pipe.
+        throw new Error(
+          `wizard writer returned non-positive byte count (${written}); aborting.`,
+        );
+      }
+      pending = pending.subarray(written);
+    }
   };
 
-  return { readLine, writeLine, githubClient };
+  // Build the IO object. The `envLookup` field is optional under
+  // `exactOptionalPropertyTypes` — we only set it when the caller
+  // provided one so an `undefined` does not show up on the property.
+  const io: SetupWizardIo = envLookup === undefined
+    ? { readLine, writeLine, githubClient }
+    : { readLine, writeLine, githubClient, envLookup };
+  return io;
 }
 
 /**
@@ -313,7 +355,7 @@ export function createWizardIo(
 export function createStdioWizardIo(
   githubClient: WizardGitHubClient,
 ): SetupWizardIo {
-  return createWizardIo(Deno.stdin, Deno.stdout, githubClient);
+  return createWizardIo(Deno.stdin, Deno.stdout, githubClient, defaultEnvLookup);
 }
 
 // ---------------------------------------------------------------------------
@@ -323,7 +365,7 @@ export function createStdioWizardIo(
 async function promptAppId(io: SetupWizardIo): Promise<number> {
   await io.writeLine("GitHub App ID (integer printed at the top of the App settings page):");
   const raw = await readRequiredLine(io, "App ID");
-  const parsed = Number.parseInt(raw, 10);
+  const parsed = Number.parseInt(raw, RADIX_DECIMAL);
   if (!Number.isInteger(parsed) || parsed < 1 || `${parsed}` !== raw) {
     throw new SetupWizardError(
       `invalid App ID ${JSON.stringify(raw)}: expected a positive integer`,
@@ -332,11 +374,14 @@ async function promptAppId(io: SetupWizardIo): Promise<number> {
   return parsed;
 }
 
-async function promptPrivateKeyPath(io: SetupWizardIo): Promise<string> {
+async function promptPrivateKeyPath(
+  io: SetupWizardIo,
+  envLookup: EnvLookup,
+): Promise<string> {
   await io.writeLine("");
   await io.writeLine("Path to the App's private key (PEM). May begin with ~/.");
   const raw = await readRequiredLine(io, "Private-key path");
-  const expanded = expandHome(raw);
+  const expanded = expandHome(raw, envLookup);
   const found = await exists(expanded, { isFile: true });
   if (!found) {
     throw new SetupWizardError(
@@ -427,7 +472,7 @@ async function promptDefaultRepo(
     `Pick the default repository (1-${choices.length}). Slash commands without an explicit [owner/repo] target this one.`,
   );
   const raw = await readRequiredLine(io, "Default repo");
-  const numeric = Number.parseInt(raw, 10);
+  const numeric = Number.parseInt(raw, RADIX_DECIMAL);
   if (!Number.isInteger(numeric) || `${numeric}` !== raw) {
     throw new SetupWizardError(
       `invalid choice ${JSON.stringify(raw)}: expected a number between 1 and ${choices.length}.`,

--- a/src/config/setup-wizard.ts
+++ b/src/config/setup-wizard.ts
@@ -385,8 +385,8 @@ function collectRepositoryChoices(
 ): readonly RepoChoice[] {
   // Flatten installation × repository into a single picker. If the same
   // repo appears under multiple installations the first one wins; the
-  // wizard logs a note rather than failing because that mostly happens
-  // when a personal install and an org install overlap.
+  // wizard silently deduplicates rather than failing because that mostly
+  // happens when a personal install and an org install overlap.
   const seen = new Set<string>();
   const choices: RepoChoice[] = [];
   for (const installation of installations) {
@@ -417,11 +417,11 @@ async function promptDefaultRepo(
 ): Promise<string> {
   await io.writeLine("");
   await io.writeLine("Reachable repositories:");
-  choices.forEach((choice, index) => {
+  for (const [index, choice] of choices.entries()) {
     // Wizard picker numbers are one-based — easier to type at a prompt.
     const label = `  ${index + 1}. ${choice.repo}`;
-    void io.writeLine(label);
-  });
+    await io.writeLine(label);
+  }
   await io.writeLine("");
   await io.writeLine(
     `Pick the default repository (1-${choices.length}). Slash commands without an explicit [owner/repo] target this one.`,

--- a/src/config/setup-wizard.ts
+++ b/src/config/setup-wizard.ts
@@ -119,6 +119,8 @@ export interface SetupWizardIo {
  */
 export class SetupWizardError extends Error {
   /**
+   * Construct a wizard error.
+   *
    * @param message Human-readable description of the failure.
    */
   constructor(message: string) {
@@ -205,18 +207,55 @@ export async function runSetupWizard(io: SetupWizardIo): Promise<Config> {
 }
 
 /**
- * Build the production-time {@link SetupWizardIo} backed by `Deno.stdin`,
- * `Deno.stdout`, and the supplied GitHub client.
+ * Minimal contract for an object that reads UTF-8 bytes from a source.
  *
- * Kept separate from {@link runSetupWizard} so tests never import a
- * stdin-touching helper; the `setup` subcommand assembles its `io`
- * here.
- *
- * @param githubClient The wizard-only GitHub client (typically backed by
- *   `src/github/app-auth.ts`).
- * @returns A live IO bundle suitable for {@link runSetupWizard}.
+ * Mirrors the shape of `Deno.stdin.read`. The wizard only needs the
+ * bytes-in interface so tests can swap in a buffer-backed reader.
  */
-export function createStdioWizardIo(
+export interface ByteReader {
+  /**
+   * Read up to `buffer.length` bytes into `buffer`. Returns the number
+   * of bytes read, or `null` at end-of-stream.
+   *
+   * @param buffer Destination buffer.
+   * @returns Bytes read, or `null` at EOF.
+   */
+  read(buffer: Uint8Array): Promise<number | null>;
+}
+
+/**
+ * Minimal contract for an object that writes UTF-8 bytes to a sink.
+ *
+ * Mirrors the shape of `Deno.stdout.write`. The wizard only needs the
+ * bytes-out interface so tests can swap in a buffer-backed writer.
+ */
+export interface ByteWriter {
+  /**
+   * Write the entire buffer. Returns the number of bytes written.
+   *
+   * @param buffer Bytes to write.
+   * @returns Bytes written.
+   */
+  write(buffer: Uint8Array): Promise<number>;
+}
+
+/**
+ * Build a {@link SetupWizardIo} backed by an arbitrary byte reader and
+ * writer. The reader is decoded as UTF-8 and split on `\n` (a trailing
+ * `\r` is stripped so Windows-style stdin Just Works). The writer
+ * receives `${text}\n` per call.
+ *
+ * Tests use this with `Deno.Buffer`-backed reader/writer pairs;
+ * production code goes through {@link createStdioWizardIo}.
+ *
+ * @param reader Byte source (typically `Deno.stdin`).
+ * @param writer Byte sink (typically `Deno.stdout`).
+ * @param githubClient Wizard-only GitHub client.
+ * @returns An IO bundle suitable for {@link runSetupWizard}.
+ */
+export function createWizardIo(
+  reader: ByteReader,
+  writer: ByteWriter,
   githubClient: WizardGitHubClient,
 ): SetupWizardIo {
   const decoder = new TextDecoder();
@@ -243,7 +282,7 @@ export function createStdioWizardIo(
         return remainder.endsWith("\r") ? remainder.slice(0, -1) : remainder;
       }
       const chunk = new Uint8Array(readChunkBytes);
-      const bytesRead = await Deno.stdin.read(chunk);
+      const bytesRead = await reader.read(chunk);
       if (bytesRead === null) {
         eof = true;
         continue;
@@ -253,10 +292,28 @@ export function createStdioWizardIo(
   };
 
   const writeLine: WriteLine = async (text: string) => {
-    await Deno.stdout.write(encoder.encode(`${text}\n`));
+    await writer.write(encoder.encode(`${text}\n`));
   };
 
   return { readLine, writeLine, githubClient };
+}
+
+/**
+ * Build the production-time {@link SetupWizardIo} backed by `Deno.stdin`,
+ * `Deno.stdout`, and the supplied GitHub client.
+ *
+ * Thin convenience wrapper around {@link createWizardIo}; the `setup`
+ * subcommand calls this and tests cover the underlying logic by
+ * passing in-memory readers/writers to {@link createWizardIo} directly.
+ *
+ * @param githubClient The wizard-only GitHub client (typically backed by
+ *   `src/github/app-auth.ts`).
+ * @returns A live IO bundle suitable for {@link runSetupWizard}.
+ */
+export function createStdioWizardIo(
+  githubClient: WizardGitHubClient,
+): SetupWizardIo {
+  return createWizardIo(Deno.stdin, Deno.stdout, githubClient);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -178,3 +178,32 @@ export const MIN_GITHUB_ISSUE_NUMBER = 1;
  * mode in a later wave.
  */
 export const STATUS_BAR_TRUNCATION_WIDTH_CODE_UNITS = 80;
+
+/**
+ * Chunk size used by `createWizardIo` when pulling bytes from the byte
+ * reader, in bytes.
+ *
+ * One kilobyte is large enough that a single read drains a full prompt
+ * answer typed at the terminal, but small enough that the unit tests'
+ * "concatenate across reads" path still gets exercised when the test
+ * reader hands back fewer bytes per call.
+ */
+export const WIZARD_READ_CHUNK_BYTES = 1_024;
+
+/**
+ * Radix used when parsing decimal user input (App ID, picker indexes).
+ *
+ * `Number.parseInt(text, RADIX_DECIMAL)` reads slightly clearer than the
+ * bare `10`, and the named constant keeps `src/` modules free of magic
+ * numbers per the rule at the top of this file.
+ */
+export const RADIX_DECIMAL = 10;
+
+/**
+ * The literal `~/` prefix the loader and wizard expand to `$HOME`.
+ *
+ * Centralised so the slice operations that strip it
+ * (`path.slice(HOME_PREFIX.length)`) carry their intent in the name
+ * rather than a bare numeric `2`.
+ */
+export const HOME_PREFIX = "~/";

--- a/tests/integration/main_daemon_test.ts
+++ b/tests/integration/main_daemon_test.ts
@@ -25,8 +25,10 @@ const SHUTDOWN_GRACE_MS = 1_000;
 
 /**
  * Build a minimal-but-valid `config.json` with a `~/`-prefixed
- * `daemon.socketPath`. The wizard normalises to `~/.local/state/...`,
- * so this matches the realistic shape of a freshly-written config.
+ * `daemon.socketPath`. The wizard preserves the user-typed `~/...`
+ * shape verbatim (path expansion happens at the daemon's binding
+ * boundary in `main.ts`, not at config-load time), so this matches the
+ * realistic shape of a freshly-written config.
  */
 function configWithTildeSocket(): string {
   return JSON.stringify(
@@ -132,8 +134,10 @@ Deno.test("main.ts daemon: expands ~/ in daemon.socketPath before binding", asyn
       `${configDir}/${CONFIG_FILENAME}`,
       configWithTildeSocket(),
     );
-    // The daemon expects the socket directory to exist; the wizard
-    // creates it on first run, but here we set it up by hand.
+    // The daemon expects the socket directory to exist. The wizard
+    // (`runSetupWizard`) does not create it today; production installs
+    // create it via `mkdir -p`. Here we set it up by hand so the
+    // spawned daemon can bind without bootstrap noise.
     const socketDir = `${fakeHome}/.local/state/makina`;
     await Deno.mkdir(socketDir, { recursive: true });
     const expectedSocketPath = `${socketDir}/${SOCKET_FILENAME}`;

--- a/tests/integration/main_daemon_test.ts
+++ b/tests/integration/main_daemon_test.ts
@@ -153,11 +153,16 @@ Deno.test("main.ts daemon: expands ~/ in daemon.socketPath before binding", asyn
       spawnEnv.DENO_DIR = denoDir;
     } else {
       // No explicit DENO_DIR: Deno's default lives under the parent's
-      // HOME, so we must reach for the parent's HOME too. Read it once
-      // and pin it.
+      // HOME, but the path is platform-specific:
+      //   darwin: ~/Library/Caches/deno
+      //   linux:  ~/.cache/deno
+      // Branch on Deno.build.os so CI runners on Linux (where DENO_DIR
+      // is also typically unset) point at the correct cache location.
       const parentHome = Deno.env.get("HOME");
       if (parentHome !== undefined) {
-        spawnEnv.DENO_DIR = `${parentHome}/Library/Caches/deno`;
+        spawnEnv.DENO_DIR = Deno.build.os === "darwin"
+          ? `${parentHome}/Library/Caches/deno`
+          : `${parentHome}/.cache/deno`;
       }
     }
     // PATH and friends are needed for Deno itself to locate sub-tools;

--- a/tests/integration/main_daemon_test.ts
+++ b/tests/integration/main_daemon_test.ts
@@ -1,0 +1,249 @@
+/**
+ * Integration tests for the `daemon` branch of `main.ts`.
+ *
+ * Covers the consumer-boundary contract that nested `~/`-prefixed path
+ * fields in `config.json` are expanded before they are used (here:
+ * `daemon.socketPath` is expanded before `Deno.listen({ transport:
+ * "unix" })` binds it). A regression in `main.ts` that drops the
+ * `expandHome(...)` call would manifest as the daemon trying to bind a
+ * literal `~` path: this test pins the behavior end-to-end by spawning
+ * the binary against a controlled `HOME` and asserting the socket file
+ * lands at `<HOME>/.../daemon.sock`, never at any path containing a
+ * literal `~`.
+ *
+ * The test does not exercise the IPC dispatch loop (that is the job of
+ * `tests/integration/daemon_server_test.ts`); it only proves the path
+ * gets expanded at the wiring boundary.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+
+const CONFIG_FILENAME = "config.json";
+const SOCKET_FILENAME = "daemon.sock";
+const STARTUP_LISTEN_TIMEOUT_MS = 10_000;
+const SHUTDOWN_GRACE_MS = 1_000;
+
+/**
+ * Build a minimal-but-valid `config.json` with a `~/`-prefixed
+ * `daemon.socketPath`. The wizard normalises to `~/.local/state/...`,
+ * so this matches the realistic shape of a freshly-written config.
+ */
+function configWithTildeSocket(): string {
+  return JSON.stringify(
+    {
+      github: {
+        appId: 1234567,
+        privateKeyPath: "~/keys/app.pem",
+        installations: { "owner/repo": 9876543 },
+        defaultRepo: "owner/repo",
+      },
+      agent: {
+        model: "claude-sonnet-4-6",
+        permissionMode: "acceptEdits",
+        maxIterationsPerTask: 4,
+      },
+      lifecycle: {
+        mergeMode: "squash",
+        settlingWindowMilliseconds: 60_000,
+        pollIntervalMilliseconds: 30_000,
+        preserveWorktreeOnMerge: false,
+      },
+      workspace: "~/workspace",
+      daemon: { socketPath: `~/.local/state/makina/${SOCKET_FILENAME}`, autoStart: true },
+      tui: { keybindings: { commandPalette: "ctrl+p", taskSwitcher: "ctrl+g" } },
+    },
+    null,
+    2,
+  );
+}
+
+/**
+ * Wait for the daemon's "[daemon] listening on <path>" line so we know
+ * `Deno.listen` has returned. We reach for stderr (not the socket file)
+ * because the listen line is the only signal that the bind actually
+ * succeeded — a regression that bound `~/...` literally would surface
+ * as a permission/ENOENT failure rather than just an unexpanded path on
+ * disk, and we want this test to fail loudly in that case.
+ *
+ * The reader returns when either (a) the listen line is matched —
+ * resolving to the captured path — or (b) the deadline elapses, in
+ * which case the accumulated stderr text is included in the rejection
+ * message so a regression failure leaves a clear breadcrumb.
+ */
+async function waitForListenLine(
+  stderr: ReadableStream<Uint8Array>,
+): Promise<string> {
+  const decoder = new TextDecoder();
+  const reader = stderr.getReader();
+  let buffer = "";
+  let deadlineTimer: number | undefined;
+  try {
+    const deadlinePromise = new Promise<never>((_, reject) => {
+      deadlineTimer = setTimeout(() => {
+        reject(
+          new Error(
+            `daemon never logged "[daemon] listening on ..." within ` +
+              `${STARTUP_LISTEN_TIMEOUT_MS}ms; stderr was:\n${buffer}`,
+          ),
+        );
+      }, STARTUP_LISTEN_TIMEOUT_MS);
+    });
+    while (true) {
+      const result = await Promise.race([reader.read(), deadlinePromise]);
+      if (result.done) {
+        throw new Error(
+          `daemon stderr closed before logging the listen line; stderr was:\n${buffer}`,
+        );
+      }
+      buffer += decoder.decode(result.value, { stream: true });
+      const match = buffer.match(/\[daemon\] listening on (.+)/);
+      const captured = match?.[1];
+      if (captured !== undefined) {
+        return captured.trimEnd();
+      }
+    }
+  } finally {
+    if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
+    reader.releaseLock();
+  }
+}
+
+Deno.test("main.ts daemon: expands ~/ in daemon.socketPath before binding", async () => {
+  // Synthetic HOME so the test does not depend on the real user's
+  // filesystem layout. The config inside is `~/.local/state/makina/...`
+  // — once expanded, it must materialise under THIS directory.
+  //
+  // We pin the parent dir to `/tmp` (rather than letting
+  // `Deno.makeTempDir` default to `$TMPDIR`, which on macOS is a long
+  // `/var/folders/.../T/` path) because Unix-domain socket paths are
+  // capped at `SUN_LEN` (~104 bytes on macOS, 108 on Linux). The
+  // expanded socket path must fit comfortably or `Deno.listen` rejects
+  // before we get to assert anything.
+  const fakeHome = await Deno.makeTempDir({ dir: "/tmp", prefix: "mh-" });
+  try {
+    // Lay down a config under the path `defaultConfigPath()` resolves
+    // for this platform (macOS gets `~/Library/Application Support/...`,
+    // every other POSIX target gets `~/.config/...`).
+    const configDir = Deno.build.os === "darwin"
+      ? `${fakeHome}/Library/Application Support/makina`
+      : `${fakeHome}/.config/makina`;
+    await Deno.mkdir(configDir, { recursive: true });
+    await Deno.writeTextFile(
+      `${configDir}/${CONFIG_FILENAME}`,
+      configWithTildeSocket(),
+    );
+    // The daemon expects the socket directory to exist; the wizard
+    // creates it on first run, but here we set it up by hand.
+    const socketDir = `${fakeHome}/.local/state/makina`;
+    await Deno.mkdir(socketDir, { recursive: true });
+    const expectedSocketPath = `${socketDir}/${SOCKET_FILENAME}`;
+
+    // Build the spawn env carefully: we override HOME so the daemon
+    // resolves `~/...` against `fakeHome`, but we MUST keep Deno's own
+    // cache pointed at the real user's `DENO_DIR`. Otherwise the
+    // spawned binary tries to re-download every dep into the synthetic
+    // HOME and the listen line never appears within the test deadline.
+    const spawnEnv: Record<string, string> = { HOME: fakeHome };
+    const denoDir = Deno.env.get("DENO_DIR");
+    if (denoDir !== undefined) {
+      spawnEnv.DENO_DIR = denoDir;
+    } else {
+      // No explicit DENO_DIR: Deno's default lives under the parent's
+      // HOME, so we must reach for the parent's HOME too. Read it once
+      // and pin it.
+      const parentHome = Deno.env.get("HOME");
+      if (parentHome !== undefined) {
+        spawnEnv.DENO_DIR = `${parentHome}/Library/Caches/deno`;
+      }
+    }
+    // PATH and friends are needed for Deno itself to locate sub-tools;
+    // pass through what the parent has so the spawn behaves like a
+    // normal `deno run`.
+    for (const passthrough of ["PATH", "TMPDIR", "LANG"]) {
+      const value = Deno.env.get(passthrough);
+      if (value !== undefined) spawnEnv[passthrough] = value;
+    }
+
+    const command = new Deno.Command(Deno.execPath(), {
+      args: ["run", "-A", "main.ts", "daemon"],
+      env: spawnEnv,
+      clearEnv: true,
+      cwd: Deno.cwd(),
+      stdout: "null",
+      stderr: "piped",
+      stdin: "null",
+    });
+
+    const child = command.spawn();
+    let stderrCancelled = false;
+
+    try {
+      const listenLineOnSocketPath = await waitForListenLine(child.stderr);
+
+      // 1. The listen line itself must contain the EXPANDED path
+      //    (no stray `~`), and must equal the expected absolute path.
+      assertEquals(
+        listenLineOnSocketPath,
+        expectedSocketPath,
+        `daemon advertised the wrong socket path: ${listenLineOnSocketPath}`,
+      );
+      assert(
+        !listenLineOnSocketPath.includes("~"),
+        `daemon advertised an unexpanded ~ in: ${listenLineOnSocketPath}`,
+      );
+
+      // 2. The socket file must exist at the expanded path.
+      const stat = await Deno.lstat(expectedSocketPath);
+      assert(stat.isSocket, `expected a socket at ${expectedSocketPath}`);
+
+      // 3. Belt-and-braces: a literal `~` directory must NOT have been
+      //    created in the cwd by the regression we are guarding
+      //    against.
+      const literalTildeDir = `${Deno.cwd()}/~`;
+      let literalTildeExists = false;
+      try {
+        await Deno.lstat(literalTildeDir);
+        literalTildeExists = true;
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) throw error;
+      }
+      assert(
+        !literalTildeExists,
+        `daemon created a literal ~ directory at ${literalTildeDir}; ` +
+          `~/ was not expanded before binding`,
+      );
+    } finally {
+      // Send SIGTERM and wait for the process to clean up its socket.
+      try {
+        child.kill("SIGTERM");
+      } catch (_) { /* already gone */ }
+      // Cancel stderr so the pipe doesn't back-pressure shutdown and so
+      // Deno's resource sanitiser does not flag a leaked stream. The
+      // listen-line reader released the lock; cancel can reclaim now.
+      if (!stderrCancelled) {
+        try {
+          await child.stderr.cancel();
+          stderrCancelled = true;
+        } catch (_) { /* already drained */ }
+      }
+      // Bound the wait so a wedged child cannot hang the test. Clear
+      // the timer no matter who wins the race, otherwise Deno's
+      // resource sanitiser flags it as a leaked timer.
+      let shutdownTimer: number | undefined;
+      const shutdownTimeout = new Promise<void>((resolve) => {
+        shutdownTimer = setTimeout(resolve, SHUTDOWN_GRACE_MS);
+      });
+      try {
+        await Promise.race([child.status, shutdownTimeout]);
+      } finally {
+        if (shutdownTimer !== undefined) clearTimeout(shutdownTimer);
+      }
+      try {
+        child.kill("SIGKILL");
+      } catch (_) { /* already gone */ }
+      await child.status;
+    }
+  } finally {
+    await Deno.remove(fakeHome, { recursive: true });
+  }
+});

--- a/tests/integration/setup_wizard_test.ts
+++ b/tests/integration/setup_wizard_test.ts
@@ -14,6 +14,7 @@
 
 import { assert, assertEquals, assertRejects } from "@std/assert";
 
+import { type EnvLookup } from "../../src/config/load.ts";
 import { parseConfig } from "../../src/config/schema.ts";
 import {
   type ByteReader,
@@ -25,6 +26,16 @@ import {
   type WizardGitHubClient,
   type WizardInstallation,
 } from "../../src/config/setup-wizard.ts";
+
+/**
+ * Build an `EnvLookup` over a fixed map. Used by tests that need to
+ * exercise the wizard's `~/` expansion without mutating `Deno.env`,
+ * which would race other tests under `--parallel`.
+ */
+function envLookupFrom(entries: Record<string, string>): EnvLookup {
+  const map = new Map(Object.entries(entries));
+  return (name) => map.get(name);
+}
 
 /**
  * Build a `readLine` that drains a scripted list of answers in order.
@@ -105,20 +116,26 @@ async function makeKeyFile(): Promise<string> {
 /**
  * Mint an `io` bundle from primitives. Centralises the construction so
  * the per-test setups stay focused on their scripted answers.
+ *
+ * `envLookup` is propagated only when the caller supplied one; with
+ * `exactOptionalPropertyTypes` enabled the field cannot be set to
+ * `undefined` explicitly.
  */
 function buildIo(args: {
   readonly answers: readonly string[];
   readonly client: WizardGitHubClient;
+  readonly envLookup?: EnvLookup;
 }): SetupWizardIo & { output: () => string; remaining: () => readonly string[] } {
   const reader = scriptedReader(args.answers);
   const writer = captureWriter();
-  return {
+  const base = {
     readLine: reader.readLine,
     writeLine: writer.writeLine,
     githubClient: args.client,
     output: writer.output,
     remaining: reader.remaining,
   };
+  return args.envLookup === undefined ? base : { ...base, envLookup: args.envLookup };
 }
 
 Deno.test("runSetupWizard: happy path produces a valid config", async () => {
@@ -380,26 +397,19 @@ Deno.test("runSetupWizard: expands ~/ for the private-key existence check", asyn
       keyPath,
       "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
     );
-    const previousHome = Deno.env.get("HOME");
-    Deno.env.set("HOME", tempHome);
-    try {
-      const client = new StubWizardGitHubClient([
-        { installationId: 1, repositories: ["a/b"] },
-      ]);
-      const io = buildIo({
-        answers: ["1", "~/key.pem", "1"],
-        client,
-      });
-      const config = await runSetupWizard(io);
-      // The user-typed form is preserved so the config stays portable.
-      assertEquals(config.github.privateKeyPath, "~/key.pem");
-    } finally {
-      if (previousHome === undefined) {
-        Deno.env.delete("HOME");
-      } else {
-        Deno.env.set("HOME", previousHome);
-      }
-    }
+    const client = new StubWizardGitHubClient([
+      { installationId: 1, repositories: ["a/b"] },
+    ]);
+    // Inject a per-test `EnvLookup` rather than mutating `Deno.env` so
+    // the integration suite stays parallel-safe.
+    const io = buildIo({
+      answers: ["1", "~/key.pem", "1"],
+      client,
+      envLookup: envLookupFrom({ HOME: tempHome }),
+    });
+    const config = await runSetupWizard(io);
+    // The user-typed form is preserved so the config stays portable.
+    assertEquals(config.github.privateKeyPath, "~/key.pem");
   } finally {
     await Deno.remove(tempHome, { recursive: true });
   }

--- a/tests/integration/setup_wizard_test.ts
+++ b/tests/integration/setup_wizard_test.ts
@@ -1,0 +1,403 @@
+/**
+ * Integration tests for `src/config/setup-wizard.ts`.
+ *
+ * The wizard's collaborators are injected (`readLine`, `writeLine`,
+ * `githubClient`) so these tests script a full first-run conversation
+ * end-to-end without touching real stdin or the network. The
+ * happy-path test pipes scripted answers into a stub
+ * {@link WizardGitHubClient} and asserts that the wizard produces a
+ * config that re-validates against the W1 zod schema. The negative
+ * tests cover the validation paths the wizard owns: missing private
+ * key, no installations reachable, malformed numeric input, and EOF on
+ * stdin.
+ */
+
+import { assert, assertEquals, assertRejects } from "@std/assert";
+
+import { parseConfig } from "../../src/config/schema.ts";
+import {
+  runSetupWizard,
+  SetupWizardError,
+  type SetupWizardIo,
+  type WizardGitHubClient,
+  type WizardInstallation,
+} from "../../src/config/setup-wizard.ts";
+
+/**
+ * Build a `readLine` that drains a scripted list of answers in order.
+ *
+ * Returns `null` once the script is exhausted so the wizard sees an EOF
+ * if it asks more questions than the test supplied.
+ */
+function scriptedReader(answers: readonly string[]): {
+  readLine: () => Promise<string | null>;
+  remaining: () => readonly string[];
+} {
+  const queue = [...answers];
+  return {
+    readLine: () => Promise.resolve(queue.shift() ?? null),
+    remaining: () => [...queue],
+  };
+}
+
+/** Capture every line the wizard writes for assertion purposes. */
+function captureWriter(): {
+  writeLine: (text: string) => void;
+  output: () => string;
+} {
+  const lines: string[] = [];
+  return {
+    writeLine: (text: string) => {
+      lines.push(text);
+    },
+    output: () => lines.join("\n"),
+  };
+}
+
+/**
+ * Stub {@link WizardGitHubClient} that returns a fixed installations
+ * list and records every call. Mirrors the in-memory-doubles convention
+ * from W1 but stays here because the wizard's narrow client interface
+ * is local to this module.
+ */
+class StubWizardGitHubClient implements WizardGitHubClient {
+  private readonly script: readonly WizardInstallation[];
+  readonly calls: { appId: number; privateKeyPath: string }[] = [];
+
+  constructor(script: readonly WizardInstallation[]) {
+    this.script = script;
+  }
+
+  getInstallations(args: {
+    readonly appId: number;
+    readonly privateKeyPath: string;
+  }): Promise<readonly WizardInstallation[]> {
+    this.calls.push({ ...args });
+    return Promise.resolve(this.script);
+  }
+}
+
+class FailingWizardGitHubClient implements WizardGitHubClient {
+  // deno-lint-ignore require-await
+  async getInstallations(): Promise<readonly WizardInstallation[]> {
+    throw new Error("simulated network failure");
+  }
+}
+
+/**
+ * Write a temp file and return its path. The caller is responsible for
+ * removal; the helper exists so the happy-path test can hand the
+ * wizard a real on-disk private key without leaking files into the
+ * repo.
+ */
+async function makeKeyFile(): Promise<string> {
+  const path = await Deno.makeTempFile({
+    prefix: "makina-key-",
+    suffix: ".pem",
+  });
+  await Deno.writeTextFile(path, "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n");
+  return path;
+}
+
+/**
+ * Mint an `io` bundle from primitives. Centralises the construction so
+ * the per-test setups stay focused on their scripted answers.
+ */
+function buildIo(args: {
+  readonly answers: readonly string[];
+  readonly client: WizardGitHubClient;
+}): SetupWizardIo & { output: () => string; remaining: () => readonly string[] } {
+  const reader = scriptedReader(args.answers);
+  const writer = captureWriter();
+  return {
+    readLine: reader.readLine,
+    writeLine: writer.writeLine,
+    githubClient: args.client,
+    output: writer.output,
+    remaining: reader.remaining,
+  };
+}
+
+Deno.test("runSetupWizard: happy path produces a valid config", async () => {
+  const keyPath = await makeKeyFile();
+  try {
+    const client = new StubWizardGitHubClient([
+      {
+        installationId: 9876543,
+        repositories: ["koraytaylan/makina", "koraytaylan/other"],
+      },
+    ]);
+    const io = buildIo({
+      answers: ["1234567", keyPath, "2"],
+      client,
+    });
+    const config = await runSetupWizard(io);
+
+    assertEquals(config.github.appId, 1234567);
+    assertEquals(config.github.privateKeyPath, keyPath);
+    assertEquals(config.github.defaultRepo, "koraytaylan/other");
+    assertEquals(config.github.installations["koraytaylan/makina"], 9876543);
+    assertEquals(config.github.installations["koraytaylan/other"], 9876543);
+
+    // The wizard must hand off something the loader would also accept.
+    const reparsed = parseConfig(JSON.parse(JSON.stringify(config)));
+    assertEquals(reparsed.success, true);
+
+    // The wizard called the GitHub client exactly once with the inputs
+    // the user supplied.
+    assertEquals(client.calls.length, 1);
+    const firstCall = client.calls[0];
+    assert(firstCall !== undefined);
+    assertEquals(firstCall.appId, 1234567);
+    assertEquals(firstCall.privateKeyPath, keyPath);
+
+    // Every scripted answer was consumed.
+    assertEquals(io.remaining().length, 0);
+  } finally {
+    await Deno.remove(keyPath).catch(() => {});
+  }
+});
+
+Deno.test("runSetupWizard: writes prompts that mention each step", async () => {
+  const keyPath = await makeKeyFile();
+  try {
+    const client = new StubWizardGitHubClient([
+      { installationId: 1, repositories: ["a/b"] },
+    ]);
+    const io = buildIo({
+      answers: ["1", keyPath, "1"],
+      client,
+    });
+    await runSetupWizard(io);
+    const transcript = io.output();
+    assert(transcript.includes("App ID"));
+    assert(transcript.includes("private key"));
+    assert(transcript.includes("Discovering installations"));
+    assert(transcript.includes("Reachable repositories"));
+    assert(transcript.includes("Default repo"));
+    assert(transcript.includes("Done"));
+  } finally {
+    await Deno.remove(keyPath).catch(() => {});
+  }
+});
+
+Deno.test("runSetupWizard: rejects a missing private-key file", async () => {
+  const tempDir = await Deno.makeTempDir({ prefix: "makina-missing-key-" });
+  try {
+    const phantom = `${tempDir}/never-saved.pem`;
+    const client = new StubWizardGitHubClient([]);
+    const io = buildIo({
+      answers: ["1234567", phantom],
+      client,
+    });
+    const error = await assertRejects(
+      () => runSetupWizard(io),
+      SetupWizardError,
+    );
+    assert(
+      error.message.includes(phantom),
+      `expected error to mention the missing path; got: ${error.message}`,
+    );
+    // The wizard short-circuits before touching the GitHub client.
+    assertEquals(client.calls.length, 0);
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("runSetupWizard: rejects a non-positive App ID", async () => {
+  const keyPath = await makeKeyFile();
+  try {
+    const client = new StubWizardGitHubClient([]);
+    const io = buildIo({
+      answers: ["0", keyPath],
+      client,
+    });
+    const error = await assertRejects(() => runSetupWizard(io), SetupWizardError);
+    assert(error.message.includes("App ID"));
+    assertEquals(client.calls.length, 0);
+  } finally {
+    await Deno.remove(keyPath).catch(() => {});
+  }
+});
+
+Deno.test("runSetupWizard: rejects a non-numeric App ID", async () => {
+  const keyPath = await makeKeyFile();
+  try {
+    const client = new StubWizardGitHubClient([]);
+    const io = buildIo({
+      answers: ["abc", keyPath],
+      client,
+    });
+    const error = await assertRejects(() => runSetupWizard(io), SetupWizardError);
+    assert(error.message.includes("App ID"));
+    assertEquals(client.calls.length, 0);
+  } finally {
+    await Deno.remove(keyPath).catch(() => {});
+  }
+});
+
+Deno.test("runSetupWizard: rejects an out-of-range default-repo choice", async () => {
+  const keyPath = await makeKeyFile();
+  try {
+    const client = new StubWizardGitHubClient([
+      { installationId: 1, repositories: ["a/b"] },
+    ]);
+    const io = buildIo({
+      answers: ["1", keyPath, "5"],
+      client,
+    });
+    const error = await assertRejects(() => runSetupWizard(io), SetupWizardError);
+    assert(error.message.includes("range"));
+  } finally {
+    await Deno.remove(keyPath).catch(() => {});
+  }
+});
+
+Deno.test("runSetupWizard: rejects a non-numeric default-repo choice", async () => {
+  const keyPath = await makeKeyFile();
+  try {
+    const client = new StubWizardGitHubClient([
+      { installationId: 1, repositories: ["a/b"] },
+    ]);
+    const io = buildIo({
+      answers: ["1", keyPath, "first"],
+      client,
+    });
+    await assertRejects(() => runSetupWizard(io), SetupWizardError);
+  } finally {
+    await Deno.remove(keyPath).catch(() => {});
+  }
+});
+
+Deno.test("runSetupWizard: errors when the App is not installed anywhere", async () => {
+  const keyPath = await makeKeyFile();
+  try {
+    const client = new StubWizardGitHubClient([]);
+    const io = buildIo({
+      answers: ["1234567", keyPath],
+      client,
+    });
+    const error = await assertRejects(() => runSetupWizard(io), SetupWizardError);
+    assert(error.message.toLowerCase().includes("install"));
+  } finally {
+    await Deno.remove(keyPath).catch(() => {});
+  }
+});
+
+Deno.test("runSetupWizard: errors when installations exist but no repositories are reachable", async () => {
+  const keyPath = await makeKeyFile();
+  try {
+    const client = new StubWizardGitHubClient([
+      { installationId: 1, repositories: [] },
+    ]);
+    const io = buildIo({
+      answers: ["1234567", keyPath],
+      client,
+    });
+    const error = await assertRejects(() => runSetupWizard(io), SetupWizardError);
+    assert(error.message.toLowerCase().includes("repositor"));
+  } finally {
+    await Deno.remove(keyPath).catch(() => {});
+  }
+});
+
+Deno.test("runSetupWizard: surfaces failures from the GitHub client", async () => {
+  const keyPath = await makeKeyFile();
+  try {
+    const client = new FailingWizardGitHubClient();
+    const io = buildIo({
+      answers: ["1234567", keyPath],
+      client,
+    });
+    const error = await assertRejects(() => runSetupWizard(io), SetupWizardError);
+    assert(error.message.includes("simulated network failure"));
+  } finally {
+    await Deno.remove(keyPath).catch(() => {});
+  }
+});
+
+Deno.test("runSetupWizard: rejects EOF on stdin", async () => {
+  const client = new StubWizardGitHubClient([]);
+  const io = buildIo({
+    answers: [],
+    client,
+  });
+  const error = await assertRejects(() => runSetupWizard(io), SetupWizardError);
+  assert(error.message.includes("end of input"));
+});
+
+Deno.test("runSetupWizard: trims whitespace from inputs", async () => {
+  const keyPath = await makeKeyFile();
+  try {
+    const client = new StubWizardGitHubClient([
+      { installationId: 7, repositories: ["a/b"] },
+    ]);
+    const io = buildIo({
+      answers: ["  1234567  ", `  ${keyPath}  `, "  1  "],
+      client,
+    });
+    const config = await runSetupWizard(io);
+    assertEquals(config.github.appId, 1234567);
+    assertEquals(config.github.privateKeyPath, keyPath);
+  } finally {
+    await Deno.remove(keyPath).catch(() => {});
+  }
+});
+
+Deno.test("runSetupWizard: deduplicates a repo that appears in multiple installations", async () => {
+  const keyPath = await makeKeyFile();
+  try {
+    const client = new StubWizardGitHubClient([
+      { installationId: 1, repositories: ["a/b", "a/c"] },
+      { installationId: 2, repositories: ["a/b", "a/d"] },
+    ]);
+    const io = buildIo({
+      answers: ["1", keyPath, "3"],
+      client,
+    });
+    const config = await runSetupWizard(io);
+    // Three distinct repos; the duplicated `a/b` belongs to the first
+    // installation (the wizard's deterministic deduplication policy).
+    assertEquals(Object.keys(config.github.installations).length, 3);
+    assertEquals(config.github.installations["a/b"], 1);
+    assertEquals(config.github.installations["a/d"], 2);
+    assertEquals(config.github.defaultRepo, "a/d");
+  } finally {
+    await Deno.remove(keyPath).catch(() => {});
+  }
+});
+
+Deno.test("runSetupWizard: expands ~/ for the private-key existence check", async () => {
+  // Save the key under a temp $HOME so a `~/...` path expands to it.
+  const tempHome = await Deno.makeTempDir({ prefix: "makina-home-key-" });
+  try {
+    const keyPath = `${tempHome}/key.pem`;
+    await Deno.writeTextFile(
+      keyPath,
+      "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+    );
+    const previousHome = Deno.env.get("HOME");
+    Deno.env.set("HOME", tempHome);
+    try {
+      const client = new StubWizardGitHubClient([
+        { installationId: 1, repositories: ["a/b"] },
+      ]);
+      const io = buildIo({
+        answers: ["1", "~/key.pem", "1"],
+        client,
+      });
+      const config = await runSetupWizard(io);
+      // The user-typed form is preserved so the config stays portable.
+      assertEquals(config.github.privateKeyPath, "~/key.pem");
+    } finally {
+      if (previousHome === undefined) {
+        Deno.env.delete("HOME");
+      } else {
+        Deno.env.set("HOME", previousHome);
+      }
+    }
+  } finally {
+    await Deno.remove(tempHome, { recursive: true });
+  }
+});

--- a/tests/integration/setup_wizard_test.ts
+++ b/tests/integration/setup_wizard_test.ts
@@ -16,6 +16,9 @@ import { assert, assertEquals, assertRejects } from "@std/assert";
 
 import { parseConfig } from "../../src/config/schema.ts";
 import {
+  type ByteReader,
+  type ByteWriter,
+  createWizardIo,
   runSetupWizard,
   SetupWizardError,
   type SetupWizardIo,
@@ -400,4 +403,109 @@ Deno.test("runSetupWizard: expands ~/ for the private-key existence check", asyn
   } finally {
     await Deno.remove(tempHome, { recursive: true });
   }
+});
+
+// ---------------------------------------------------------------------------
+// createWizardIo: line-buffered reader, CR-stripping, EOF handling
+// ---------------------------------------------------------------------------
+
+/**
+ * Buffer-backed {@link ByteReader} over a fixed UTF-8 string. The
+ * reader hands out one chunk per call so the line buffer's
+ * "concatenate across reads" path is exercised.
+ */
+class StringReader implements ByteReader {
+  private buffer: Uint8Array;
+  private offset = 0;
+  private readonly maxChunkBytes: number;
+
+  constructor(text: string, maxChunkBytes: number = 4) {
+    this.buffer = new TextEncoder().encode(text);
+    this.maxChunkBytes = maxChunkBytes;
+  }
+
+  read(out: Uint8Array): Promise<number | null> {
+    if (this.offset >= this.buffer.length) {
+      return Promise.resolve(null);
+    }
+    const remaining = this.buffer.length - this.offset;
+    const limit = Math.min(out.length, this.maxChunkBytes, remaining);
+    out.set(this.buffer.subarray(this.offset, this.offset + limit));
+    this.offset += limit;
+    return Promise.resolve(limit);
+  }
+}
+
+/** Capture-all {@link ByteWriter} for assertions. */
+class CapturingWriter implements ByteWriter {
+  readonly chunks: Uint8Array[] = [];
+
+  write(buffer: Uint8Array): Promise<number> {
+    this.chunks.push(new Uint8Array(buffer));
+    return Promise.resolve(buffer.length);
+  }
+
+  text(): string {
+    let total = 0;
+    for (const chunk of this.chunks) total += chunk.length;
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of this.chunks) {
+      out.set(chunk, offset);
+      offset += chunk.length;
+    }
+    return new TextDecoder().decode(out);
+  }
+}
+
+const dummyClient: WizardGitHubClient = {
+  getInstallations: () => Promise.resolve([]),
+};
+
+Deno.test("createWizardIo: reads multi-byte chunks and yields one line at a time", async () => {
+  const reader = new StringReader("alpha\nbeta\ngamma\n", 3);
+  const writer = new CapturingWriter();
+  const io = createWizardIo(reader, writer, dummyClient);
+  assertEquals(await io.readLine(), "alpha");
+  assertEquals(await io.readLine(), "beta");
+  assertEquals(await io.readLine(), "gamma");
+  assertEquals(await io.readLine(), null);
+});
+
+Deno.test("createWizardIo: strips a trailing carriage return", async () => {
+  const reader = new StringReader("alpha\r\nbeta\r\n", 4);
+  const io = createWizardIo(reader, new CapturingWriter(), dummyClient);
+  assertEquals(await io.readLine(), "alpha");
+  assertEquals(await io.readLine(), "beta");
+  assertEquals(await io.readLine(), null);
+});
+
+Deno.test("createWizardIo: yields a final line without a trailing newline", async () => {
+  const reader = new StringReader("alpha\nbeta", 8);
+  const io = createWizardIo(reader, new CapturingWriter(), dummyClient);
+  assertEquals(await io.readLine(), "alpha");
+  assertEquals(await io.readLine(), "beta");
+  assertEquals(await io.readLine(), null);
+});
+
+Deno.test("createWizardIo: yields a final CR-stripped line at EOF", async () => {
+  const reader = new StringReader("trailing\r", 16);
+  const io = createWizardIo(reader, new CapturingWriter(), dummyClient);
+  assertEquals(await io.readLine(), "trailing");
+  assertEquals(await io.readLine(), null);
+});
+
+Deno.test("createWizardIo: writeLine appends a newline per call", async () => {
+  const writer = new CapturingWriter();
+  const io = createWizardIo(new StringReader("", 1), writer, dummyClient);
+  await io.writeLine("hello");
+  await io.writeLine("world");
+  assertEquals(writer.text(), "hello\nworld\n");
+});
+
+Deno.test("createWizardIo: returns null repeatedly after EOF", async () => {
+  const reader = new StringReader("", 4);
+  const io = createWizardIo(reader, new CapturingWriter(), dummyClient);
+  assertEquals(await io.readLine(), null);
+  assertEquals(await io.readLine(), null);
 });

--- a/tests/unit/config_load_test.ts
+++ b/tests/unit/config_load_test.ts
@@ -15,7 +15,17 @@
 
 import { assert, assertEquals, assertRejects, assertThrows } from "@std/assert";
 
-import { ConfigLoadError, expandHome, loadConfig } from "../../src/config/load.ts";
+import { ConfigLoadError, type EnvLookup, expandHome, loadConfig } from "../../src/config/load.ts";
+
+/**
+ * Build an `EnvLookup` over a fixed map. Tests use this instead of
+ * mutating `Deno.env`; the suite runs with `--parallel`, so global env
+ * mutation can race across files.
+ */
+function envLookupFrom(entries: Record<string, string>): EnvLookup {
+  const map = new Map(Object.entries(entries));
+  return (name) => map.get(name);
+}
 
 function fullValidConfigText(): string {
   return JSON.stringify(
@@ -97,18 +107,13 @@ Deno.test("loadConfig: expands a leading ~/ against $HOME", async () => {
   try {
     const filePath = `${tempDir}/config.json`;
     await Deno.writeTextFile(filePath, fullValidConfigText());
-    const previousHome = Deno.env.get("HOME");
-    Deno.env.set("HOME", tempDir);
-    try {
-      const config = await loadConfig("~/config.json");
-      assertEquals(config.github.appId, 1234567);
-    } finally {
-      if (previousHome === undefined) {
-        Deno.env.delete("HOME");
-      } else {
-        Deno.env.set("HOME", previousHome);
-      }
-    }
+    // Inject a per-test `EnvLookup` rather than mutating `Deno.env` so
+    // the suite can run with `deno test --parallel` without racing.
+    const config = await loadConfig(
+      "~/config.json",
+      envLookupFrom({ HOME: tempDir }),
+    );
+    assertEquals(config.github.appId, 1234567);
   } finally {
     await Deno.remove(tempDir, { recursive: true });
   }
@@ -197,77 +202,45 @@ Deno.test("loadConfig: read-failed surfaces when the path points at a directory"
 });
 
 Deno.test("expandHome: returns ~ alone as $HOME", () => {
-  const previous = Deno.env.get("HOME");
-  Deno.env.set("HOME", "/Users/mock");
-  try {
-    assertEquals(expandHome("~"), "/Users/mock");
-  } finally {
-    if (previous === undefined) {
-      Deno.env.delete("HOME");
-    } else {
-      Deno.env.set("HOME", previous);
-    }
-  }
+  assertEquals(
+    expandHome("~", envLookupFrom({ HOME: "/Users/mock" })),
+    "/Users/mock",
+  );
 });
 
 Deno.test("expandHome: leaves non-~ paths untouched", () => {
-  assertEquals(expandHome("/abs/path"), "/abs/path");
-  assertEquals(expandHome("./rel"), "./rel");
-  assertEquals(expandHome("~user/foo"), "~user/foo");
+  // No `$HOME` lookup is needed for these inputs; pass an empty env so
+  // a future bug that *does* reach for `HOME` would surface as a clear
+  // "cannot expand" error.
+  const empty = envLookupFrom({});
+  assertEquals(expandHome("/abs/path", empty), "/abs/path");
+  assertEquals(expandHome("./rel", empty), "./rel");
+  assertEquals(expandHome("~user/foo", empty), "~user/foo");
 });
 
 Deno.test("expandHome: handles a $HOME with a trailing slash without producing //", () => {
-  const previous = Deno.env.get("HOME");
-  Deno.env.set("HOME", "/Users/mock/");
-  try {
-    assertEquals(expandHome("~/foo/bar"), "/Users/mock/foo/bar");
-  } finally {
-    if (previous === undefined) {
-      Deno.env.delete("HOME");
-    } else {
-      Deno.env.set("HOME", previous);
-    }
-  }
+  assertEquals(
+    expandHome("~/foo/bar", envLookupFrom({ HOME: "/Users/mock/" })),
+    "/Users/mock/foo/bar",
+  );
 });
 
 Deno.test("expandHome: throws when ~/ is used without $HOME set", () => {
   // Per ADR-008 (Windows out of scope) the loader only honors $HOME.
-  // The test scrubs USERPROFILE too so we'd notice if a future change
-  // accidentally re-introduced a Windows fallback.
-  const previousHome = Deno.env.get("HOME");
-  const previousProfile = Deno.env.get("USERPROFILE");
-  Deno.env.delete("HOME");
-  Deno.env.delete("USERPROFILE");
-  try {
-    assertThrows(() => expandHome("~/foo"), Error, "cannot expand");
-  } finally {
-    if (previousHome !== undefined) {
-      Deno.env.set("HOME", previousHome);
-    }
-    if (previousProfile !== undefined) {
-      Deno.env.set("USERPROFILE", previousProfile);
-    }
-  }
+  assertThrows(
+    () => expandHome("~/foo", envLookupFrom({})),
+    Error,
+    "cannot expand",
+  );
 });
 
 Deno.test("expandHome: ignores USERPROFILE (ADR-008 — Windows out of scope)", () => {
   // We do NOT promise %USERPROFILE% expansion. Setting it without HOME
   // must still raise so we never accidentally start advertising native
   // Windows behavior we don't actually support.
-  const previousHome = Deno.env.get("HOME");
-  const previousProfile = Deno.env.get("USERPROFILE");
-  Deno.env.delete("HOME");
-  Deno.env.set("USERPROFILE", "/Users/mock");
-  try {
-    assertThrows(() => expandHome("~/foo"), Error, "cannot expand");
-  } finally {
-    if (previousHome !== undefined) {
-      Deno.env.set("HOME", previousHome);
-    }
-    if (previousProfile === undefined) {
-      Deno.env.delete("USERPROFILE");
-    } else {
-      Deno.env.set("USERPROFILE", previousProfile);
-    }
-  }
+  assertThrows(
+    () => expandHome("~/foo", envLookupFrom({ USERPROFILE: "/Users/mock" })),
+    Error,
+    "cannot expand",
+  );
 });

--- a/tests/unit/config_load_test.ts
+++ b/tests/unit/config_load_test.ts
@@ -230,7 +230,10 @@ Deno.test("expandHome: handles a $HOME with a trailing slash without producing /
   }
 });
 
-Deno.test("expandHome: throws when ~/ is used without a home directory", () => {
+Deno.test("expandHome: throws when ~/ is used without $HOME set", () => {
+  // Per ADR-008 (Windows out of scope) the loader only honors $HOME.
+  // The test scrubs USERPROFILE too so we'd notice if a future change
+  // accidentally re-introduced a Windows fallback.
   const previousHome = Deno.env.get("HOME");
   const previousProfile = Deno.env.get("USERPROFILE");
   Deno.env.delete("HOME");
@@ -247,13 +250,16 @@ Deno.test("expandHome: throws when ~/ is used without a home directory", () => {
   }
 });
 
-Deno.test("expandHome: falls back to USERPROFILE when HOME is unset", () => {
+Deno.test("expandHome: ignores USERPROFILE (ADR-008 — Windows out of scope)", () => {
+  // We do NOT promise %USERPROFILE% expansion. Setting it without HOME
+  // must still raise so we never accidentally start advertising native
+  // Windows behavior we don't actually support.
   const previousHome = Deno.env.get("HOME");
   const previousProfile = Deno.env.get("USERPROFILE");
   Deno.env.delete("HOME");
   Deno.env.set("USERPROFILE", "/Users/mock");
   try {
-    assertEquals(expandHome("~/foo"), "/Users/mock/foo");
+    assertThrows(() => expandHome("~/foo"), Error, "cannot expand");
   } finally {
     if (previousHome !== undefined) {
       Deno.env.set("HOME", previousHome);

--- a/tests/unit/config_load_test.ts
+++ b/tests/unit/config_load_test.ts
@@ -1,0 +1,267 @@
+/**
+ * Unit tests for `src/config/load.ts`.
+ *
+ * Covers:
+ *   - Happy path against a JSON file: round-trips through
+ *     {@link parseConfig} and yields a typed {@link Config}.
+ *   - JSONC-tolerance: comments and trailing commas parse cleanly.
+ *   - `~/` expansion: a leading `~/` resolves against `$HOME` (the
+ *     loader runs the home expansion before reading).
+ *   - Failure modes: missing file, malformed JSON, schema-invalid
+ *     content. Each surfaces a {@link ConfigLoadError} with the
+ *     expected `kind`, and the schema-failure message embeds the
+ *     failing zod path.
+ */
+
+import { assert, assertEquals, assertRejects, assertThrows } from "@std/assert";
+
+import { ConfigLoadError, expandHome, loadConfig } from "../../src/config/load.ts";
+
+function fullValidConfigText(): string {
+  return JSON.stringify(
+    {
+      github: {
+        appId: 1234567,
+        privateKeyPath: "/keys/app.pem",
+        installations: { "owner/repo": 9876543 },
+        defaultRepo: "owner/repo",
+      },
+      agent: {
+        model: "claude-sonnet-4-6",
+        permissionMode: "acceptEdits",
+        maxIterationsPerTask: 4,
+      },
+      lifecycle: {
+        mergeMode: "squash",
+        settlingWindowMilliseconds: 60_000,
+        pollIntervalMilliseconds: 30_000,
+        preserveWorktreeOnMerge: false,
+      },
+      workspace: "/tmp/workspace",
+      daemon: { socketPath: "/tmp/daemon.sock", autoStart: true },
+      tui: { keybindings: { commandPalette: "ctrl+p", taskSwitcher: "ctrl+g" } },
+    },
+    null,
+    2,
+  );
+}
+
+async function withTempFile<T>(
+  contents: string,
+  body: (path: string) => Promise<T>,
+): Promise<T> {
+  const path = await Deno.makeTempFile({ prefix: "makina-config-", suffix: ".json" });
+  try {
+    await Deno.writeTextFile(path, contents);
+    return await body(path);
+  } finally {
+    await Deno.remove(path).catch(() => {});
+  }
+}
+
+Deno.test("loadConfig: happy path returns the parsed config", async () => {
+  await withTempFile(fullValidConfigText(), async (path) => {
+    const config = await loadConfig(path);
+    assertEquals(config.github.appId, 1234567);
+    assertEquals(config.github.defaultRepo, "owner/repo");
+    assertEquals(config.lifecycle.mergeMode, "squash");
+  });
+});
+
+Deno.test("loadConfig: tolerates JSONC comments and trailing commas", async () => {
+  const jsonc = `// makina config
+{
+  "github": {
+    "appId": 1, // an inline comment
+    "privateKeyPath": "/k.pem",
+    "installations": { "a/b": 1 },
+    "defaultRepo": "a/b",
+  },
+  /* a block
+     comment */
+  "agent": { "model": "m", "permissionMode": "acceptEdits" },
+  "lifecycle": { "mergeMode": "manual" },
+  "workspace": "/w",
+  "daemon": { "socketPath": "/s" },
+}
+`;
+  await withTempFile(jsonc, async (path) => {
+    const config = await loadConfig(path);
+    assertEquals(config.github.appId, 1);
+    assertEquals(config.lifecycle.mergeMode, "manual");
+  });
+});
+
+Deno.test("loadConfig: expands a leading ~/ against $HOME", async () => {
+  const tempDir = await Deno.makeTempDir({ prefix: "makina-home-" });
+  try {
+    const filePath = `${tempDir}/config.json`;
+    await Deno.writeTextFile(filePath, fullValidConfigText());
+    const previousHome = Deno.env.get("HOME");
+    Deno.env.set("HOME", tempDir);
+    try {
+      const config = await loadConfig("~/config.json");
+      assertEquals(config.github.appId, 1234567);
+    } finally {
+      if (previousHome === undefined) {
+        Deno.env.delete("HOME");
+      } else {
+        Deno.env.set("HOME", previousHome);
+      }
+    }
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("loadConfig: missing file raises ConfigLoadError(not-found)", async () => {
+  const tempDir = await Deno.makeTempDir({ prefix: "makina-missing-" });
+  try {
+    const missingPath = `${tempDir}/does-not-exist.json`;
+    const error = await assertRejects(
+      () => loadConfig(missingPath),
+      ConfigLoadError,
+    );
+    assertEquals(error.kind, "not-found");
+    assertEquals(error.resolvedPath, missingPath);
+    assert(error.message.includes(missingPath));
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("loadConfig: invalid JSON raises ConfigLoadError(invalid-json)", async () => {
+  await withTempFile("{ this is not json", async (path) => {
+    const error = await assertRejects(
+      () => loadConfig(path),
+      ConfigLoadError,
+    );
+    assertEquals(error.kind, "invalid-json");
+    assertEquals(error.resolvedPath, path);
+  });
+});
+
+Deno.test("loadConfig: schema failure embeds zod path in the message", async () => {
+  const broken = JSON.parse(fullValidConfigText());
+  broken.github.appId = -1;
+  await withTempFile(JSON.stringify(broken), async (path) => {
+    const error = await assertRejects(
+      () => loadConfig(path),
+      ConfigLoadError,
+    );
+    assertEquals(error.kind, "invalid-schema");
+    assert(error.message.includes("github.appId"));
+    assert(error.issues.length > 0);
+    const first = error.issues[0];
+    assert(first !== undefined);
+    assertEquals(first.path[0], "github");
+    assertEquals(first.path[1], "appId");
+  });
+});
+
+Deno.test("loadConfig: schema failure with non-identifier key uses bracket notation", async () => {
+  const broken = JSON.parse(fullValidConfigText());
+  // Put an installation slug that contains slashes, then break the
+  // installation id type so the failing path includes the slug as a
+  // record key — the load-error formatter renders it with bracket
+  // notation rather than dot notation.
+  broken.github.installations = { "owner/repo": "not-a-number" };
+  await withTempFile(JSON.stringify(broken), async (path) => {
+    const error = await assertRejects(
+      () => loadConfig(path),
+      ConfigLoadError,
+    );
+    assertEquals(error.kind, "invalid-schema");
+    assert(
+      error.message.includes('github.installations["owner/repo"]'),
+      `expected bracket-notation rendering; got: ${error.message}`,
+    );
+  });
+});
+
+Deno.test("loadConfig: read-failed surfaces when the path points at a directory", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "makina-dir-" });
+  try {
+    const error = await assertRejects(
+      () => loadConfig(dir),
+      ConfigLoadError,
+    );
+    // On macOS / Linux, reading a directory returns IsADirectory or
+    // similar; the loader does not specialise on it, so it manifests as
+    // `read-failed`.
+    assertEquals(error.kind, "read-failed");
+    assertEquals(error.resolvedPath, dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("expandHome: returns ~ alone as $HOME", () => {
+  const previous = Deno.env.get("HOME");
+  Deno.env.set("HOME", "/Users/mock");
+  try {
+    assertEquals(expandHome("~"), "/Users/mock");
+  } finally {
+    if (previous === undefined) {
+      Deno.env.delete("HOME");
+    } else {
+      Deno.env.set("HOME", previous);
+    }
+  }
+});
+
+Deno.test("expandHome: leaves non-~ paths untouched", () => {
+  assertEquals(expandHome("/abs/path"), "/abs/path");
+  assertEquals(expandHome("./rel"), "./rel");
+  assertEquals(expandHome("~user/foo"), "~user/foo");
+});
+
+Deno.test("expandHome: handles a $HOME with a trailing slash without producing //", () => {
+  const previous = Deno.env.get("HOME");
+  Deno.env.set("HOME", "/Users/mock/");
+  try {
+    assertEquals(expandHome("~/foo/bar"), "/Users/mock/foo/bar");
+  } finally {
+    if (previous === undefined) {
+      Deno.env.delete("HOME");
+    } else {
+      Deno.env.set("HOME", previous);
+    }
+  }
+});
+
+Deno.test("expandHome: throws when ~/ is used without a home directory", () => {
+  const previousHome = Deno.env.get("HOME");
+  const previousProfile = Deno.env.get("USERPROFILE");
+  Deno.env.delete("HOME");
+  Deno.env.delete("USERPROFILE");
+  try {
+    assertThrows(() => expandHome("~/foo"), Error, "cannot expand");
+  } finally {
+    if (previousHome !== undefined) {
+      Deno.env.set("HOME", previousHome);
+    }
+    if (previousProfile !== undefined) {
+      Deno.env.set("USERPROFILE", previousProfile);
+    }
+  }
+});
+
+Deno.test("expandHome: falls back to USERPROFILE when HOME is unset", () => {
+  const previousHome = Deno.env.get("HOME");
+  const previousProfile = Deno.env.get("USERPROFILE");
+  Deno.env.delete("HOME");
+  Deno.env.set("USERPROFILE", "/Users/mock");
+  try {
+    assertEquals(expandHome("~/foo"), "/Users/mock/foo");
+  } finally {
+    if (previousHome !== undefined) {
+      Deno.env.set("HOME", previousHome);
+    }
+    if (previousProfile === undefined) {
+      Deno.env.delete("USERPROFILE");
+    } else {
+      Deno.env.set("USERPROFILE", previousProfile);
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Implements [#3](https://github.com/koraytaylan/makina/issues/3) — config loader and `setup` wizard.

## Linked issue

Closes #3

## Definition of Done

- [x] JSDoc on every exported symbol; `deno doc --lint` green.
- [x] Tests cover the new code; coverage \(\geq\) 80% lines + branches.
- [x] Commits follow Conventional Commits.
- [x] `deno task ci` is green on this branch.

## References

- Plan §Configuration; ADR-003.
