### PR TITLE
feat(#5): high-level GitHubClient over @octokit/core

### DIFF
--- a/docs/adrs/010-github-client-rate-limit-retry-policy.md
+++ b/docs/adrs/010-github-client-rate-limit-retry-policy.md
@@ -1,0 +1,83 @@
+# ADR-010: Header-driven retry policy for the GitHub client
+
+## Status
+
+Accepted (2026-04-26).
+
+## Context
+
+`GitHubClientImpl` (Wave 2) wraps `@octokit/core` and is the only HTTP path the supervisor uses to
+talk to GitHub. We need a retry policy for transient failures that:
+
+1. Honors GitHub's two flavors of rate limit (primary quota and secondary abuse limits) so we wait
+   the right amount instead of pounding the API.
+2. Does **not** retry on non-rate-limit errors, because every retry adds latency the supervisor
+   hides badly — the stabilize loop already has a higher-level backoff for unknown failures.
+
+GitHub signals rate limits two ways:
+
+- `Retry-After: <seconds>` on `429` — the secondary (abuse) rate limit.
+- `X-RateLimit-Remaining: 0` paired with `X-RateLimit-Reset: <epoch-seconds>` on `403` (and
+  occasionally `429`) — the primary, hourly-bucket quota.
+
+Plain `403` without those headers is a permission/scope error: the installation token is missing a
+permission, the SSO authorization expired, the resource is private to a different org. Retrying
+makes the same call return the same `403` after a needless sleep.
+
+The first cut of the client retried _any_ `403`/`429`: when no header guidance was present,
+`computeRetrySleepMilliseconds` always fell back to a 1 s constant sleep. The Copilot review on PR
+#29 (issue #5) flagged that this both contradicts the JSDoc on the function ("returns null when no
+header guidance applies") and inflates latency on the permission-error path.
+
+## Decision
+
+The retry fires **only** on a clear rate-limit signal:
+
+1. `Retry-After` present (any 4xx) → sleep that many seconds, retry once.
+2. `X-RateLimit-Remaining: 0` paired with `X-RateLimit-Reset` present (any 4xx) → sleep until the
+   reset, retry once.
+3. `429` with neither header → fall back to `DEFAULT_FALLBACK_RETRY_SLEEP_MILLISECONDS` (1 s) and
+   retry once. The `429` status alone is a rate-limit signal.
+4. `403` with neither header → propagate immediately. No sleep, no retry.
+5. Anything else (`5xx`, `404`, etc.) → propagate immediately.
+
+`computeRetrySleepMilliseconds` returns `number | null` for real now: `null` means "do not retry,"
+which `requestWithRetry` translates into a propagated error. The 1 s constant is cap-clamped by
+`maxRetrySleepMilliseconds` so a future caller cannot exceed the configured retry ceiling.
+
+Sleep durations are clamped from above by `maxRetrySleepMilliseconds` (default 5 minutes) so a
+runaway `Retry-After` cannot stall the supervisor for an hour. Negative deltas (a reset already in
+the past) clamp to 0 — we still issue the retry immediately because the bucket has already refilled.
+
+## Consequences
+
+**Positive:**
+
+- Permission errors (`403` without rate-limit headers) surface in roughly one round-trip instead of
+  one round-trip plus 1 s of dead-air. Useful when the supervisor needs to flag `NEEDS_HUMAN`
+  promptly.
+- The retry semantics now match the JSDoc and read straight off the headers — there is one sentence
+  ("did GitHub tell us to wait?") that decides whether to retry, and that sentence is inspectable
+  from the response.
+- The narrower retry surface keeps the request log shorter, which makes the `github-call` TaskEvents
+  easier to read in the TUI.
+
+**Negative:**
+
+- A future GitHub change that started returning `403` for transient rate-limit conditions without
+  any of the three headers above would not retry. We accept that: GitHub's contract for primary rate
+  limits is documented to include the `X-RateLimit-Reset` header, and if it ever stops we want a
+  loud failure rather than silent retries.
+- The retry policy is per-request and stateless. Multiple concurrent rate-limited calls each pay
+  their own retry sleep instead of coordinating — the supervisor caps in-flight requests elsewhere;
+  no shared limiter is needed at this layer.
+
+## Alternatives considered
+
+- **Always retry on 4xx with a constant fallback.** Original behavior. Rejected: confuses rate-limit
+  and permission failures, and the constant sleep adds latency on every permission error.
+- **Retry 5xx as well.** Rejected: the supervisor's stabilize loop has its own backoff that already
+  handles transient GitHub trouble; retrying both layers compounds latency on a real outage.
+- **Use `@octokit/plugin-retry`.** Rejected for now: the plugin's policy is opinionated and adds
+  another dependency for behavior we can express in ~30 lines. Revisit if our retry needs grow (e.g.
+  exponential backoff, circuit-breaker semantics).

--- a/docs/adrs/011-github-client-rate-limit-retry-policy.md
+++ b/docs/adrs/011-github-client-rate-limit-retry-policy.md
@@ -1,4 +1,4 @@
-# ADR-010: Header-driven retry policy for the GitHub client
+# ADR-011: Header-driven retry policy for the GitHub client
 
 ## Status
 
@@ -29,21 +29,32 @@ The first cut of the client retried _any_ `403`/`429`: when no header guidance w
 #29 (issue #5) flagged that this both contradicts the JSDoc on the function ("returns null when no
 header guidance applies") and inflates latency on the permission-error path.
 
+A second pass of that same review flagged a leftover contradiction: the prose said the retry should
+fire on a `Retry-After` header for any 4xx, but `requestWithRetry` still gated on
+`status ∈ {403, 429}` before consulting the headers. We resolved it the way the prose read:
+`requestWithRetry` no longer gates on status, and the header check itself is the gate.
+
 ## Decision
 
-The retry fires **only** on a clear rate-limit signal:
+The retry fires **only** on a clear rate-limit signal. The decision lives entirely in
+`computeRetrySleepMilliseconds(status, headers)`; `requestWithRetry` simply propagates when that
+function returns `null`. The signals it honors:
 
-1. `Retry-After` present (any 4xx) → sleep that many seconds, retry once.
-2. `X-RateLimit-Remaining: 0` paired with `X-RateLimit-Reset` present (any 4xx) → sleep until the
-   reset, retry once.
+1. `Retry-After` present (any HTTP status) → sleep that many seconds, retry once.
+2. `X-RateLimit-Remaining: 0` paired with `X-RateLimit-Reset` present (any HTTP status) → sleep
+   until the reset, retry once.
 3. `429` with neither header → fall back to `DEFAULT_FALLBACK_RETRY_SLEEP_MILLISECONDS` (1 s) and
    retry once. The `429` status alone is a rate-limit signal.
 4. `403` with neither header → propagate immediately. No sleep, no retry.
-5. Anything else (`5xx`, `404`, etc.) → propagate immediately.
+5. Anything else (`5xx`, `404`, etc.) with no rate-limit headers → propagate immediately.
 
 `computeRetrySleepMilliseconds` returns `number | null` for real now: `null` means "do not retry,"
 which `requestWithRetry` translates into a propagated error. The 1 s constant is cap-clamped by
 `maxRetrySleepMilliseconds` so a future caller cannot exceed the configured retry ceiling.
+
+Decoupling the retry decision from the status code costs us nothing in practice — GitHub only sets
+`Retry-After` / `X-RateLimit-Reset` on rate-limited responses — but it keeps the impl and the ADR
+saying the same thing in one place: "did GitHub tell us to wait?"
 
 Sleep durations are clamped from above by `maxRetrySleepMilliseconds` (default 5 minutes) so a
 runaway `Retry-After` cannot stall the supervisor for an hour. Negative deltas (a reset already in

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -1,0 +1,812 @@
+/**
+ * github/client.ts — high-level typed GitHub client used by the supervisor.
+ *
+ * Implements {@link GitHubClient} from `src/types.ts` and adds the four
+ * stabilize-phase methods (`listCheckRuns`, `getCheckRunLogs`,
+ * `listReviews`, `listReviewComments`) the Wave 4 conversations and CI
+ * loops need. Built on `@octokit/core` with a {@link GitHubAuth}
+ * strategy injected: every request resolves an installation token via
+ * `getInstallationToken` immediately before the call so token rotation
+ * is automatic.
+ *
+ * **Rate-limit awareness.** `Retry-After` (secondary rate limit) and
+ * `X-RateLimit-Reset` (primary rate limit) are honored: when GitHub
+ * answers `429` or `403` with one of those headers, the client sleeps
+ * the indicated duration and retries the request **once**. A second
+ * failure propagates. 5xx responses propagate immediately — they
+ * indicate transient GitHub trouble that the supervisor's higher-level
+ * retry policy handles.
+ *
+ * **Test seam.** `Octokit` exposes a `request: { fetch }` option;
+ * `tests/unit/github_client_test.ts` injects a scripted fake fetch so
+ * unit tests never touch the network. The {@link GitHubClientOptions}
+ * surface forwards `fetch` and `nowMilliseconds`/`sleepMilliseconds`
+ * hooks so the rate-limit branches are deterministic.
+ *
+ * @module
+ */
+
+import { Octokit } from "@octokit/core";
+
+import {
+  type CombinedStatus,
+  type GitHubAuth,
+  type GitHubClient,
+  type InstallationId,
+  type IssueDetails,
+  type IssueNumber,
+  makeIssueNumber,
+  type MergeMode,
+  type PullRequestDetails,
+  type RepoFullName,
+} from "../types.ts";
+
+// ---------------------------------------------------------------------------
+// Public extra payload types (the four methods not in the W1 interface)
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregate result of a single GitHub check run.
+ *
+ * Mirrors the subset of the [Check Runs API](https://docs.github.com/en/rest/checks/runs)
+ * payload the stabilize loop reads.
+ */
+export interface CheckRunSummary {
+  /** Numeric check-run id; stable per push. */
+  readonly id: number;
+  /** Workflow / check name (e.g. `"build"`, `"ci/lint"`). */
+  readonly name: string;
+  /** Lifecycle status of the run. */
+  readonly status: "queued" | "in_progress" | "completed";
+  /**
+   * Final outcome once `status === "completed"`; `null` while the run is
+   * still queued or in progress.
+   */
+  readonly conclusion:
+    | "success"
+    | "failure"
+    | "neutral"
+    | "cancelled"
+    | "timed_out"
+    | "action_required"
+    | "stale"
+    | "skipped"
+    | null;
+  /** URL of the check-run details page on GitHub. */
+  readonly htmlUrl: string;
+}
+
+/**
+ * One review submitted on a pull request.
+ *
+ * Mirrors the subset of the [Pulls Reviews API](https://docs.github.com/en/rest/pulls/reviews)
+ * the stabilize loop's conversations phase reads.
+ */
+export interface PullRequestReview {
+  /** Review id; stable. */
+  readonly id: number;
+  /** Login of the reviewer (or bot). */
+  readonly user: string;
+  /** Verdict the reviewer left. */
+  readonly state:
+    | "APPROVED"
+    | "CHANGES_REQUESTED"
+    | "COMMENTED"
+    | "DISMISSED"
+    | "PENDING";
+  /** Free-text review body. */
+  readonly body: string;
+  /** ISO-8601 timestamp the review was submitted, when present. */
+  readonly submittedAtIso?: string;
+}
+
+/**
+ * One inline review comment on a pull request.
+ *
+ * Mirrors the subset of the [Pulls Comments API](https://docs.github.com/en/rest/pulls/comments)
+ * the stabilize loop reads. Threading metadata
+ * (`pull_request_review_id`, `in_reply_to_id`) is preserved so the
+ * conversations phase can group comments by thread.
+ */
+export interface PullRequestReviewComment {
+  /** Comment id; stable. */
+  readonly id: number;
+  /** Review id this comment belongs to, when present. */
+  readonly pullRequestReviewId: number | null;
+  /** Login of the commenter. */
+  readonly user: string;
+  /** Comment body (markdown). */
+  readonly body: string;
+  /** Repository file path the comment is anchored to. */
+  readonly path: string;
+  /** Diff line the comment targets, when present. */
+  readonly line: number | null;
+  /** Parent comment id when this is a reply, otherwise `null`. */
+  readonly inReplyToId: number | null;
+  /** ISO-8601 timestamp the comment was created. */
+  readonly createdAtIso: string;
+}
+
+// ---------------------------------------------------------------------------
+// Options surface
+// ---------------------------------------------------------------------------
+
+/**
+ * Construction options for {@link GitHubClient}.
+ *
+ * Every field except `auth` and `installationId` is optional; the
+ * default values reproduce real-world behavior. The `now`,
+ * `sleep`, and `fetch` hooks exist so the unit tests can drive the
+ * rate-limit retry branches without sleeping for real or hitting the
+ * network.
+ */
+export interface GitHubClientOptions {
+  /** Installation-token mint; usually `src/github/app-auth.ts`. */
+  readonly auth: GitHubAuth;
+  /** Installation id this client makes requests on behalf of. */
+  readonly installationId: InstallationId;
+  /**
+   * `User-Agent` to send. Defaults to `makina-github-client/0.1`. GitHub
+   * rejects requests without a `User-Agent`.
+   */
+  readonly userAgent?: string;
+  /**
+   * Override the base URL (defaults to `https://api.github.com`). Useful
+   * for testing against GitHub Enterprise stand-ins.
+   */
+  readonly baseUrl?: string;
+  /**
+   * Inject the underlying `fetch`. Tests pass a scripted fake;
+   * production leaves this undefined and `@octokit/core` uses the
+   * runtime `fetch`.
+   */
+  readonly fetch?: typeof fetch;
+  /**
+   * Wall-clock source used to compute `X-RateLimit-Reset` waits.
+   * Defaults to `() => Date.now()`.
+   */
+  readonly nowMilliseconds?: () => number;
+  /**
+   * Sleep primitive used between a rate-limited response and the retry.
+   * Defaults to `globalThis.setTimeout`-based sleep.
+   */
+  readonly sleepMilliseconds?: (milliseconds: number) => Promise<void>;
+  /**
+   * Upper bound on a single retry sleep, in milliseconds. Caps absurd
+   * `Retry-After`/`X-RateLimit-Reset` values so a buggy GitHub never
+   * stalls the supervisor for an hour. Defaults to
+   * {@link DEFAULT_MAX_RETRY_SLEEP_MILLISECONDS}.
+   */
+  readonly maxRetrySleepMilliseconds?: number;
+}
+
+/**
+ * Default cap on a single rate-limit retry sleep, in milliseconds.
+ *
+ * Five minutes is well above any realistic `Retry-After` GitHub returns
+ * for secondary limits but well below the supervisor's settling window
+ * upper bound. See {@link GitHubClientOptions.maxRetrySleepMilliseconds}.
+ */
+export const DEFAULT_MAX_RETRY_SLEEP_MILLISECONDS = 5 * 60 * 1_000;
+
+/**
+ * Default fallback sleep when GitHub flagged us with `429`/`403` but
+ * supplied no `Retry-After` or `X-RateLimit-Reset` header. One second
+ * is conservative — enough to clear a transient burst without serializing
+ * the supervisor on every retry.
+ */
+export const DEFAULT_FALLBACK_RETRY_SLEEP_MILLISECONDS = 1_000;
+
+/**
+ * HTTP status codes that trigger a single rate-limit-aware retry. `429`
+ * is GitHub's secondary rate-limit signal; `403` is the primary one when
+ * the remaining quota is exhausted (also expressed via
+ * `X-RateLimit-Remaining: 0`).
+ */
+const RATE_LIMITED_STATUS_CODES: ReadonlySet<number> = new Set([403, 429]);
+
+const HEADER_RETRY_AFTER = "retry-after";
+const HEADER_RATE_LIMIT_REMAINING = "x-ratelimit-remaining";
+const HEADER_RATE_LIMIT_RESET = "x-ratelimit-reset";
+
+/**
+ * Default `User-Agent` string. GitHub demands a non-empty UA on every
+ * request; ours identifies the daemon and its version line.
+ */
+const DEFAULT_USER_AGENT = "makina-github-client/0.1";
+
+// ---------------------------------------------------------------------------
+// GitHubClient implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Concrete {@link GitHubClient} backed by `@octokit/core`.
+ *
+ * Construct one per installation. Methods accept branded `RepoFullName`
+ * / `IssueNumber` arguments so the call sites cannot accidentally swap
+ * an installation id in for an issue number.
+ *
+ * @example
+ * ```ts
+ * import { GitHubAppAuth } from "./app-auth.ts";
+ * const auth = new GitHubAppAuth({ ... });
+ * const client = new GitHubClientImpl({
+ *   auth,
+ *   installationId: makeInstallationId(123),
+ * });
+ * const issue = await client.getIssue(makeRepoFullName("a/b"), makeIssueNumber(1));
+ * ```
+ */
+export class GitHubClientImpl implements GitHubClient {
+  private readonly auth: GitHubAuth;
+  private readonly installationId: InstallationId;
+  private readonly octokit: Octokit;
+  private readonly nowMilliseconds: () => number;
+  private readonly sleepMilliseconds: (milliseconds: number) => Promise<void>;
+  private readonly maxRetrySleepMilliseconds: number;
+
+  /**
+   * Construct a {@link GitHubClientImpl}.
+   *
+   * @param options Auth, installation, and (optionally) test seams. See
+   *   {@link GitHubClientOptions} for the full surface.
+   */
+  constructor(options: GitHubClientOptions) {
+    this.auth = options.auth;
+    this.installationId = options.installationId;
+    this.nowMilliseconds = options.nowMilliseconds ?? (() => Date.now());
+    this.sleepMilliseconds = options.sleepMilliseconds ?? defaultSleep;
+    this.maxRetrySleepMilliseconds = options.maxRetrySleepMilliseconds ??
+      DEFAULT_MAX_RETRY_SLEEP_MILLISECONDS;
+
+    const userAgent = options.userAgent ?? DEFAULT_USER_AGENT;
+    const octokitOptions: Record<string, unknown> = { userAgent };
+    if (options.baseUrl !== undefined) {
+      octokitOptions.baseUrl = options.baseUrl;
+    }
+    if (options.fetch !== undefined) {
+      octokitOptions.request = { fetch: options.fetch };
+    }
+    this.octokit = new Octokit(octokitOptions);
+  }
+
+  /**
+   * Fetch issue details.
+   *
+   * @param repo Target repository.
+   * @param issueNumber Issue number within `repo`.
+   * @returns A subset of the GitHub issue payload the supervisor reads.
+   */
+  async getIssue(repo: RepoFullName, issueNumber: IssueNumber): Promise<IssueDetails> {
+    const { owner, name } = splitRepo(repo);
+    const response = await this.requestWithRetry(
+      "GET /repos/{owner}/{repo}/issues/{issue_number}",
+      { owner, repo: name, issue_number: issueNumber },
+    );
+    const data = response.data as IssueResponse;
+    return {
+      number: makeIssueNumber(data.number),
+      title: data.title,
+      body: data.body ?? "",
+      state: data.state,
+    };
+  }
+
+  /**
+   * Open a pull request.
+   *
+   * @param repo Target repository.
+   * @param args Head/base refs and PR metadata.
+   * @returns The freshly-opened PR's id, head SHA, and refs.
+   */
+  async createPullRequest(
+    repo: RepoFullName,
+    args: { headRef: string; baseRef: string; title: string; body: string },
+  ): Promise<PullRequestDetails> {
+    const { owner, name } = splitRepo(repo);
+    const response = await this.requestWithRetry(
+      "POST /repos/{owner}/{repo}/pulls",
+      {
+        owner,
+        repo: name,
+        head: args.headRef,
+        base: args.baseRef,
+        title: args.title,
+        body: args.body,
+      },
+    );
+    return projectPullRequest(response.data as PullRequestResponse);
+  }
+
+  /**
+   * Request reviewers (e.g. `["Copilot"]`) on a pull request. The
+   * GitHub API treats this as fire-and-forget; no body is returned to
+   * the caller.
+   *
+   * @param repo Target repository.
+   * @param pullRequestNumber Pull-request number.
+   * @param reviewers GitHub logins to request review from.
+   */
+  async requestReviewers(
+    repo: RepoFullName,
+    pullRequestNumber: IssueNumber,
+    reviewers: readonly string[],
+  ): Promise<void> {
+    const { owner, name } = splitRepo(repo);
+    await this.requestWithRetry(
+      "POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",
+      {
+        owner,
+        repo: name,
+        pull_number: pullRequestNumber,
+        reviewers: [...reviewers],
+      },
+    );
+  }
+
+  /**
+   * Read the combined commit status (legacy Statuses API aggregate) for
+   * `sha`. The CI phase polls this until the state is non-pending.
+   *
+   * @param repo Target repository.
+   * @param sha Commit SHA.
+   * @returns Aggregate status across every contributing check.
+   */
+  async getCombinedStatus(repo: RepoFullName, sha: string): Promise<CombinedStatus> {
+    const { owner, name } = splitRepo(repo);
+    const response = await this.requestWithRetry(
+      "GET /repos/{owner}/{repo}/commits/{ref}/status",
+      { owner, repo: name, ref: sha },
+    );
+    const data = response.data as CombinedStatusResponse;
+    return { state: data.state, sha: data.sha };
+  }
+
+  /**
+   * List individual check runs (Checks API) attached to `sha`. The
+   * stabilize loop's CI phase reads this in addition to the combined
+   * status to surface per-check failure context.
+   *
+   * @param repo Target repository.
+   * @param sha Commit SHA.
+   * @returns The check runs in GitHub's natural order.
+   */
+  async listCheckRuns(
+    repo: RepoFullName,
+    sha: string,
+  ): Promise<readonly CheckRunSummary[]> {
+    const { owner, name } = splitRepo(repo);
+    const response = await this.requestWithRetry(
+      "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
+      { owner, repo: name, ref: sha },
+    );
+    const data = response.data as CheckRunListResponse;
+    return data.check_runs.map((run) => ({
+      id: run.id,
+      name: run.name,
+      status: run.status,
+      conclusion: run.conclusion,
+      htmlUrl: run.html_url,
+    }));
+  }
+
+  /**
+   * Fetch the raw logs ZIP for a single check run. Returned as a
+   * `Uint8Array` so consumers can persist or extract without coupling
+   * to a streaming API.
+   *
+   * GitHub responds with `application/zip`; the agent runner's
+   * "explain CI failure" prompt unpacks the entry it cares about.
+   *
+   * @param repo Target repository.
+   * @param checkRunId Check-run id from {@link listCheckRuns}.
+   * @returns The ZIP bytes.
+   */
+  async getCheckRunLogs(repo: RepoFullName, checkRunId: number): Promise<Uint8Array> {
+    const { owner, name } = splitRepo(repo);
+    const response = await this.requestWithRetry(
+      "GET /repos/{owner}/{repo}/check-runs/{check_run_id}/logs",
+      {
+        owner,
+        repo: name,
+        check_run_id: checkRunId,
+        request: { parseSuccessResponseBody: false },
+      },
+    );
+    return await coerceToBytes(response.data);
+  }
+
+  /**
+   * List submitted reviews on a pull request, in submission order.
+   *
+   * @param repo Target repository.
+   * @param pullRequestNumber Pull-request number.
+   * @returns Reviews in their submission order.
+   */
+  async listReviews(
+    repo: RepoFullName,
+    pullRequestNumber: IssueNumber,
+  ): Promise<readonly PullRequestReview[]> {
+    const { owner, name } = splitRepo(repo);
+    const response = await this.requestWithRetry(
+      "GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+      { owner, repo: name, pull_number: pullRequestNumber },
+    );
+    const data = response.data as ReviewResponse[];
+    return data.map((review) => projectReview(review));
+  }
+
+  /**
+   * List inline review comments on a pull request, in creation order.
+   *
+   * @param repo Target repository.
+   * @param pullRequestNumber Pull-request number.
+   * @returns Inline review comments in their creation order.
+   */
+  async listReviewComments(
+    repo: RepoFullName,
+    pullRequestNumber: IssueNumber,
+  ): Promise<readonly PullRequestReviewComment[]> {
+    const { owner, name } = splitRepo(repo);
+    const response = await this.requestWithRetry(
+      "GET /repos/{owner}/{repo}/pulls/{pull_number}/comments",
+      { owner, repo: name, pull_number: pullRequestNumber },
+    );
+    const data = response.data as ReviewCommentResponse[];
+    return data.map((comment) => projectReviewComment(comment));
+  }
+
+  /**
+   * Merge the pull request per `mode`.
+   *
+   * - `"squash"` performs a squash merge.
+   * - `"rebase"` performs a rebase merge.
+   * - `"manual"` is a no-op at the API level — the supervisor stays in
+   *   `READY_TO_MERGE` and waits for the operator to merge from the
+   *   GitHub UI; we still validate the input so a stale call site
+   *   cannot pass `"manual"` and get a silent merge.
+   *
+   * @param repo Target repository.
+   * @param pullRequestNumber Pull-request number.
+   * @param mode Merge strategy.
+   */
+  async mergePullRequest(
+    repo: RepoFullName,
+    pullRequestNumber: IssueNumber,
+    mode: MergeMode,
+  ): Promise<void> {
+    if (mode === "manual") {
+      return;
+    }
+    const { owner, name } = splitRepo(repo);
+    await this.requestWithRetry(
+      "PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge",
+      {
+        owner,
+        repo: name,
+        pull_number: pullRequestNumber,
+        merge_method: mode,
+      },
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  /**
+   * Issue an Octokit request and retry exactly once when GitHub answers
+   * `403` or `429` with a `Retry-After` or `X-RateLimit-Reset` header.
+   * 5xx responses propagate immediately; the supervisor's higher-level
+   * retry policy decides whether to back off or fail the task.
+   */
+  private async requestWithRetry(
+    route: string,
+    parameters: Record<string, unknown>,
+  ): Promise<{ data: unknown; status: number; headers: Record<string, string> }> {
+    try {
+      return await this.executeRequest(route, parameters);
+    } catch (firstError) {
+      if (!(firstError instanceof Error)) throw firstError;
+      const status = readStatus(firstError);
+      const headers = readHeaders(firstError);
+      if (status !== undefined && RATE_LIMITED_STATUS_CODES.has(status)) {
+        const waitMilliseconds = this.computeRetrySleepMilliseconds(headers);
+        if (waitMilliseconds !== null) {
+          await this.sleepMilliseconds(waitMilliseconds);
+          return await this.executeRequest(route, parameters);
+        }
+      }
+      throw firstError;
+    }
+  }
+
+  /**
+   * Single Octokit invocation: mints a token, attaches it to the
+   * request, executes, and normalizes the response.
+   */
+  private async executeRequest(
+    route: string,
+    parameters: Record<string, unknown>,
+  ): Promise<{ data: unknown; status: number; headers: Record<string, string> }> {
+    const token = await this.auth.getInstallationToken(this.installationId);
+    const response = await this.octokit.request(route, {
+      ...parameters,
+      headers: {
+        authorization: `token ${token}`,
+      },
+    });
+    return {
+      data: response.data,
+      status: response.status,
+      headers: normalizeHeaderRecord(response.headers),
+    };
+  }
+
+  /**
+   * Translate the rate-limit response headers into a sleep duration in
+   * milliseconds. Returns `null` when no header guidance applies — but
+   * always falls back to {@link DEFAULT_FALLBACK_RETRY_SLEEP_MILLISECONDS}
+   * for a 429/403 with no headers because GitHub does occasionally
+   * return one without either.
+   *
+   * Honors:
+   *
+   * - `Retry-After` (seconds, GitHub secondary rate limit)
+   * - `X-RateLimit-Remaining: 0` paired with `X-RateLimit-Reset`
+   *   (Unix-seconds epoch, GitHub primary rate limit)
+   */
+  private computeRetrySleepMilliseconds(
+    headers: Record<string, string>,
+  ): number | null {
+    const retryAfter = headers[HEADER_RETRY_AFTER];
+    if (retryAfter !== undefined) {
+      const seconds = Number.parseFloat(retryAfter);
+      if (!Number.isNaN(seconds) && seconds >= 0) {
+        return clamp(seconds * 1_000, 0, this.maxRetrySleepMilliseconds);
+      }
+    }
+    const remainingRaw = headers[HEADER_RATE_LIMIT_REMAINING];
+    const resetRaw = headers[HEADER_RATE_LIMIT_RESET];
+    if (resetRaw !== undefined) {
+      const remaining = remainingRaw === undefined ? 0 : Number.parseInt(remainingRaw, 10);
+      if (!Number.isNaN(remaining) && remaining <= 0) {
+        const resetSeconds = Number.parseInt(resetRaw, 10);
+        if (!Number.isNaN(resetSeconds)) {
+          const deltaMilliseconds = resetSeconds * 1_000 - this.nowMilliseconds();
+          return clamp(deltaMilliseconds, 0, this.maxRetrySleepMilliseconds);
+        }
+      }
+    }
+    // No header guidance — fall back to a small constant so we still
+    // retry once. Cap by the configured max so a future caller cannot
+    // make this larger than the configured retry ceiling.
+    return clamp(
+      DEFAULT_FALLBACK_RETRY_SLEEP_MILLISECONDS,
+      0,
+      this.maxRetrySleepMilliseconds,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Local helpers
+// ---------------------------------------------------------------------------
+
+interface IssueResponse {
+  readonly number: number;
+  readonly title: string;
+  readonly body: string | null;
+  readonly state: "open" | "closed";
+}
+
+interface PullRequestResponse {
+  readonly number: number;
+  readonly head: { readonly sha: string; readonly ref: string };
+  readonly base: { readonly ref: string };
+  readonly state: "open" | "closed";
+  readonly merged?: boolean;
+  readonly merged_at?: string | null;
+}
+
+interface CombinedStatusResponse {
+  readonly state: "pending" | "success" | "failure" | "error";
+  readonly sha: string;
+}
+
+interface CheckRunListResponse {
+  readonly check_runs: readonly CheckRunResponse[];
+}
+
+interface CheckRunResponse {
+  readonly id: number;
+  readonly name: string;
+  readonly status: "queued" | "in_progress" | "completed";
+  readonly conclusion: CheckRunSummary["conclusion"];
+  readonly html_url: string;
+}
+
+interface ReviewResponse {
+  readonly id: number;
+  readonly user: { readonly login: string } | null;
+  readonly state: PullRequestReview["state"];
+  readonly body: string | null;
+  readonly submitted_at?: string | null;
+}
+
+interface ReviewCommentResponse {
+  readonly id: number;
+  readonly pull_request_review_id: number | null;
+  readonly user: { readonly login: string } | null;
+  readonly body: string;
+  readonly path: string;
+  readonly line: number | null;
+  readonly in_reply_to_id?: number | null;
+  readonly created_at: string;
+}
+
+function splitRepo(repo: RepoFullName): { owner: string; name: string } {
+  const slashIndex = repo.indexOf("/");
+  // `RepoFullName` is brand-validated; the slash is always present.
+  const owner = repo.slice(0, slashIndex);
+  const name = repo.slice(slashIndex + 1);
+  return { owner, name };
+}
+
+function projectPullRequest(data: PullRequestResponse): PullRequestDetails {
+  const state: PullRequestDetails["state"] = data.merged === true
+    ? "merged"
+    : (data.merged_at !== undefined && data.merged_at !== null)
+    ? "merged"
+    : data.state;
+  return {
+    number: makeIssueNumber(data.number),
+    headSha: data.head.sha,
+    headRef: data.head.ref,
+    baseRef: data.base.ref,
+    state,
+  };
+}
+
+function projectReview(data: ReviewResponse): PullRequestReview {
+  const base: {
+    id: number;
+    user: string;
+    state: PullRequestReview["state"];
+    body: string;
+  } = {
+    id: data.id,
+    user: data.user?.login ?? "",
+    state: data.state,
+    body: data.body ?? "",
+  };
+  if (data.submitted_at !== undefined && data.submitted_at !== null) {
+    return { ...base, submittedAtIso: data.submitted_at };
+  }
+  return base;
+}
+
+function projectReviewComment(data: ReviewCommentResponse): PullRequestReviewComment {
+  return {
+    id: data.id,
+    pullRequestReviewId: data.pull_request_review_id,
+    user: data.user?.login ?? "",
+    body: data.body,
+    path: data.path,
+    line: data.line,
+    inReplyToId: data.in_reply_to_id ?? null,
+    createdAtIso: data.created_at,
+  };
+}
+
+/**
+ * Best-effort extraction of an HTTP status from an error thrown by
+ * `@octokit/core`. Octokit raises `RequestError` from
+ * `@octokit/request-error` with a `status` field; some test doubles
+ * might throw plain `Error` objects with a `status` property attached.
+ */
+function readStatus(error: Error): number | undefined {
+  const candidate = error as Error & { status?: unknown };
+  if (typeof candidate.status === "number") {
+    return candidate.status;
+  }
+  return undefined;
+}
+
+function readHeaders(error: Error): Record<string, string> {
+  const candidate = error as Error & {
+    response?: { headers?: unknown };
+    headers?: unknown;
+  };
+  if (candidate.response !== undefined) {
+    const responseHeaders = candidate.response.headers;
+    if (responseHeaders !== undefined) {
+      return normalizeHeaderRecord(responseHeaders);
+    }
+  }
+  if (candidate.headers !== undefined) {
+    return normalizeHeaderRecord(candidate.headers);
+  }
+  return {};
+}
+
+function normalizeHeaderRecord(headers: unknown): Record<string, string> {
+  if (headers === null || headers === undefined) {
+    return {};
+  }
+  if (typeof Headers !== "undefined" && headers instanceof Headers) {
+    const out: Record<string, string> = {};
+    headers.forEach((value, key) => {
+      out[key.toLowerCase()] = value;
+    });
+    return out;
+  }
+  if (typeof headers !== "object") {
+    return {};
+  }
+  const source = headers as Record<string, unknown>;
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (typeof value === "string") {
+      out[key.toLowerCase()] = value;
+    } else if (typeof value === "number") {
+      out[key.toLowerCase()] = String(value);
+    }
+  }
+  return out;
+}
+
+function clamp(value: number, lower: number, upper: number): number {
+  if (Number.isNaN(value)) return lower;
+  if (value < lower) return lower;
+  if (value > upper) return upper;
+  return value;
+}
+
+async function coerceToBytes(body: unknown): Promise<Uint8Array> {
+  if (body instanceof Uint8Array) {
+    return body;
+  }
+  if (body instanceof ArrayBuffer) {
+    return new Uint8Array(body);
+  }
+  if (typeof Response !== "undefined" && body instanceof Response) {
+    const buffer = await body.arrayBuffer();
+    return new Uint8Array(buffer);
+  }
+  if (typeof Blob !== "undefined" && body instanceof Blob) {
+    const buffer = await body.arrayBuffer();
+    return new Uint8Array(buffer);
+  }
+  if (typeof body === "string") {
+    return new TextEncoder().encode(body);
+  }
+  // With `parseSuccessResponseBody: false`, Octokit returns the raw
+  // `Response` body which on Deno may surface as a ReadableStream.
+  // `new Response(stream).arrayBuffer()` collects it without consuming
+  // the global runtime stream API directly.
+  if (body !== null && typeof body === "object") {
+    const buffer = await new Response(body as BodyInit).arrayBuffer();
+    return new Uint8Array(buffer);
+  }
+  throw new TypeError(
+    `Unexpected response body type for binary endpoint: ${typeof body}`,
+  );
+}
+
+function defaultSleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => {
+    if (milliseconds <= 0) {
+      resolve();
+      return;
+    }
+    const handle = setTimeout(resolve, milliseconds);
+    // `setTimeout` in Deno returns a numeric handle; `unref` is not on
+    // every runtime. We do not block daemon shutdown on a pending retry
+    // sleep — the supervisor cancels in-flight requests on shutdown.
+    const maybeUnref = handle as unknown as { unref?: () => void };
+    if (typeof maybeUnref.unref === "function") {
+      maybeUnref.unref();
+    }
+  });
+}

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -13,11 +13,11 @@
  * is automatic.
  *
  * **Rate-limit awareness.** The retry policy intentionally fires only
- * when GitHub gave us a clear rate-limit signal (see ADR-010):
+ * when GitHub gave us a clear rate-limit signal (see ADR-011):
  *
- * - `Retry-After` present (any 4xx) — sleep that duration, retry once.
- * - `X-RateLimit-Remaining: 0` paired with `X-RateLimit-Reset` (any 4xx)
- *   — sleep until the reset, retry once.
+ * - `Retry-After` present (any status) — sleep that duration, retry once.
+ * - `X-RateLimit-Remaining: 0` paired with `X-RateLimit-Reset` (any
+ *   status) — sleep until the reset, retry once.
  * - `429` with neither header — sleep
  *   {@link DEFAULT_FALLBACK_RETRY_SLEEP_MILLISECONDS} and retry once;
  *   the `429` itself is the rate-limit signal.
@@ -275,17 +275,9 @@ export const DEFAULT_MAX_RETRY_SLEEP_MILLISECONDS = 5 * 60 * 1_000;
  * — enough to clear a transient burst without serializing the supervisor
  * on every retry. `403` does not use this fallback; without rate-limit
  * headers a `403` is treated as a permission error and propagates. See
- * ADR-010.
+ * ADR-011.
  */
 export const DEFAULT_FALLBACK_RETRY_SLEEP_MILLISECONDS = 1_000;
-
-/**
- * HTTP status codes that may trigger the single rate-limit-aware retry.
- * `429` is GitHub's secondary rate-limit signal; `403` is the primary
- * one **only** when paired with `X-RateLimit-Remaining: 0` (see ADR-010
- * for why a header-less 403 propagates instead of retrying).
- */
-const RATE_LIMITED_STATUS_CODES: ReadonlySet<number> = new Set([403, 429]);
 
 const HEADER_RETRY_AFTER = "retry-after";
 const HEADER_RATE_LIMIT_REMAINING = "x-ratelimit-remaining";
@@ -578,16 +570,21 @@ export class GitHubClientImpl implements StabilizeGitHubClient {
 
   /**
    * Issue an Octokit request and retry exactly once when GitHub gave us a
-   * clear rate-limit signal (see ADR-010 for the full policy):
+   * clear rate-limit signal (see ADR-011 for the full policy):
    *
-   * - `Retry-After` header present (any 4xx).
-   * - `X-RateLimit-Remaining: 0` paired with `X-RateLimit-Reset` (any 4xx).
+   * - `Retry-After` header present (any status) — the secondary
+   *   rate-limit signal.
+   * - `X-RateLimit-Remaining: 0` paired with `X-RateLimit-Reset` (any
+   *   status) — the primary rate-limit signal.
    * - `429` with neither header — the status itself is the signal.
    *
-   * A `403` with no rate-limit headers propagates immediately because it
-   * is a permission/scope error, not a quota event. 5xx propagates so
-   * the supervisor's higher-level retry policy can decide whether to
-   * back off.
+   * The retry decision lives entirely in
+   * {@link GitHubClientImpl.computeRetrySleepMilliseconds}: it returns a
+   * sleep duration when one of the above conditions holds and `null`
+   * otherwise. A `403` with no rate-limit headers therefore propagates
+   * immediately (permission/scope error, not a quota event), and 5xx
+   * propagates so the supervisor's higher-level retry policy can decide
+   * whether to back off.
    */
   private async requestWithRetry(
     route: string,
@@ -598,7 +595,7 @@ export class GitHubClientImpl implements StabilizeGitHubClient {
     } catch (firstError) {
       if (!(firstError instanceof Error)) throw firstError;
       const status = readStatus(firstError);
-      if (status === undefined || !RATE_LIMITED_STATUS_CODES.has(status)) {
+      if (status === undefined) {
         throw firstError;
       }
       const headers = readHeaders(firstError);
@@ -635,9 +632,8 @@ export class GitHubClientImpl implements StabilizeGitHubClient {
 
   /**
    * Translate the rate-limit response headers into a sleep duration in
-   * milliseconds, or `null` when no retry should fire.
-   *
-   * Honors (any rate-limited status):
+   * milliseconds, or `null` when no retry should fire. Honors the
+   * header-driven signals regardless of HTTP status (see ADR-011):
    *
    * - `Retry-After` (seconds, GitHub secondary rate limit).
    * - `X-RateLimit-Remaining: 0` paired with `X-RateLimit-Reset`

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -4,18 +4,29 @@
  * Implements {@link GitHubClient} from `src/types.ts` and adds the four
  * stabilize-phase methods (`listCheckRuns`, `getCheckRunLogs`,
  * `listReviews`, `listReviewComments`) the Wave 4 conversations and CI
- * loops need. Built on `@octokit/core` with a {@link GitHubAuth}
+ * loops need. Those four extensions live behind
+ * {@link StabilizeGitHubClient}, an additive interface exported from this
+ * module; the Wave 1 {@link GitHubClient} contract in `src/types.ts`
+ * stays frozen. Built on `@octokit/core` with a {@link GitHubAuth}
  * strategy injected: every request resolves an installation token via
  * `getInstallationToken` immediately before the call so token rotation
  * is automatic.
  *
- * **Rate-limit awareness.** `Retry-After` (secondary rate limit) and
- * `X-RateLimit-Reset` (primary rate limit) are honored: when GitHub
- * answers `429` or `403` with one of those headers, the client sleeps
- * the indicated duration and retries the request **once**. A second
- * failure propagates. 5xx responses propagate immediately — they
- * indicate transient GitHub trouble that the supervisor's higher-level
- * retry policy handles.
+ * **Rate-limit awareness.** The retry policy intentionally fires only
+ * when GitHub gave us a clear rate-limit signal (see ADR-010):
+ *
+ * - `Retry-After` present (any 4xx) — sleep that duration, retry once.
+ * - `X-RateLimit-Remaining: 0` paired with `X-RateLimit-Reset` (any 4xx)
+ *   — sleep until the reset, retry once.
+ * - `429` with neither header — sleep
+ *   {@link DEFAULT_FALLBACK_RETRY_SLEEP_MILLISECONDS} and retry once;
+ *   the `429` itself is the rate-limit signal.
+ * - `403` with neither header — propagate immediately. A 403 without
+ *   rate-limit headers is a permission/scope error, not a quota event,
+ *   and retrying just adds latency before the same failure surfaces.
+ *
+ * 5xx responses propagate immediately — they indicate transient GitHub
+ * trouble that the supervisor's higher-level retry policy handles.
  *
  * **Test seam.** `Octokit` exposes a `request: { fetch }` option;
  * `tests/unit/github_client_test.ts` injects a scripted fake fetch so
@@ -128,6 +139,75 @@ export interface PullRequestReviewComment {
 }
 
 // ---------------------------------------------------------------------------
+// Stabilize-phase additive interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Stabilize-phase extension of {@link GitHubClient}.
+ *
+ * The W1 `GitHubClient` contract in `src/types.ts` is intentionally
+ * minimal — every interface there is the surface every Wave 2 branch
+ * builds in parallel and consumer waves cannot cheaply reshape it.
+ * The four methods Wave 4's stabilize loop needs (per-check-run reads
+ * for the CI phase, review/comment reads for the conversations phase)
+ * are additive, so we expose them on a separate interface that
+ * **extends** `GitHubClient` instead. Consumers (Wave 4's supervisor,
+ * the in-memory double `tests/helpers/in_memory_github_client.ts`)
+ * depend on this interface rather than the concrete
+ * {@link GitHubClientImpl} class.
+ *
+ * @example
+ * ```ts
+ * function startStabilizeLoop(client: StabilizeGitHubClient) {
+ *   // Type-checked access to both W1 + W4 methods.
+ * }
+ * ```
+ */
+export interface StabilizeGitHubClient extends GitHubClient {
+  /**
+   * List individual check runs (Checks API) attached to `sha`.
+   *
+   * @param repo Target repository.
+   * @param sha Commit SHA.
+   * @returns The check runs in GitHub's natural order.
+   */
+  listCheckRuns(
+    repo: RepoFullName,
+    sha: string,
+  ): Promise<readonly CheckRunSummary[]>;
+  /**
+   * Fetch the raw logs ZIP for a single check run, as bytes.
+   *
+   * @param repo Target repository.
+   * @param checkRunId Check-run id from {@link StabilizeGitHubClient.listCheckRuns}.
+   * @returns The ZIP bytes.
+   */
+  getCheckRunLogs(repo: RepoFullName, checkRunId: number): Promise<Uint8Array>;
+  /**
+   * List submitted reviews on a pull request, in submission order.
+   *
+   * @param repo Target repository.
+   * @param pullRequestNumber Pull-request number.
+   * @returns Reviews in their submission order.
+   */
+  listReviews(
+    repo: RepoFullName,
+    pullRequestNumber: IssueNumber,
+  ): Promise<readonly PullRequestReview[]>;
+  /**
+   * List inline review comments on a pull request, in creation order.
+   *
+   * @param repo Target repository.
+   * @param pullRequestNumber Pull-request number.
+   * @returns Inline review comments in their creation order.
+   */
+  listReviewComments(
+    repo: RepoFullName,
+    pullRequestNumber: IssueNumber,
+  ): Promise<readonly PullRequestReviewComment[]>;
+}
+
+// ---------------------------------------------------------------------------
 // Options surface
 // ---------------------------------------------------------------------------
 
@@ -190,18 +270,20 @@ export interface GitHubClientOptions {
 export const DEFAULT_MAX_RETRY_SLEEP_MILLISECONDS = 5 * 60 * 1_000;
 
 /**
- * Default fallback sleep when GitHub flagged us with `429`/`403` but
- * supplied no `Retry-After` or `X-RateLimit-Reset` header. One second
- * is conservative — enough to clear a transient burst without serializing
- * the supervisor on every retry.
+ * Default fallback sleep when GitHub answered `429` with no rate-limit
+ * headers (the status itself is the signal). One second is conservative
+ * — enough to clear a transient burst without serializing the supervisor
+ * on every retry. `403` does not use this fallback; without rate-limit
+ * headers a `403` is treated as a permission error and propagates. See
+ * ADR-010.
  */
 export const DEFAULT_FALLBACK_RETRY_SLEEP_MILLISECONDS = 1_000;
 
 /**
- * HTTP status codes that trigger a single rate-limit-aware retry. `429`
- * is GitHub's secondary rate-limit signal; `403` is the primary one when
- * the remaining quota is exhausted (also expressed via
- * `X-RateLimit-Remaining: 0`).
+ * HTTP status codes that may trigger the single rate-limit-aware retry.
+ * `429` is GitHub's secondary rate-limit signal; `403` is the primary
+ * one **only** when paired with `X-RateLimit-Remaining: 0` (see ADR-010
+ * for why a header-less 403 propagates instead of retrying).
  */
 const RATE_LIMITED_STATUS_CODES: ReadonlySet<number> = new Set([403, 429]);
 
@@ -237,7 +319,7 @@ const DEFAULT_USER_AGENT = "makina-github-client/0.1";
  * const issue = await client.getIssue(makeRepoFullName("a/b"), makeIssueNumber(1));
  * ```
  */
-export class GitHubClientImpl implements GitHubClient {
+export class GitHubClientImpl implements StabilizeGitHubClient {
   private readonly auth: GitHubAuth;
   private readonly installationId: InstallationId;
   private readonly octokit: Octokit;
@@ -495,10 +577,17 @@ export class GitHubClientImpl implements GitHubClient {
   // -------------------------------------------------------------------------
 
   /**
-   * Issue an Octokit request and retry exactly once when GitHub answers
-   * `403` or `429` with a `Retry-After` or `X-RateLimit-Reset` header.
-   * 5xx responses propagate immediately; the supervisor's higher-level
-   * retry policy decides whether to back off or fail the task.
+   * Issue an Octokit request and retry exactly once when GitHub gave us a
+   * clear rate-limit signal (see ADR-010 for the full policy):
+   *
+   * - `Retry-After` header present (any 4xx).
+   * - `X-RateLimit-Remaining: 0` paired with `X-RateLimit-Reset` (any 4xx).
+   * - `429` with neither header — the status itself is the signal.
+   *
+   * A `403` with no rate-limit headers propagates immediately because it
+   * is a permission/scope error, not a quota event. 5xx propagates so
+   * the supervisor's higher-level retry policy can decide whether to
+   * back off.
    */
   private async requestWithRetry(
     route: string,
@@ -509,15 +598,16 @@ export class GitHubClientImpl implements GitHubClient {
     } catch (firstError) {
       if (!(firstError instanceof Error)) throw firstError;
       const status = readStatus(firstError);
-      const headers = readHeaders(firstError);
-      if (status !== undefined && RATE_LIMITED_STATUS_CODES.has(status)) {
-        const waitMilliseconds = this.computeRetrySleepMilliseconds(headers);
-        if (waitMilliseconds !== null) {
-          await this.sleepMilliseconds(waitMilliseconds);
-          return await this.executeRequest(route, parameters);
-        }
+      if (status === undefined || !RATE_LIMITED_STATUS_CODES.has(status)) {
+        throw firstError;
       }
-      throw firstError;
+      const headers = readHeaders(firstError);
+      const waitMilliseconds = this.computeRetrySleepMilliseconds(status, headers);
+      if (waitMilliseconds === null) {
+        throw firstError;
+      }
+      await this.sleepMilliseconds(waitMilliseconds);
+      return await this.executeRequest(route, parameters);
     }
   }
 
@@ -545,18 +635,24 @@ export class GitHubClientImpl implements GitHubClient {
 
   /**
    * Translate the rate-limit response headers into a sleep duration in
-   * milliseconds. Returns `null` when no header guidance applies — but
-   * always falls back to {@link DEFAULT_FALLBACK_RETRY_SLEEP_MILLISECONDS}
-   * for a 429/403 with no headers because GitHub does occasionally
-   * return one without either.
+   * milliseconds, or `null` when no retry should fire.
    *
-   * Honors:
+   * Honors (any rate-limited status):
    *
-   * - `Retry-After` (seconds, GitHub secondary rate limit)
+   * - `Retry-After` (seconds, GitHub secondary rate limit).
    * - `X-RateLimit-Remaining: 0` paired with `X-RateLimit-Reset`
-   *   (Unix-seconds epoch, GitHub primary rate limit)
+   *   (Unix-seconds epoch, GitHub primary rate limit).
+   *
+   * If neither header applies, the status itself decides:
+   *
+   * - `429` falls back to {@link DEFAULT_FALLBACK_RETRY_SLEEP_MILLISECONDS}
+   *   (the status alone is a rate-limit signal).
+   * - Anything else returns `null` so the caller propagates without
+   *   retrying — a `403` with no rate-limit headers is a permission
+   *   error, not a quota event.
    */
   private computeRetrySleepMilliseconds(
+    status: number,
     headers: Record<string, string>,
   ): number | null {
     const retryAfter = headers[HEADER_RETRY_AFTER];
@@ -568,8 +664,8 @@ export class GitHubClientImpl implements GitHubClient {
     }
     const remainingRaw = headers[HEADER_RATE_LIMIT_REMAINING];
     const resetRaw = headers[HEADER_RATE_LIMIT_RESET];
-    if (resetRaw !== undefined) {
-      const remaining = remainingRaw === undefined ? 0 : Number.parseInt(remainingRaw, 10);
+    if (resetRaw !== undefined && remainingRaw !== undefined) {
+      const remaining = Number.parseInt(remainingRaw, 10);
       if (!Number.isNaN(remaining) && remaining <= 0) {
         const resetSeconds = Number.parseInt(resetRaw, 10);
         if (!Number.isNaN(resetSeconds)) {
@@ -578,14 +674,17 @@ export class GitHubClientImpl implements GitHubClient {
         }
       }
     }
-    // No header guidance — fall back to a small constant so we still
-    // retry once. Cap by the configured max so a future caller cannot
-    // make this larger than the configured retry ceiling.
-    return clamp(
-      DEFAULT_FALLBACK_RETRY_SLEEP_MILLISECONDS,
-      0,
-      this.maxRetrySleepMilliseconds,
-    );
+    if (status === 429) {
+      // 429 with no header guidance: status alone is the rate-limit
+      // signal, so fall back to a small constant. Cap by the configured
+      // max so a future caller cannot exceed the retry ceiling.
+      return clamp(
+        DEFAULT_FALLBACK_RETRY_SLEEP_MILLISECONDS,
+        0,
+        this.maxRetrySleepMilliseconds,
+      );
+    }
+    return null;
   }
 }
 

--- a/tests/helpers/in_memory_github_client.ts
+++ b/tests/helpers/in_memory_github_client.ts
@@ -16,6 +16,7 @@
 
 import {
   type CombinedStatus,
+  type GitHubClient,
   type IssueDetails,
   type IssueNumber,
   type MergeMode,
@@ -28,6 +29,12 @@ import {
   type PullRequestReviewComment,
   type StabilizeGitHubClient,
 } from "../../src/github/client.ts";
+
+// `GitHubClient` is imported so the `{@inheritdoc GitHubClient.*}` JSDoc
+// tags below resolve under `deno doc --lint`. The type itself is not
+// referenced at runtime (the implemented contract is the wider
+// `StabilizeGitHubClient`), so we tag it as intentionally used.
+type _UseGitHubClient = GitHubClient;
 
 /** A scripted reply or thrown error. */
 export type ScriptedReply<TValue> =

--- a/tests/helpers/in_memory_github_client.ts
+++ b/tests/helpers/in_memory_github_client.ts
@@ -1,6 +1,6 @@
 /**
  * tests/helpers/in_memory_github_client.ts — scriptable
- * {@link GitHubClient} double.
+ * {@link StabilizeGitHubClient} double.
  *
  * Wave 2 ships the real client over `@octokit/core`. Consumer waves test
  * against this double: per-method timelines let a test say "the first
@@ -9,19 +9,25 @@
  * polling. Every call is recorded so assertions can verify call shape and
  * order.
  *
- * Compiles against `src/types.ts` so a contract drift is caught at the
- * `deno check` step.
+ * Compiles against `src/types.ts` (W1 contract) and
+ * `src/github/client.ts` (the additive {@link StabilizeGitHubClient}
+ * interface) so a contract drift is caught at the `deno check` step.
  */
 
 import {
   type CombinedStatus,
-  type GitHubClient,
   type IssueDetails,
   type IssueNumber,
   type MergeMode,
   type PullRequestDetails,
   type RepoFullName,
 } from "../../src/types.ts";
+import {
+  type CheckRunSummary,
+  type PullRequestReview,
+  type PullRequestReviewComment,
+  type StabilizeGitHubClient,
+} from "../../src/github/client.ts";
 
 /** A scripted reply or thrown error. */
 export type ScriptedReply<TValue> =
@@ -59,6 +65,26 @@ export type RecordedCall =
     readonly sha: string;
   }
   | {
+    readonly method: "listCheckRuns";
+    readonly repo: RepoFullName;
+    readonly sha: string;
+  }
+  | {
+    readonly method: "getCheckRunLogs";
+    readonly repo: RepoFullName;
+    readonly checkRunId: number;
+  }
+  | {
+    readonly method: "listReviews";
+    readonly repo: RepoFullName;
+    readonly pullRequestNumber: IssueNumber;
+  }
+  | {
+    readonly method: "listReviewComments";
+    readonly repo: RepoFullName;
+    readonly pullRequestNumber: IssueNumber;
+  }
+  | {
     readonly method: "mergePullRequest";
     readonly repo: RepoFullName;
     readonly pullRequestNumber: IssueNumber;
@@ -70,6 +96,10 @@ interface MethodTimelines {
   createPullRequest: ScriptedReply<PullRequestDetails>[];
   requestReviewers: ScriptedReply<void>[];
   getCombinedStatus: ScriptedReply<CombinedStatus>[];
+  listCheckRuns: ScriptedReply<readonly CheckRunSummary[]>[];
+  getCheckRunLogs: ScriptedReply<Uint8Array>[];
+  listReviews: ScriptedReply<readonly PullRequestReview[]>[];
+  listReviewComments: ScriptedReply<readonly PullRequestReviewComment[]>[];
   mergePullRequest: ScriptedReply<void>[];
 }
 
@@ -90,12 +120,16 @@ interface MethodTimelines {
  * assertEquals(second.state, "success");
  * ```
  */
-export class InMemoryGitHubClient implements GitHubClient {
+export class InMemoryGitHubClient implements StabilizeGitHubClient {
   private readonly timelines: MethodTimelines = {
     getIssue: [],
     createPullRequest: [],
     requestReviewers: [],
     getCombinedStatus: [],
+    listCheckRuns: [],
+    getCheckRunLogs: [],
+    listReviews: [],
+    listReviewComments: [],
     mergePullRequest: [],
   };
   private readonly callLog: RecordedCall[] = [];
@@ -133,6 +167,44 @@ export class InMemoryGitHubClient implements GitHubClient {
    */
   queueGetCombinedStatus(reply: ScriptedReply<CombinedStatus>): void {
     this.timelines.getCombinedStatus.push(reply);
+  }
+
+  /**
+   * Queue the next reply for
+   * {@link InMemoryGitHubClient.listCheckRuns}.
+   * @param reply The next scripted reply.
+   */
+  queueListCheckRuns(reply: ScriptedReply<readonly CheckRunSummary[]>): void {
+    this.timelines.listCheckRuns.push(reply);
+  }
+
+  /**
+   * Queue the next reply for
+   * {@link InMemoryGitHubClient.getCheckRunLogs}.
+   * @param reply The next scripted reply.
+   */
+  queueGetCheckRunLogs(reply: ScriptedReply<Uint8Array>): void {
+    this.timelines.getCheckRunLogs.push(reply);
+  }
+
+  /**
+   * Queue the next reply for
+   * {@link InMemoryGitHubClient.listReviews}.
+   * @param reply The next scripted reply.
+   */
+  queueListReviews(reply: ScriptedReply<readonly PullRequestReview[]>): void {
+    this.timelines.listReviews.push(reply);
+  }
+
+  /**
+   * Queue the next reply for
+   * {@link InMemoryGitHubClient.listReviewComments}.
+   * @param reply The next scripted reply.
+   */
+  queueListReviewComments(
+    reply: ScriptedReply<readonly PullRequestReviewComment[]>,
+  ): void {
+    this.timelines.listReviewComments.push(reply);
   }
 
   /**
@@ -187,6 +259,46 @@ export class InMemoryGitHubClient implements GitHubClient {
   getCombinedStatus(repo: RepoFullName, sha: string): Promise<CombinedStatus> {
     this.callLog.push({ method: "getCombinedStatus", repo, sha });
     return resolveScripted(this.timelines.getCombinedStatus, "getCombinedStatus");
+  }
+
+  /** {@inheritdoc StabilizeGitHubClient.listCheckRuns} */
+  listCheckRuns(
+    repo: RepoFullName,
+    sha: string,
+  ): Promise<readonly CheckRunSummary[]> {
+    this.callLog.push({ method: "listCheckRuns", repo, sha });
+    return resolveScripted(this.timelines.listCheckRuns, "listCheckRuns");
+  }
+
+  /** {@inheritdoc StabilizeGitHubClient.getCheckRunLogs} */
+  getCheckRunLogs(repo: RepoFullName, checkRunId: number): Promise<Uint8Array> {
+    this.callLog.push({ method: "getCheckRunLogs", repo, checkRunId });
+    return resolveScripted(this.timelines.getCheckRunLogs, "getCheckRunLogs");
+  }
+
+  /** {@inheritdoc StabilizeGitHubClient.listReviews} */
+  listReviews(
+    repo: RepoFullName,
+    pullRequestNumber: IssueNumber,
+  ): Promise<readonly PullRequestReview[]> {
+    this.callLog.push({ method: "listReviews", repo, pullRequestNumber });
+    return resolveScripted(this.timelines.listReviews, "listReviews");
+  }
+
+  /** {@inheritdoc StabilizeGitHubClient.listReviewComments} */
+  listReviewComments(
+    repo: RepoFullName,
+    pullRequestNumber: IssueNumber,
+  ): Promise<readonly PullRequestReviewComment[]> {
+    this.callLog.push({
+      method: "listReviewComments",
+      repo,
+      pullRequestNumber,
+    });
+    return resolveScripted(
+      this.timelines.listReviewComments,
+      "listReviewComments",
+    );
   }
 
   /** {@inheritdoc GitHubClient.mergePullRequest} */

--- a/tests/unit/github_client_test.ts
+++ b/tests/unit/github_client_test.ts
@@ -251,25 +251,6 @@ Deno.test("createPullRequest: happy path posts to /pulls and projects PR", async
   assertEquals(parsedBody.body, "Implements #1.");
 });
 
-Deno.test("createPullRequest: derives merged state from merged_at when present", async () => {
-  const harness = new FakeFetchHarness();
-  harness.enqueueResponse(200, {
-    number: 11,
-    head: { sha: "f00", ref: "feat" },
-    base: { ref: "main" },
-    state: "closed",
-    merged_at: "2026-04-26T12:00:00Z",
-  });
-  const { client } = buildClient(harness);
-  const pr = await client.createPullRequest(REPO, {
-    headRef: "feat",
-    baseRef: "main",
-    title: "t",
-    body: "b",
-  });
-  assertEquals(pr.state, "merged");
-});
-
 Deno.test("createPullRequest: 429 with X-RateLimit-Reset waits until reset and retries", async () => {
   const harness = new FakeFetchHarness();
   // Set 'now' to t = 1000 seconds; reset = 1003 -> sleep ~3000ms.
@@ -739,7 +720,7 @@ Deno.test("retry: X-RateLimit-Reset that is already in the past sleeps zero", as
 });
 
 Deno.test(
-  "retry: 403 with X-RateLimit-Remaining > 0 still triggers fallback retry",
+  "retry: 403 with X-RateLimit-Remaining > 0 propagates without retry",
   async () => {
     const harness = new FakeFetchHarness();
     harness.enqueueResponse(403, { message: "Forbidden" }, {
@@ -748,9 +729,40 @@ Deno.test(
         "x-ratelimit-reset": "1000",
       },
     });
-    // The X-RateLimit-Reset branch only fires when remaining <= 0; with
-    // 100 remaining the client falls through to the constant fallback,
-    // sleeps once, and retries.
+    // 403 with quota left is a permission/scope error, not a rate-limit
+    // event — see ADR-010. The client must not sleep or retry.
+    const { client } = buildClient(harness);
+    await assertRejects(() => client.getIssue(REPO, makeIssueNumber(1)));
+    assertEquals(harness.recordedRequests.length, 1);
+    assertEquals(harness.recordedSleeps.length, 0);
+  },
+);
+
+Deno.test(
+  "retry: 403 with no rate-limit headers propagates without retry",
+  async () => {
+    const harness = new FakeFetchHarness();
+    harness.enqueueResponse(403, { message: "Forbidden" });
+    // Bare 403 → permission error, not a rate-limit event.
+    const { client } = buildClient(harness);
+    await assertRejects(() => client.getIssue(REPO, makeIssueNumber(1)));
+    assertEquals(harness.recordedRequests.length, 1);
+    assertEquals(harness.recordedSleeps.length, 0);
+  },
+);
+
+Deno.test(
+  "retry: 403 with X-RateLimit-Remaining=0 sleeps until reset and retries",
+  async () => {
+    const harness = new FakeFetchHarness();
+    // now=1_000_000ms; reset=1003 -> sleep ~3000ms.
+    harness.setTime(1_000_000);
+    harness.enqueueResponse(403, { message: "primary limit" }, {
+      headers: {
+        "x-ratelimit-remaining": "0",
+        "x-ratelimit-reset": "1003",
+      },
+    });
     harness.enqueueResponse(200, {
       number: 1,
       title: "ok",
@@ -760,7 +772,7 @@ Deno.test(
     const { client } = buildClient(harness);
     await client.getIssue(REPO, makeIssueNumber(1));
     assertEquals(harness.recordedRequests.length, 2);
-    assertEquals(harness.recordedSleeps, [DEFAULT_FALLBACK_RETRY_SLEEP_MILLISECONDS]);
+    assertEquals(harness.recordedSleeps, [3_000]);
   },
 );
 

--- a/tests/unit/github_client_test.ts
+++ b/tests/unit/github_client_test.ts
@@ -1,0 +1,843 @@
+/**
+ * Unit tests for `src/github/client.ts`.
+ *
+ * Each public method is covered by three tests:
+ *
+ * 1. **Happy path** — verifies the request shape (URL, method, body,
+ *    `Authorization` header from the auth double) and the projection of
+ *    GitHub's payload into the typed return value.
+ * 2. **429 rate-limit retry** — the first response is a `429` with
+ *    `Retry-After`; the client sleeps the indicated duration and
+ *    retries once. The injected sleep records its argument so the test
+ *    asserts the delay deterministically.
+ * 3. **5xx propagation** — a `500` propagates immediately (no retry).
+ *
+ * The tests inject a scripted `fetch` so no real network is touched.
+ * The injected `nowMilliseconds`/`sleepMilliseconds` hooks make the
+ * rate-limit math deterministic.
+ */
+
+import { assertEquals, assertGreaterOrEqual, assertRejects } from "@std/assert";
+
+import {
+  type CheckRunSummary,
+  DEFAULT_FALLBACK_RETRY_SLEEP_MILLISECONDS,
+  DEFAULT_MAX_RETRY_SLEEP_MILLISECONDS,
+  GitHubClientImpl,
+  type GitHubClientOptions,
+  type PullRequestReview,
+  type PullRequestReviewComment,
+} from "../../src/github/client.ts";
+import { makeInstallationId, makeIssueNumber, makeRepoFullName } from "../../src/types.ts";
+
+import { InMemoryGitHubAuth } from "../helpers/in_memory_github_auth.ts";
+
+interface RecordedRequest {
+  readonly url: string;
+  readonly method: string;
+  readonly headers: Record<string, string>;
+  readonly body: string | null;
+}
+
+/**
+ * Per-test scripted fetch + sleep harness. Each call to `enqueue` adds
+ * one fake response (or thrown network error) and the harness records
+ * the inbound request so assertions can verify URL/method/body.
+ */
+class FakeFetchHarness {
+  readonly recordedRequests: RecordedRequest[] = [];
+  readonly recordedSleeps: number[] = [];
+  private readonly responseQueue: Array<() => Promise<Response>> = [];
+  private currentTimeMilliseconds = 1_700_000_000_000;
+
+  enqueueResponse(
+    status: number,
+    body: unknown,
+    options: { headers?: Record<string, string>; binary?: Uint8Array } = {},
+  ): void {
+    this.responseQueue.push(() => {
+      const headers = new Headers({
+        "content-type": options.binary !== undefined ? "application/zip" : "application/json",
+        ...(options.headers ?? {}),
+      });
+      const payload: BodyInit = options.binary !== undefined
+        ? (options.binary as unknown as BodyInit)
+        : JSON.stringify(body);
+      return Promise.resolve(new Response(payload, { status, headers }));
+    });
+  }
+
+  fetch: typeof fetch = (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.toString()
+      : input.url;
+    const method = init?.method ??
+      (typeof input !== "string" && !(input instanceof URL) ? input.method : "GET");
+    const headersIn = new Headers(init?.headers ?? {});
+    const headers: Record<string, string> = {};
+    headersIn.forEach((value, key) => {
+      headers[key.toLowerCase()] = value;
+    });
+    const bodyRaw = init?.body;
+    const body: string | null = typeof bodyRaw === "string" ? bodyRaw : null;
+    this.recordedRequests.push({ url, method: method ?? "GET", headers, body });
+    const next = this.responseQueue.shift();
+    if (next === undefined) {
+      throw new Error(`FakeFetchHarness: no scripted response for ${method} ${url}`);
+    }
+    return next();
+  };
+
+  sleep = (milliseconds: number): Promise<void> => {
+    this.recordedSleeps.push(milliseconds);
+    this.currentTimeMilliseconds += milliseconds;
+    return Promise.resolve();
+  };
+
+  now = (): number => this.currentTimeMilliseconds;
+
+  setTime(milliseconds: number): void {
+    this.currentTimeMilliseconds = milliseconds;
+  }
+}
+
+interface BuildOptions {
+  readonly maxRetrySleepMilliseconds?: number;
+}
+
+function buildClient(
+  harness: FakeFetchHarness,
+  buildOptions: BuildOptions = {},
+): { client: GitHubClientImpl; auth: InMemoryGitHubAuth } {
+  const auth = new InMemoryGitHubAuth();
+  const options: GitHubClientOptions = {
+    auth,
+    installationId: makeInstallationId(123),
+    fetch: harness.fetch,
+    sleepMilliseconds: harness.sleep,
+    nowMilliseconds: harness.now,
+    ...(buildOptions.maxRetrySleepMilliseconds !== undefined
+      ? { maxRetrySleepMilliseconds: buildOptions.maxRetrySleepMilliseconds }
+      : {}),
+  };
+  return { client: new GitHubClientImpl(options), auth };
+}
+
+const REPO = makeRepoFullName("octocat/hello-world");
+
+// ---------------------------------------------------------------------------
+// getIssue
+// ---------------------------------------------------------------------------
+
+Deno.test("getIssue: happy path projects GitHub payload into IssueDetails", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, {
+    number: 42,
+    title: "Bug: thing broken",
+    body: "Steps to reproduce.",
+    state: "open",
+  });
+  const { client } = buildClient(harness);
+
+  const issue = await client.getIssue(REPO, makeIssueNumber(42));
+
+  assertEquals(issue.number, 42);
+  assertEquals(issue.title, "Bug: thing broken");
+  assertEquals(issue.body, "Steps to reproduce.");
+  assertEquals(issue.state, "open");
+
+  assertEquals(harness.recordedRequests.length, 1);
+  const recorded = harness.recordedRequests[0];
+  assertEquals(recorded?.method, "GET");
+  assertEquals(
+    recorded?.url,
+    "https://api.github.com/repos/octocat/hello-world/issues/42",
+  );
+  // Auth header present and non-empty.
+  assertEquals(
+    recorded?.headers["authorization"]?.startsWith("token "),
+    true,
+  );
+});
+
+Deno.test("getIssue: happy path tolerates a null issue body", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, {
+    number: 7,
+    title: "no body issue",
+    body: null,
+    state: "closed",
+  });
+  const { client } = buildClient(harness);
+  const issue = await client.getIssue(REPO, makeIssueNumber(7));
+  assertEquals(issue.body, "");
+  assertEquals(issue.state, "closed");
+});
+
+Deno.test("getIssue: 429 with Retry-After backs off and retries once", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(429, { message: "Rate limited" }, {
+    headers: { "retry-after": "2" },
+  });
+  harness.enqueueResponse(200, {
+    number: 1,
+    title: "ok",
+    body: "",
+    state: "open",
+  });
+  const { client } = buildClient(harness);
+
+  const issue = await client.getIssue(REPO, makeIssueNumber(1));
+
+  assertEquals(issue.number, 1);
+  assertEquals(harness.recordedRequests.length, 2);
+  assertEquals(harness.recordedSleeps, [2_000]);
+});
+
+Deno.test("getIssue: 500 propagates immediately without retry", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(500, { message: "boom" });
+  const { client } = buildClient(harness);
+
+  await assertRejects(
+    () => client.getIssue(REPO, makeIssueNumber(1)),
+    Error,
+  );
+  assertEquals(harness.recordedRequests.length, 1);
+  assertEquals(harness.recordedSleeps.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// createPullRequest
+// ---------------------------------------------------------------------------
+
+Deno.test("createPullRequest: happy path posts to /pulls and projects PR", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(201, {
+    number: 9,
+    head: { sha: "deadbeef", ref: "feature/x" },
+    base: { ref: "main" },
+    state: "open",
+  });
+  const { client } = buildClient(harness);
+
+  const pr = await client.createPullRequest(REPO, {
+    headRef: "feature/x",
+    baseRef: "main",
+    title: "Add x",
+    body: "Implements #1.",
+  });
+
+  assertEquals(pr.number, 9);
+  assertEquals(pr.headSha, "deadbeef");
+  assertEquals(pr.headRef, "feature/x");
+  assertEquals(pr.baseRef, "main");
+  assertEquals(pr.state, "open");
+
+  const recorded = harness.recordedRequests[0];
+  assertEquals(recorded?.method, "POST");
+  assertEquals(recorded?.url, "https://api.github.com/repos/octocat/hello-world/pulls");
+  const parsedBody = recorded?.body !== null && recorded?.body !== undefined
+    ? JSON.parse(recorded.body) as Record<string, unknown>
+    : {};
+  assertEquals(parsedBody.head, "feature/x");
+  assertEquals(parsedBody.base, "main");
+  assertEquals(parsedBody.title, "Add x");
+  assertEquals(parsedBody.body, "Implements #1.");
+});
+
+Deno.test("createPullRequest: derives merged state from merged_at when present", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, {
+    number: 11,
+    head: { sha: "f00", ref: "feat" },
+    base: { ref: "main" },
+    state: "closed",
+    merged_at: "2026-04-26T12:00:00Z",
+  });
+  const { client } = buildClient(harness);
+  const pr = await client.createPullRequest(REPO, {
+    headRef: "feat",
+    baseRef: "main",
+    title: "t",
+    body: "b",
+  });
+  assertEquals(pr.state, "merged");
+});
+
+Deno.test("createPullRequest: 429 with X-RateLimit-Reset waits until reset and retries", async () => {
+  const harness = new FakeFetchHarness();
+  // Set 'now' to t = 1000 seconds; reset = 1003 -> sleep ~3000ms.
+  harness.setTime(1_000_000);
+  harness.enqueueResponse(429, { message: "primary limit" }, {
+    headers: {
+      "x-ratelimit-remaining": "0",
+      "x-ratelimit-reset": "1003",
+    },
+  });
+  harness.enqueueResponse(201, {
+    number: 1,
+    head: { sha: "s", ref: "h" },
+    base: { ref: "b" },
+    state: "open",
+  });
+  const { client } = buildClient(harness);
+
+  await client.createPullRequest(REPO, {
+    headRef: "h",
+    baseRef: "b",
+    title: "t",
+    body: "b",
+  });
+
+  assertEquals(harness.recordedRequests.length, 2);
+  assertEquals(harness.recordedSleeps.length, 1);
+  // 1003s = 1_003_000ms, less now=1_000_000ms = 3_000ms.
+  assertEquals(harness.recordedSleeps[0], 3_000);
+});
+
+Deno.test("createPullRequest: 502 propagates without retry", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(502, { message: "bad gateway" });
+  const { client } = buildClient(harness);
+  await assertRejects(() =>
+    client.createPullRequest(REPO, {
+      headRef: "h",
+      baseRef: "b",
+      title: "t",
+      body: "b",
+    })
+  );
+  assertEquals(harness.recordedRequests.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// requestReviewers
+// ---------------------------------------------------------------------------
+
+Deno.test("requestReviewers: happy path posts the reviewer list", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(201, {});
+  const { client } = buildClient(harness);
+
+  await client.requestReviewers(REPO, makeIssueNumber(7), ["Copilot", "alice"]);
+
+  const recorded = harness.recordedRequests[0];
+  assertEquals(recorded?.method, "POST");
+  assertEquals(
+    recorded?.url,
+    "https://api.github.com/repos/octocat/hello-world/pulls/7/requested_reviewers",
+  );
+  const parsed = recorded?.body !== null && recorded?.body !== undefined
+    ? JSON.parse(recorded.body) as Record<string, unknown>
+    : {};
+  assertEquals(parsed.reviewers, ["Copilot", "alice"]);
+});
+
+Deno.test("requestReviewers: 429 retries once and then succeeds", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(429, {}, { headers: { "retry-after": "1" } });
+  harness.enqueueResponse(201, {});
+  const { client } = buildClient(harness);
+  await client.requestReviewers(REPO, makeIssueNumber(1), ["Copilot"]);
+  assertEquals(harness.recordedSleeps, [1_000]);
+  assertEquals(harness.recordedRequests.length, 2);
+});
+
+Deno.test("requestReviewers: 503 propagates", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(503, {});
+  const { client } = buildClient(harness);
+  await assertRejects(() => client.requestReviewers(REPO, makeIssueNumber(1), ["Copilot"]));
+  assertEquals(harness.recordedRequests.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// getCombinedStatus
+// ---------------------------------------------------------------------------
+
+Deno.test("getCombinedStatus: happy path returns the aggregate state", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, { state: "success", sha: "abc" });
+  const { client } = buildClient(harness);
+  const status = await client.getCombinedStatus(REPO, "abc");
+  assertEquals(status.state, "success");
+  assertEquals(status.sha, "abc");
+  const recorded = harness.recordedRequests[0];
+  assertEquals(
+    recorded?.url,
+    "https://api.github.com/repos/octocat/hello-world/commits/abc/status",
+  );
+  assertEquals(recorded?.method, "GET");
+});
+
+Deno.test("getCombinedStatus: 429 with no headers falls back to constant sleep", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(429, { message: "rate limited" });
+  harness.enqueueResponse(200, { state: "pending", sha: "abc" });
+  const { client } = buildClient(harness);
+  await client.getCombinedStatus(REPO, "abc");
+  assertEquals(harness.recordedRequests.length, 2);
+  assertEquals(harness.recordedSleeps, [DEFAULT_FALLBACK_RETRY_SLEEP_MILLISECONDS]);
+});
+
+Deno.test("getCombinedStatus: 500 propagates", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(500, {});
+  const { client } = buildClient(harness);
+  await assertRejects(() => client.getCombinedStatus(REPO, "abc"));
+  assertEquals(harness.recordedRequests.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// listCheckRuns
+// ---------------------------------------------------------------------------
+
+Deno.test("listCheckRuns: happy path projects the check_runs array", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, {
+    check_runs: [
+      {
+        id: 1,
+        name: "build",
+        status: "completed",
+        conclusion: "success",
+        html_url: "https://github.com/check/1",
+      },
+      {
+        id: 2,
+        name: "lint",
+        status: "in_progress",
+        conclusion: null,
+        html_url: "https://github.com/check/2",
+      },
+    ],
+  });
+  const { client } = buildClient(harness);
+
+  const runs: readonly CheckRunSummary[] = await client.listCheckRuns(REPO, "abc");
+  assertEquals(runs.length, 2);
+  assertEquals(runs[0]?.name, "build");
+  assertEquals(runs[0]?.conclusion, "success");
+  assertEquals(runs[1]?.status, "in_progress");
+  assertEquals(runs[1]?.conclusion, null);
+
+  const recorded = harness.recordedRequests[0];
+  assertEquals(
+    recorded?.url,
+    "https://api.github.com/repos/octocat/hello-world/commits/abc/check-runs",
+  );
+});
+
+Deno.test("listCheckRuns: 429 retries with Retry-After", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(429, {}, { headers: { "retry-after": "0.5" } });
+  harness.enqueueResponse(200, { check_runs: [] });
+  const { client } = buildClient(harness);
+  await client.listCheckRuns(REPO, "abc");
+  assertEquals(harness.recordedSleeps, [500]);
+  assertEquals(harness.recordedRequests.length, 2);
+});
+
+Deno.test("listCheckRuns: 500 propagates", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(500, {});
+  const { client } = buildClient(harness);
+  await assertRejects(() => client.listCheckRuns(REPO, "abc"));
+  assertEquals(harness.recordedRequests.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// getCheckRunLogs
+// ---------------------------------------------------------------------------
+
+Deno.test("getCheckRunLogs: happy path returns the raw bytes", async () => {
+  const harness = new FakeFetchHarness();
+  const fakeZip = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0xde, 0xad]);
+  harness.enqueueResponse(200, undefined, { binary: fakeZip });
+  const { client } = buildClient(harness);
+
+  const bytes = await client.getCheckRunLogs(REPO, 99);
+  assertEquals(Array.from(bytes), Array.from(fakeZip));
+
+  const recorded = harness.recordedRequests[0];
+  assertEquals(
+    recorded?.url,
+    "https://api.github.com/repos/octocat/hello-world/check-runs/99/logs",
+  );
+});
+
+Deno.test("getCheckRunLogs: 429 retries once", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(429, {}, { headers: { "retry-after": "1" } });
+  const fakeZip = new Uint8Array([1, 2, 3]);
+  harness.enqueueResponse(200, undefined, { binary: fakeZip });
+  const { client } = buildClient(harness);
+  const bytes = await client.getCheckRunLogs(REPO, 1);
+  assertEquals(Array.from(bytes), [1, 2, 3]);
+  assertEquals(harness.recordedSleeps, [1_000]);
+});
+
+Deno.test("getCheckRunLogs: 500 propagates", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(500, {});
+  const { client } = buildClient(harness);
+  await assertRejects(() => client.getCheckRunLogs(REPO, 1));
+  assertEquals(harness.recordedRequests.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// listReviews
+// ---------------------------------------------------------------------------
+
+Deno.test("listReviews: happy path projects review entries", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, [
+    {
+      id: 10,
+      user: { login: "Copilot" },
+      state: "COMMENTED",
+      body: "looks ok",
+      submitted_at: "2026-04-26T12:00:00Z",
+    },
+    {
+      id: 11,
+      user: null,
+      state: "APPROVED",
+      body: null,
+    },
+  ]);
+  const { client } = buildClient(harness);
+
+  const reviews: readonly PullRequestReview[] = await client.listReviews(
+    REPO,
+    makeIssueNumber(7),
+  );
+  assertEquals(reviews.length, 2);
+  assertEquals(reviews[0]?.user, "Copilot");
+  assertEquals(reviews[0]?.state, "COMMENTED");
+  assertEquals(reviews[0]?.submittedAtIso, "2026-04-26T12:00:00Z");
+  assertEquals(reviews[1]?.user, "");
+  assertEquals(reviews[1]?.body, "");
+  assertEquals(reviews[1]?.submittedAtIso, undefined);
+
+  const recorded = harness.recordedRequests[0];
+  assertEquals(
+    recorded?.url,
+    "https://api.github.com/repos/octocat/hello-world/pulls/7/reviews",
+  );
+});
+
+Deno.test("listReviews: 429 retries once", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(429, {}, { headers: { "retry-after": "1" } });
+  harness.enqueueResponse(200, []);
+  const { client } = buildClient(harness);
+  await client.listReviews(REPO, makeIssueNumber(7));
+  assertEquals(harness.recordedSleeps, [1_000]);
+  assertEquals(harness.recordedRequests.length, 2);
+});
+
+Deno.test("listReviews: 500 propagates", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(500, {});
+  const { client } = buildClient(harness);
+  await assertRejects(() => client.listReviews(REPO, makeIssueNumber(7)));
+  assertEquals(harness.recordedRequests.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// listReviewComments
+// ---------------------------------------------------------------------------
+
+Deno.test("listReviewComments: happy path projects comment entries", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, [
+    {
+      id: 100,
+      pull_request_review_id: 10,
+      user: { login: "Copilot" },
+      body: "Consider renaming.",
+      path: "src/x.ts",
+      line: 12,
+      in_reply_to_id: null,
+      created_at: "2026-04-26T12:00:00Z",
+    },
+    {
+      id: 101,
+      pull_request_review_id: 10,
+      user: null,
+      body: "Replying.",
+      path: "src/x.ts",
+      line: null,
+      in_reply_to_id: 100,
+      created_at: "2026-04-26T12:01:00Z",
+    },
+  ]);
+  const { client } = buildClient(harness);
+
+  const comments: readonly PullRequestReviewComment[] = await client
+    .listReviewComments(REPO, makeIssueNumber(7));
+  assertEquals(comments.length, 2);
+  assertEquals(comments[0]?.user, "Copilot");
+  assertEquals(comments[0]?.line, 12);
+  assertEquals(comments[0]?.inReplyToId, null);
+  assertEquals(comments[1]?.user, "");
+  assertEquals(comments[1]?.inReplyToId, 100);
+  assertEquals(comments[1]?.line, null);
+
+  const recorded = harness.recordedRequests[0];
+  assertEquals(
+    recorded?.url,
+    "https://api.github.com/repos/octocat/hello-world/pulls/7/comments",
+  );
+});
+
+Deno.test("listReviewComments: 429 retries once", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(429, {}, { headers: { "retry-after": "1" } });
+  harness.enqueueResponse(200, []);
+  const { client } = buildClient(harness);
+  await client.listReviewComments(REPO, makeIssueNumber(7));
+  assertEquals(harness.recordedSleeps, [1_000]);
+  assertEquals(harness.recordedRequests.length, 2);
+});
+
+Deno.test("listReviewComments: 500 propagates", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(500, {});
+  const { client } = buildClient(harness);
+  await assertRejects(() => client.listReviewComments(REPO, makeIssueNumber(7)));
+  assertEquals(harness.recordedRequests.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// mergePullRequest
+// ---------------------------------------------------------------------------
+
+Deno.test("mergePullRequest: squash mode PUTs to /merge with merge_method", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, { merged: true, sha: "abc" });
+  const { client } = buildClient(harness);
+  await client.mergePullRequest(REPO, makeIssueNumber(7), "squash");
+  const recorded = harness.recordedRequests[0];
+  assertEquals(recorded?.method, "PUT");
+  assertEquals(
+    recorded?.url,
+    "https://api.github.com/repos/octocat/hello-world/pulls/7/merge",
+  );
+  const parsed = recorded?.body !== null && recorded?.body !== undefined
+    ? JSON.parse(recorded.body) as Record<string, unknown>
+    : {};
+  assertEquals(parsed.merge_method, "squash");
+});
+
+Deno.test("mergePullRequest: rebase mode sends merge_method=rebase", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, { merged: true, sha: "abc" });
+  const { client } = buildClient(harness);
+  await client.mergePullRequest(REPO, makeIssueNumber(7), "rebase");
+  const recorded = harness.recordedRequests[0];
+  const parsed = recorded?.body !== null && recorded?.body !== undefined
+    ? JSON.parse(recorded.body) as Record<string, unknown>
+    : {};
+  assertEquals(parsed.merge_method, "rebase");
+});
+
+Deno.test("mergePullRequest: manual mode is a no-op (no HTTP call)", async () => {
+  const harness = new FakeFetchHarness();
+  const { client } = buildClient(harness);
+  await client.mergePullRequest(REPO, makeIssueNumber(7), "manual");
+  assertEquals(harness.recordedRequests.length, 0);
+});
+
+Deno.test("mergePullRequest: 429 retries once", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(429, {}, { headers: { "retry-after": "1" } });
+  harness.enqueueResponse(200, { merged: true, sha: "abc" });
+  const { client } = buildClient(harness);
+  await client.mergePullRequest(REPO, makeIssueNumber(7), "squash");
+  assertEquals(harness.recordedSleeps, [1_000]);
+  assertEquals(harness.recordedRequests.length, 2);
+});
+
+Deno.test("mergePullRequest: 500 propagates without retry", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(500, {});
+  const { client } = buildClient(harness);
+  await assertRejects(() => client.mergePullRequest(REPO, makeIssueNumber(7), "squash"));
+  assertEquals(harness.recordedRequests.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Cross-cutting: rate-limit math and edge cases
+// ---------------------------------------------------------------------------
+
+Deno.test("retry: a second 429 propagates (only one retry per call)", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(429, {}, { headers: { "retry-after": "1" } });
+  harness.enqueueResponse(429, {}, { headers: { "retry-after": "1" } });
+  const { client } = buildClient(harness);
+  await assertRejects(() => client.getIssue(REPO, makeIssueNumber(1)));
+  // Exactly one retry attempted.
+  assertEquals(harness.recordedRequests.length, 2);
+  assertEquals(harness.recordedSleeps.length, 1);
+});
+
+Deno.test("retry: an excessive Retry-After is clamped by maxRetrySleepMilliseconds", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(429, {}, { headers: { "retry-after": "9999999" } });
+  harness.enqueueResponse(200, {
+    number: 1,
+    title: "ok",
+    body: "",
+    state: "open",
+  });
+  const { client } = buildClient(harness, { maxRetrySleepMilliseconds: 5_000 });
+  await client.getIssue(REPO, makeIssueNumber(1));
+  assertEquals(harness.recordedSleeps, [5_000]);
+});
+
+Deno.test("retry: defaults clamp to DEFAULT_MAX_RETRY_SLEEP_MILLISECONDS", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(429, {}, { headers: { "retry-after": "9999999" } });
+  harness.enqueueResponse(200, {
+    number: 1,
+    title: "ok",
+    body: "",
+    state: "open",
+  });
+  const { client } = buildClient(harness);
+  await client.getIssue(REPO, makeIssueNumber(1));
+  assertEquals(harness.recordedSleeps[0], DEFAULT_MAX_RETRY_SLEEP_MILLISECONDS);
+});
+
+Deno.test("retry: X-RateLimit-Reset that is already in the past sleeps zero", async () => {
+  const harness = new FakeFetchHarness();
+  // now=2_000_000ms, reset=1000s=1_000_000ms is in the past.
+  harness.setTime(2_000_000);
+  harness.enqueueResponse(403, { message: "rate limited" }, {
+    headers: {
+      "x-ratelimit-remaining": "0",
+      "x-ratelimit-reset": "1000",
+    },
+  });
+  harness.enqueueResponse(200, {
+    number: 1,
+    title: "ok",
+    body: "",
+    state: "open",
+  });
+  const { client } = buildClient(harness);
+  await client.getIssue(REPO, makeIssueNumber(1));
+  assertEquals(harness.recordedSleeps, [0]);
+});
+
+Deno.test(
+  "retry: 403 with X-RateLimit-Remaining > 0 still triggers fallback retry",
+  async () => {
+    const harness = new FakeFetchHarness();
+    harness.enqueueResponse(403, { message: "Forbidden" }, {
+      headers: {
+        "x-ratelimit-remaining": "100",
+        "x-ratelimit-reset": "1000",
+      },
+    });
+    // The X-RateLimit-Reset branch only fires when remaining <= 0; with
+    // 100 remaining the client falls through to the constant fallback,
+    // sleeps once, and retries.
+    harness.enqueueResponse(200, {
+      number: 1,
+      title: "ok",
+      body: "",
+      state: "open",
+    });
+    const { client } = buildClient(harness);
+    await client.getIssue(REPO, makeIssueNumber(1));
+    assertEquals(harness.recordedRequests.length, 2);
+    assertEquals(harness.recordedSleeps, [DEFAULT_FALLBACK_RETRY_SLEEP_MILLISECONDS]);
+  },
+);
+
+Deno.test("auth: each call mints a token via the injected GitHubAuth", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, {
+    number: 1,
+    title: "ok",
+    body: "",
+    state: "open",
+  });
+  const { client, auth } = buildClient(harness);
+  await client.getIssue(REPO, makeIssueNumber(1));
+  // The auth double records every getInstallationToken call.
+  assertEquals(auth.recordedRequests().length, 1);
+  // The Authorization header carries the deterministic fake token.
+  const recorded = harness.recordedRequests[0];
+  assertEquals(
+    recorded?.headers["authorization"],
+    "token inmemory-token-123-1",
+  );
+});
+
+Deno.test("retry: a sleep duration is non-negative even with a zero Retry-After", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(429, {}, { headers: { "retry-after": "0" } });
+  harness.enqueueResponse(200, {
+    number: 1,
+    title: "ok",
+    body: "",
+    state: "open",
+  });
+  const { client } = buildClient(harness);
+  await client.getIssue(REPO, makeIssueNumber(1));
+  assertEquals(harness.recordedSleeps.length, 1);
+  assertGreaterOrEqual(harness.recordedSleeps[0] ?? -1, 0);
+});
+
+Deno.test("retry: a non-rate-limited 4xx propagates without retry", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(404, { message: "Not Found" });
+  const { client } = buildClient(harness);
+  await assertRejects(() => client.getIssue(REPO, makeIssueNumber(1)));
+  assertEquals(harness.recordedRequests.length, 1);
+  assertEquals(harness.recordedSleeps.length, 0);
+});
+
+Deno.test(
+  "constructor: custom userAgent and baseUrl are forwarded to Octokit",
+  async () => {
+    const harness = new FakeFetchHarness();
+    harness.enqueueResponse(200, {
+      number: 1,
+      title: "ok",
+      body: "",
+      state: "open",
+    });
+    const auth = new InMemoryGitHubAuth();
+    const client = new GitHubClientImpl({
+      auth,
+      installationId: makeInstallationId(123),
+      fetch: harness.fetch,
+      sleepMilliseconds: harness.sleep,
+      nowMilliseconds: harness.now,
+      userAgent: "custom-ua/1.0",
+      baseUrl: "https://example.test/api/v3",
+    });
+    await client.getIssue(REPO, makeIssueNumber(1));
+    const recorded = harness.recordedRequests[0];
+    assertEquals(
+      recorded?.url,
+      "https://example.test/api/v3/repos/octocat/hello-world/issues/1",
+    );
+    // Octokit appends its own version suffix; assert our UA is the prefix.
+    assertEquals(
+      recorded?.headers["user-agent"]?.startsWith("custom-ua/1.0"),
+      true,
+    );
+  },
+);

--- a/tests/unit/github_client_test.ts
+++ b/tests/unit/github_client_test.ts
@@ -730,7 +730,7 @@ Deno.test(
       },
     });
     // 403 with quota left is a permission/scope error, not a rate-limit
-    // event — see ADR-010. The client must not sleep or retry.
+    // event — see ADR-011. The client must not sleep or retry.
     const { client } = buildClient(harness);
     await assertRejects(() => client.getIssue(REPO, makeIssueNumber(1)));
     assertEquals(harness.recordedRequests.length, 1);

--- a/tests/unit/in_memory_doubles_test.ts
+++ b/tests/unit/in_memory_doubles_test.ts
@@ -166,7 +166,7 @@ Deno.test("InMemoryGitHubClient: records every method invocation", async () => {
   assertEquals(calls[3]?.method, "mergePullRequest");
 });
 
-Deno.test("InMemoryGitHubClient: records the four stabilize-phase methods", async () => {
+Deno.test("InMemoryGitHubClient: records the stabilize-phase methods (getCombinedStatus + four extensions)", async () => {
   const client = new InMemoryGitHubClient();
   const repo = makeRepoFullName("a/b");
   client.queueGetCombinedStatus({

--- a/tests/unit/in_memory_doubles_test.ts
+++ b/tests/unit/in_memory_doubles_test.ts
@@ -166,6 +166,81 @@ Deno.test("InMemoryGitHubClient: records every method invocation", async () => {
   assertEquals(calls[3]?.method, "mergePullRequest");
 });
 
+Deno.test("InMemoryGitHubClient: records the four stabilize-phase methods", async () => {
+  const client = new InMemoryGitHubClient();
+  const repo = makeRepoFullName("a/b");
+  client.queueGetCombinedStatus({
+    kind: "value",
+    value: { state: "success", sha: "abc" },
+  });
+  client.queueListCheckRuns({
+    kind: "value",
+    value: [
+      {
+        id: 1,
+        name: "build",
+        status: "completed",
+        conclusion: "success",
+        htmlUrl: "https://github.com/check/1",
+      },
+    ],
+  });
+  client.queueGetCheckRunLogs({
+    kind: "value",
+    value: new Uint8Array([1, 2, 3]),
+  });
+  client.queueListReviews({
+    kind: "value",
+    value: [
+      {
+        id: 10,
+        user: "Copilot",
+        state: "COMMENTED",
+        body: "looks ok",
+        submittedAtIso: "2026-04-26T12:00:00Z",
+      },
+    ],
+  });
+  client.queueListReviewComments({
+    kind: "value",
+    value: [
+      {
+        id: 100,
+        pullRequestReviewId: 10,
+        user: "Copilot",
+        body: "Consider renaming.",
+        path: "src/x.ts",
+        line: 12,
+        inReplyToId: null,
+        createdAtIso: "2026-04-26T12:00:00Z",
+      },
+    ],
+  });
+
+  const status = await client.getCombinedStatus(repo, "abc");
+  const runs = await client.listCheckRuns(repo, "abc");
+  const logs = await client.getCheckRunLogs(repo, 1);
+  const reviews = await client.listReviews(repo, makeIssueNumber(7));
+  const comments = await client.listReviewComments(repo, makeIssueNumber(7));
+
+  assertEquals(status.state, "success");
+  assertEquals(runs.length, 1);
+  assertEquals(runs[0]?.name, "build");
+  assertEquals(Array.from(logs), [1, 2, 3]);
+  assertEquals(reviews.length, 1);
+  assertEquals(reviews[0]?.state, "COMMENTED");
+  assertEquals(comments.length, 1);
+  assertEquals(comments[0]?.line, 12);
+
+  const calls = client.recordedCalls();
+  assertEquals(calls.length, 5);
+  assertEquals(calls[0]?.method, "getCombinedStatus");
+  assertEquals(calls[1]?.method, "listCheckRuns");
+  assertEquals(calls[2]?.method, "getCheckRunLogs");
+  assertEquals(calls[3]?.method, "listReviews");
+  assertEquals(calls[4]?.method, "listReviewComments");
+});
+
 // ---------------------------------------------------------------------------
 // InMemoryDaemonClient
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements [#5](https://github.com/koraytaylan/makina/issues/5) — typed GitHubClient with rate-limit-aware retry, covering every method the supervisor needs.

## Linked issue

Closes #5

## Definition of Done

- [x] JSDoc on every exported symbol; `deno doc --lint` green.
- [x] Each method covered by happy-path + 429 retry + 5xx propagation tests.
- [x] No real network in tests.
- [x] `deno task ci` is green.

## References

- Plan §Architecture (GitHubClient), §Lifecycle.
