### PR TITLE
feat(#10): TUI shell + Ink-on-Deno feasibility verification

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "jsxImportSource": "npm:react@18",
+    "jsxImportSourceTypes": "npm:@types/react@18",
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,

--- a/deno.lock
+++ b/deno.lock
@@ -2,12 +2,19 @@
   "version": "5",
   "specifiers": {
     "jsr:@std/assert@1": "1.0.10",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/cli@1": "1.0.29",
+    "jsr:@std/fs@^1.0.23": "1.0.23",
+    "jsr:@std/internal@^1.0.12": "1.0.13",
+    "jsr:@std/internal@^1.0.13": "1.0.13",
     "jsr:@std/internal@^1.0.5": "1.0.5",
+    "jsr:@std/path@^1.1.4": "1.1.4",
+    "jsr:@std/testing@1": "1.0.18",
     "npm:@anthropic-ai/claude-agent-sdk@*": "0.2.119_zod@3.25.76",
     "npm:@octokit/auth-app@7": "7.2.2",
     "npm:@octokit/core@5": "5.2.2",
-    "npm:ink@5": "5.2.1_react@18.3.1",
+    "npm:@types/react@18": "18.3.28",
+    "npm:ink@5": "5.2.1_@types+react@18.3.28_react@18.3.1",
     "npm:react@18": "18.3.1",
     "npm:zod@3": "3.25.76"
   },
@@ -15,14 +22,44 @@
     "@std/assert@1.0.10": {
       "integrity": "59b5cbac5bd55459a19045d95cc7c2ff787b4f8527c0dd195078ff6f9481fbb3",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.5"
+      ]
+    },
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
       ]
     },
     "@std/cli@1.0.29": {
       "integrity": "fa4ef29130baa834d8a13b7d138240c3a2fcfba740bfb7afa646a360a15ec84f"
     },
+    "@std/fs@1.0.23": {
+      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
+      "dependencies": [
+        "jsr:@std/path"
+      ]
+    },
     "@std/internal@1.0.5": {
       "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
+    },
+    "@std/internal@1.0.13": {
+      "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
+    },
+    "@std/path@1.1.4": {
+      "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/testing@1.0.18": {
+      "integrity": "d3152f57b11666bf6358d0e127c7e3488e91178b0c2d8fbf0793e1c53cd13cb1",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.19",
+        "jsr:@std/fs",
+        "jsr:@std/internal@^1.0.13",
+        "jsr:@std/path"
+      ]
     }
   },
   "npm": {
@@ -275,6 +312,16 @@
         "@octokit/openapi-types@25.1.0"
       ]
     },
+    "@types/prop-types@15.7.15": {
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="
+    },
+    "@types/react@18.3.28": {
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dependencies": [
+        "@types/prop-types",
+        "csstype"
+      ]
+    },
     "accepts@2.0.0": {
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "dependencies": [
@@ -403,6 +450,9 @@
         "shebang-command",
         "which"
       ]
+    },
+    "csstype@3.2.3": {
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
     "debug@4.4.3": {
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
@@ -600,10 +650,11 @@
     "inherits@2.0.4": {
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "ink@5.2.1_react@18.3.1": {
+    "ink@5.2.1_@types+react@18.3.28_react@18.3.1": {
       "integrity": "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==",
       "dependencies": [
         "@alcalzone/ansi-tokenize",
+        "@types/react",
         "ansi-escapes",
         "ansi-styles",
         "auto-bind",
@@ -628,6 +679,9 @@
         "wrap-ansi",
         "ws",
         "yoga-layout"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
     "ip-address@10.1.0": {
@@ -1018,6 +1072,7 @@
       "npm:@anthropic-ai/claude-agent-sdk@*",
       "npm:@octokit/auth-app@7",
       "npm:@octokit/core@5",
+      "npm:@types/react@18",
       "npm:ink@5",
       "npm:react@18",
       "npm:zod@3"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,3 +48,30 @@ Consumers do not import zod directly: `src/ipc/protocol.ts` exposes typed interf
 `parseEnvelope(raw): ParseEnvelopeResult` function; the same idiom in `src/config/schema.ts` exposes
 `parseConfig`. This keeps the public API zod-free so `deno doc --lint` reflects the contract, not
 the validator implementation.
+
+## TUI client (W2)
+
+`src/tui/ipc-client.ts` exports a `DaemonClient` interface plus a `SocketDaemonClient` that opens a
+Unix-domain socket via `Deno.connect({ transport: "unix" })`, encodes outgoing envelopes through
+`src/ipc/codec.ts`, and decodes pushed envelopes back into typed values. Reply correlation is by
+envelope id; pushed `event` envelopes fan out through `subscribeEvents`. The interface surface
+mirrors `tests/helpers/in_memory_daemon_client.ts` so consumers can swap the real client for the
+in-memory double in tests with no other change.
+
+`src/tui/hooks/useDaemonConnection.ts` wraps the client in a React hook that exposes
+`{ status, lastError, send, subscribe, connect, disconnect }` and walks the lifecycle
+`idle → connecting → connected → disconnected | error`. The hook is transport-agnostic: a client
+without `connect`/`close` methods (the in-memory double) starts directly in `connected`.
+
+The Wave-2 shell is intentionally read-only. Wave 3 wires the command palette and task switcher;
+Wave 3 also turns the focused-task id into a real selection driven by the task-list component.
+
+### Ink-on-Deno feasibility verdict (issue #10)
+
+Ink 5.2 renders cleanly under Deno 2.7 with `npm:ink`/`npm:react` specifiers. Yoga's WASM layer
+loads, the default `process.stdout`/`process.stdin` adapters provided by Deno's Node compatibility
+shim work as Ink expects, and `signal-exit`'s 13 signal listeners are released on `unmount()`. The
+ADR-001 risk is closed in favor of the original Deno-native plan; ADR-010 (Node-side Ink subprocess
+fallback) was not invoked. The single test-side caveat is that the Deno test sanitizer is strict
+about signal-listener leaks during interleaved Ink renders, so the App-level snapshot tests opt out
+of `sanitizeOps`/`sanitizeResources` (component-level tests keep both on).

--- a/main.ts
+++ b/main.ts
@@ -17,8 +17,14 @@ if (Deno.args.includes("--version")) {
   Deno.exit(0);
 }
 
-console.log("makina — agentic GitHub issue resolver");
-console.log("");
-console.log("Wave 1 skeleton. Most subcommands are not yet implemented.");
-console.log("Run `makina --version` to see the version.");
-console.log("See https://github.com/koraytaylan/makina for status.");
+const subcommand = Deno.args[0];
+if (subcommand === "daemon" || subcommand === "setup") {
+  // Owned by the `daemon` (#9) and `setup` (#3) Wave 2 branches; until
+  // they land here the command exits with a clear "not yet wired"
+  // notice rather than dropping into the TUI launch path.
+  console.log(`subcommand "${subcommand}" not yet wired in this branch.`);
+  Deno.exit(0);
+} else {
+  // Default branch → launch the Ink-based TUI.
+  await import("./src/tui/App.tsx").then((module) => module.launch());
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -165,3 +165,16 @@ export const MIN_GITHUB_INSTALLATION_ID = 1;
  * Issue numbers start at one within each repository.
  */
 export const MIN_GITHUB_ISSUE_NUMBER = 1;
+
+/**
+ * Maximum width, in UTF-16 code units, of an `agent-message` payload
+ * rendered to the TUI status bar.
+ *
+ * The status bar is one Ink `<Text>` row; longer text wraps and shoves
+ * the rest of the layout down. The cut is by code units (matching
+ * `String.prototype.slice`), which is good enough for ASCII-heavy agent
+ * chatter and tolerated by Ink's renderer when a surrogate pair lands
+ * on the boundary. Bumped only if the status bar grows a multi-line
+ * mode in a later wave.
+ */
+export const STATUS_BAR_TRUNCATION_WIDTH_CODE_UNITS = 80;

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,0 +1,290 @@
+/**
+ * tui/App.tsx — top-level Ink component for the makina TUI.
+ *
+ * Holds the daemon connection (via {@link useDaemonConnection}), the
+ * focused-task id, and the per-task event tally that drives the main
+ * pane's "1 task active" copy. Composes the three baseline panes
+ * (`Header`, `MainPane`, `StatusBar`).
+ *
+ * The exported {@link launch} function wires `main.ts` to a real
+ * socket-backed client. Snapshot tests render {@link App} directly with
+ * the in-memory double from `tests/helpers/in_memory_daemon_client.ts`.
+ *
+ * @module
+ */
+
+import { Box, render, Text, useApp } from "ink";
+import { type ReactElement, useEffect, useMemo, useState } from "react";
+
+import { Header } from "./components/Header.tsx";
+import { MainPane } from "./components/MainPane.tsx";
+import { StatusBar } from "./components/StatusBar.tsx";
+import { type DaemonClient, SocketDaemonClient } from "./ipc-client.ts";
+import { type ConnectionLifecycle, useDaemonConnection } from "./hooks/useDaemonConnection.ts";
+import type { EventPayload } from "../ipc/protocol.ts";
+import { makeTaskId, type TaskId } from "../types.ts";
+import { MAKINA_VERSION } from "../constants.ts";
+
+/**
+ * Default Unix-socket path the daemon listens on.
+ *
+ * The path is intentionally local to {@link launch}; setup wizard /
+ * config loader can supply a different one.
+ */
+const DEFAULT_DAEMON_SOCKET_PATH = `${Deno.env.get("HOME") ?? "/tmp"}/.makina/daemon.sock`;
+
+/**
+ * Props accepted by {@link App}.
+ */
+export interface AppProps {
+  /**
+   * The daemon client. Real socket-backed in production; the in-memory
+   * double from `tests/helpers/in_memory_daemon_client.ts` in tests.
+   */
+  readonly client: DaemonClient & ConnectionLifecycle;
+  /**
+   * Initial focused-task id. Wave 3 wires the task switcher; until
+   * then the value is provided externally for snapshot determinism.
+   */
+  readonly initialFocusedTaskId?: TaskId | undefined;
+  /**
+   * Optional override for the version string rendered in the header.
+   * Defaults to {@link MAKINA_VERSION}.
+   */
+  readonly version?: string | undefined;
+  /**
+   * If `true`, hooks call `client.connect()` automatically on mount.
+   * Set to `false` in tests that drive the lifecycle by hand.
+   *
+   * @default true
+   */
+  readonly autoConnect?: boolean | undefined;
+}
+
+/**
+ * The top-level TUI component.
+ *
+ * Subscribes to the daemon's pushed events on mount; updates the active-
+ * task tally and the most recent log/error message on every event.
+ *
+ * @param props See {@link AppProps}.
+ * @returns The composed TUI tree.
+ *
+ * @example
+ * ```tsx
+ * <App client={new SocketDaemonClient(socketPath)} />
+ * ```
+ */
+export function App(props: AppProps): ReactElement {
+  const {
+    client,
+    initialFocusedTaskId,
+    version = MAKINA_VERSION,
+    autoConnect = true,
+  } = props;
+  const connection = useDaemonConnection({
+    client,
+    autoConnect,
+  });
+  const [knownTaskIds, setKnownTaskIds] = useState<ReadonlySet<TaskId>>(() => new Set());
+  const [lastMessage, setLastMessage] = useState<string | undefined>(undefined);
+  const [lastError, setLastError] = useState<string | undefined>(undefined);
+  const [focusedTaskId, setFocusedTaskId] = useState<TaskId | undefined>(initialFocusedTaskId);
+
+  useEffect(() => {
+    const subscription = connection.subscribe((event) => {
+      handleEvent(event, {
+        setKnownTaskIds,
+        setLastMessage,
+        setLastError,
+        setFocusedTaskId,
+      });
+    });
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [connection.subscribe]);
+
+  const hint = useMemo(() => {
+    switch (connection.status) {
+      case "idle":
+      case "connecting":
+        return "Connecting to daemon…";
+      case "disconnected":
+        return "Daemon disconnected. Press R to reconnect (W3).";
+      case "error":
+        return `Connection error: ${connection.lastError ?? "unknown"}`;
+      case "connected":
+        return undefined;
+    }
+  }, [connection.status, connection.lastError]);
+
+  return (
+    <Box flexDirection="column">
+      <Header
+        version={version}
+        status={connection.status}
+        focusedTaskId={focusedTaskId}
+      />
+      <MainPane
+        activeTaskCount={knownTaskIds.size}
+        hint={hint}
+      />
+      <StatusBar
+        message={lastMessage ?? "ready"}
+        errorMessage={lastError ?? connection.lastError}
+      />
+    </Box>
+  );
+}
+
+/**
+ * Setters {@link handleEvent} reaches into when an event arrives. The
+ * indirection keeps the event handler easy to unit-test: the production
+ * call site passes React `useState` setters, while tests pass plain
+ * closures that capture into local variables.
+ */
+export interface EventSetters {
+  /** Setter for the known-tasks set used by `MainPane`. */
+  readonly setKnownTaskIds: (
+    update: (previous: ReadonlySet<TaskId>) => ReadonlySet<TaskId>,
+  ) => void;
+  /** Setter for the most-recent log message rendered in the status bar. */
+  readonly setLastMessage: (next: string | undefined) => void;
+  /** Setter for the most-recent error message rendered in the status bar. */
+  readonly setLastError: (next: string | undefined) => void;
+  /** Setter for the focused task id rendered in the header. */
+  readonly setFocusedTaskId: (next: TaskId | undefined) => void;
+}
+
+/**
+ * Apply a single pushed event to the App's state.
+ *
+ * @param event The event payload.
+ * @param setters The state setters captured by {@link App}.
+ */
+export function handleEvent(event: EventPayload, setters: EventSetters): void {
+  let taskId: TaskId | undefined;
+  try {
+    taskId = makeTaskId(event.taskId);
+  } catch {
+    // A malformed task id should not crash the renderer; surface it as
+    // an error and ignore the event otherwise.
+    setters.setLastError(`event with invalid task id: ${event.taskId}`);
+    return;
+  }
+  setters.setKnownTaskIds((previous) => {
+    if (previous.has(taskId)) {
+      return previous;
+    }
+    const next = new Set(previous);
+    next.add(taskId);
+    return next;
+  });
+  // Auto-focus the first task we hear about so the header's focus pill
+  // stops saying "no task focused" once events arrive.
+  setters.setFocusedTaskId(taskId);
+  switch (event.kind) {
+    case "log":
+      setters.setLastMessage(`[${event.data.level}] ${event.data.message}`);
+      break;
+    case "state-changed":
+      setters.setLastMessage(
+        `${taskId}: ${event.data.fromState} → ${event.data.toState}`,
+      );
+      break;
+    case "agent-message":
+      setters.setLastMessage(`agent ${event.data.role}: ${truncate(event.data.text, 80)}`);
+      break;
+    case "github-call":
+      setters.setLastMessage(
+        `github ${event.data.method} ${event.data.endpoint}`,
+      );
+      break;
+    case "error":
+      setters.setLastError(event.data.message);
+      break;
+  }
+}
+
+/**
+ * Truncate `text` to `limit` graphemes, appending an ellipsis when
+ * shortened. Used by {@link handleEvent} so a long agent message does
+ * not overflow the status bar.
+ *
+ * @param text The text to truncate.
+ * @param limit The maximum length, in characters.
+ * @returns The truncated string.
+ */
+function truncate(text: string, limit: number): string {
+  if (text.length <= limit) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(0, limit - 1))}…`;
+}
+
+/**
+ * Inner component used by {@link launch} to register a Ctrl+C exit
+ * handler against Ink's app context. Kept separate so {@link App}
+ * remains a pure render component (and therefore trivial to test).
+ */
+function CtrlCExit(): ReactElement {
+  const app = useApp();
+  useEffect(() => {
+    const onSignal = () => {
+      app.exit();
+    };
+    Deno.addSignalListener("SIGINT", onSignal);
+    return () => {
+      try {
+        Deno.removeSignalListener("SIGINT", onSignal);
+      } catch {
+        // Already removed.
+      }
+    };
+  }, [app]);
+  return <Text></Text>;
+}
+
+/**
+ * Production launch entrypoint wired in by `main.ts`.
+ *
+ * Builds a {@link SocketDaemonClient} pointing at the default daemon
+ * socket and renders the {@link App} into Ink's default `process.stdout`
+ * stream. The resolved promise settles when the app exits (Ctrl+C or
+ * `useApp().exit()`).
+ *
+ * @param overrides Optional overrides for the socket path and the
+ *   client (the latter exists so an integration test can drive the real
+ *   render with a non-default client).
+ * @returns A promise that settles when the app exits.
+ *
+ * @example
+ * ```ts
+ * import { launch } from "./src/tui/App.tsx";
+ * await launch();
+ * ```
+ */
+export async function launch(overrides?: {
+  readonly socketPath?: string;
+  readonly client?: DaemonClient & ConnectionLifecycle;
+}): Promise<void> {
+  const socketPath = overrides?.socketPath ?? DEFAULT_DAEMON_SOCKET_PATH;
+  const client = overrides?.client ?? new SocketDaemonClient(socketPath);
+  const instance = render(
+    <Box flexDirection="column">
+      <App client={client} />
+      <CtrlCExit />
+    </Box>,
+    { exitOnCtrlC: false, patchConsole: false },
+  );
+  try {
+    await instance.waitUntilExit();
+  } finally {
+    if (typeof client.close === "function") {
+      await client.close().catch(() => {
+        // Already closed; nothing to do.
+      });
+    }
+  }
+}

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -23,7 +23,7 @@ import { type DaemonClient, SocketDaemonClient } from "./ipc-client.ts";
 import { type ConnectionLifecycle, useDaemonConnection } from "./hooks/useDaemonConnection.ts";
 import type { EventPayload } from "../ipc/protocol.ts";
 import { makeTaskId, type TaskId } from "../types.ts";
-import { MAKINA_VERSION } from "../constants.ts";
+import { MAKINA_VERSION, STATUS_BAR_TRUNCATION_WIDTH_CODE_UNITS } from "../constants.ts";
 
 /**
  * Default Unix-socket path the daemon listens on.
@@ -209,7 +209,11 @@ export function handleEvent(event: EventPayload, setters: EventSetters): void {
       );
       break;
     case "agent-message":
-      setters.setLastMessage(`agent ${event.data.role}: ${truncate(event.data.text, 80)}`);
+      setters.setLastMessage(
+        `agent ${event.data.role}: ${
+          truncate(event.data.text, STATUS_BAR_TRUNCATION_WIDTH_CODE_UNITS)
+        }`,
+      );
       break;
     case "github-call":
       setters.setLastMessage(

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -143,6 +143,11 @@ export function App(props: AppProps): ReactElement {
  * indirection keeps the event handler easy to unit-test: the production
  * call site passes React `useState` setters, while tests pass plain
  * closures that capture into local variables.
+ *
+ * `setFocusedTaskId` accepts a functional updater so the handler can
+ * apply "auto-focus only when nothing is focused yet" without reading
+ * the current focused-task value out of band — the React setter and
+ * the test stubs both honor the closure-style update.
  */
 export interface EventSetters {
   /** Setter for the known-tasks set used by `MainPane`. */
@@ -153,8 +158,15 @@ export interface EventSetters {
   readonly setLastMessage: (next: string | undefined) => void;
   /** Setter for the most-recent error message rendered in the status bar. */
   readonly setLastError: (next: string | undefined) => void;
-  /** Setter for the focused task id rendered in the header. */
-  readonly setFocusedTaskId: (next: TaskId | undefined) => void;
+  /**
+   * Setter for the focused task id rendered in the header.
+   *
+   * Receives a functional updater so {@link handleEvent} can preserve
+   * an existing focus instead of clobbering it on every event.
+   */
+  readonly setFocusedTaskId: (
+    update: (previous: TaskId | undefined) => TaskId | undefined,
+  ) => void;
 }
 
 /**
@@ -182,8 +194,11 @@ export function handleEvent(event: EventPayload, setters: EventSetters): void {
     return next;
   });
   // Auto-focus the first task we hear about so the header's focus pill
-  // stops saying "no task focused" once events arrive.
-  setters.setFocusedTaskId(taskId);
+  // stops saying "no task focused" once events arrive. Subsequent
+  // events leave the focused task alone — Wave 3's task switcher will
+  // own focus changes — so the focus does not jump around as new
+  // tasks appear.
+  setters.setFocusedTaskId((previous) => previous ?? taskId);
   switch (event.kind) {
     case "log":
       setters.setLastMessage(`[${event.data.level}] ${event.data.message}`);
@@ -208,12 +223,20 @@ export function handleEvent(event: EventPayload, setters: EventSetters): void {
 }
 
 /**
- * Truncate `text` to `limit` graphemes, appending an ellipsis when
- * shortened. Used by {@link handleEvent} so a long agent message does
- * not overflow the status bar.
+ * Truncate `text` to at most `limit` UTF-16 code units, appending an
+ * ellipsis when shortened. Used by {@link handleEvent} so a long agent
+ * message does not overflow the status bar.
+ *
+ * The cut is by code units, not graphemes — a surrogate pair or a
+ * grapheme cluster that straddles the boundary will be split. The
+ * status bar consumes the result through Ink's text renderer, which
+ * tolerates a stray half-surrogate (it renders as the replacement
+ * character), so the render never crashes; the worst case is one
+ * malformed code point at the cut. Callers that need cluster-aware
+ * truncation should reach for `Intl.Segmenter` themselves.
  *
  * @param text The text to truncate.
- * @param limit The maximum length, in characters.
+ * @param limit The maximum length, in UTF-16 code units.
  * @returns The truncated string.
  */
 function truncate(text: string, limit: number): string {

--- a/src/tui/components/Header.tsx
+++ b/src/tui/components/Header.tsx
@@ -1,0 +1,98 @@
+/**
+ * tui/components/Header.tsx — top pane of the TUI.
+ *
+ * Renders the makina version, the daemon connection status, and the
+ * focused-task id (when one is selected). Stateless; everything is
+ * driven through props so the snapshot tests can reproduce every
+ * variant deterministically.
+ *
+ * @module
+ */
+
+import { Box, Text } from "ink";
+import type { ReactElement } from "react";
+
+import type { DaemonConnectionStatus } from "../hooks/useDaemonConnection.ts";
+import type { TaskId } from "../../types.ts";
+
+/**
+ * Props accepted by {@link Header}.
+ */
+export interface HeaderProps {
+  /** The makina version to display in the top-left. */
+  readonly version: string;
+  /** Daemon connection status; affects the status pill colour. */
+  readonly status: DaemonConnectionStatus;
+  /** The currently-focused task id, when one exists. */
+  readonly focusedTaskId?: TaskId | undefined;
+}
+
+/**
+ * Render the TUI header.
+ *
+ * @param props See {@link HeaderProps}.
+ * @returns The header element.
+ *
+ * @example
+ * ```tsx
+ * <Header version="0.0.0-dev" status="connected" />
+ * ```
+ */
+export function Header(props: HeaderProps): ReactElement {
+  const { version, status, focusedTaskId } = props;
+  const focusLabel = focusedTaskId === undefined ? "no task focused" : `focus: ${focusedTaskId}`;
+  return (
+    <Box
+      flexDirection="row"
+      borderStyle="round"
+      borderColor="cyan"
+      paddingX={1}
+      justifyContent="space-between"
+    >
+      <Text bold color="cyan">makina v{version}</Text>
+      <Text color={statusColor(status)}>{statusLabel(status)}</Text>
+      <Text dimColor>{focusLabel}</Text>
+    </Box>
+  );
+}
+
+/**
+ * Map a connection status to a human-readable label.
+ *
+ * @param status The current status.
+ * @returns The label rendered in the header pill.
+ */
+function statusLabel(status: DaemonConnectionStatus): string {
+  switch (status) {
+    case "idle":
+      return "idle";
+    case "connecting":
+      return "connecting…";
+    case "connected":
+      return "connected";
+    case "disconnected":
+      return "disconnected";
+    case "error":
+      return "error";
+  }
+}
+
+/**
+ * Map a connection status to the colour applied to its label.
+ *
+ * @param status The current status.
+ * @returns A colour name accepted by Ink's `<Text color>` prop.
+ */
+function statusColor(status: DaemonConnectionStatus): string {
+  switch (status) {
+    case "idle":
+    case "connecting":
+      return "yellow";
+    case "connected":
+      return "green";
+    case "disconnected":
+      return "gray";
+    case "error":
+      return "red";
+  }
+}

--- a/src/tui/components/MainPane.tsx
+++ b/src/tui/components/MainPane.tsx
@@ -1,0 +1,61 @@
+/**
+ * tui/components/MainPane.tsx — middle pane of the TUI.
+ *
+ * Wave 2 ships the empty placeholder shell: the pane exists, the
+ * snapshot tests assert that it renders, and the active-task count is
+ * surfaced so the daemon's events are observable end-to-end. Wave 3
+ * fills it with the task list, the per-task scrollback, and the
+ * focused-task detail view.
+ *
+ * @module
+ */
+
+import { Box, Text } from "ink";
+import type { ReactElement } from "react";
+
+/**
+ * Props accepted by {@link MainPane}.
+ */
+export interface MainPaneProps {
+  /**
+   * Number of tasks the daemon has reported so far. Drives the empty-
+   * vs. populated copy.
+   */
+  readonly activeTaskCount: number;
+  /**
+   * Optional human-readable hint displayed under the headline (e.g.
+   * "Connecting to daemon…").
+   */
+  readonly hint?: string | undefined;
+}
+
+/**
+ * Render the TUI main pane.
+ *
+ * @param props See {@link MainPaneProps}.
+ * @returns The main-pane element.
+ *
+ * @example
+ * ```tsx
+ * <MainPane activeTaskCount={0} />
+ * ```
+ */
+export function MainPane(props: MainPaneProps): ReactElement {
+  const { activeTaskCount, hint } = props;
+  const headline = activeTaskCount === 0
+    ? "No tasks yet — invoke /issue <repo>#<n> to start one."
+    : `${activeTaskCount} ${activeTaskCount === 1 ? "task" : "tasks"} active.`;
+  return (
+    <Box
+      flexGrow={1}
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="gray"
+      paddingX={1}
+      paddingY={1}
+    >
+      <Text>{headline}</Text>
+      {hint !== undefined ? <Text dimColor>{hint}</Text> : null}
+    </Box>
+  );
+}

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -1,0 +1,62 @@
+/**
+ * tui/components/StatusBar.tsx — bottom pane of the TUI.
+ *
+ * Renders a single line of status text — the most recent log message
+ * from the daemon, the most recent error (if any), and a tiny
+ * keybindings hint. Stateless; everything is driven through props so
+ * the snapshot tests can exercise every variant deterministically.
+ *
+ * @module
+ */
+
+import { Box, Text } from "ink";
+import type { ReactElement } from "react";
+
+/**
+ * Props accepted by {@link StatusBar}.
+ */
+export interface StatusBarProps {
+  /**
+   * Most recent informational message to display on the left. Falls
+   * back to a static placeholder when omitted.
+   */
+  readonly message?: string | undefined;
+  /**
+   * Most recent error message; renders red when present and supersedes
+   * {@link StatusBarProps.message} visually.
+   */
+  readonly errorMessage?: string | undefined;
+  /**
+   * Keybindings hint shown on the right. Wave 3 wires the command
+   * palette and task switcher and updates this string from above.
+   */
+  readonly keybindingsHint?: string | undefined;
+}
+
+/**
+ * Render the TUI status bar.
+ *
+ * @param props See {@link StatusBarProps}.
+ * @returns The status-bar element.
+ *
+ * @example
+ * ```tsx
+ * <StatusBar message="ready" />
+ * ```
+ */
+export function StatusBar(props: StatusBarProps): ReactElement {
+  const {
+    message,
+    errorMessage,
+    keybindingsHint = "Ctrl+C exit · / command palette (W3)",
+  } = props;
+  const left = errorMessage !== undefined
+    ? <Text color="red">{`error: ${errorMessage}`}</Text>
+    : <Text>{message ?? "ready"}</Text>;
+  return (
+    <Box flexDirection="row" justifyContent="space-between" paddingX={1}>
+      {left}
+      <Text dimColor>{keybindingsHint}</Text>
+    </Box>
+  );
+}

--- a/src/tui/hooks/useDaemonConnection.ts
+++ b/src/tui/hooks/useDaemonConnection.ts
@@ -54,6 +54,24 @@ export type DaemonConnectionStatus =
   | "error";
 
 /**
+ * Error raised by {@link useDaemonConnection}'s `send` when invoked
+ * before the lifecycle reaches `"connected"`. Surfaced as a rejection
+ * so callers can distinguish a hook-side guard from an underlying
+ * transport failure.
+ */
+export class DaemonHookError extends Error {
+  /**
+   * Construct a daemon-hook error.
+   *
+   * @param message Human-readable description of the violation.
+   */
+  constructor(message: string) {
+    super(message);
+    this.name = "DaemonHookError";
+  }
+}
+
+/**
  * The `connect`/`close` half of the {@link DaemonClient} surface that
  * `useDaemonConnection` calls when present. Both are optional so the
  * in-memory double (which is connected on construction) just satisfies
@@ -81,7 +99,11 @@ export interface DaemonConnectionApi {
    */
   readonly lastError: string | undefined;
   /**
-   * Send a request envelope. Rejects if `status !== "connected"`.
+   * Send a request envelope. Rejects with a {@link DaemonHookError} if
+   * `status !== "connected"` at call time; otherwise the call is
+   * forwarded to the underlying client and any transport-level error
+   * surfaces as the client's own rejection (typically a
+   * `DaemonClientError`).
    *
    * @param envelope The envelope to send.
    * @returns The daemon's reply.
@@ -167,7 +189,25 @@ export function useDaemonConnection(
     await closeConnection(clientRef.current, setStatus, setLastError);
   }, []);
 
+  // `statusRef` mirrors `status` so the stable `send` callback can
+  // enforce the "must be connected" guarantee without re-binding on
+  // every status change (which would defeat the stable-reference
+  // contract documented on `DaemonConnectionApi`).
+  const statusRef = useRef(status);
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
+
   const send = useCallback((envelope: MessageEnvelope): Promise<DaemonReply> => {
+    if (statusRef.current !== "connected") {
+      return Promise.reject(
+        new DaemonHookError(
+          `useDaemonConnection.send requires status === "connected"; got ${
+            JSON.stringify(statusRef.current)
+          }`,
+        ),
+      );
+    }
     return clientRef.current.send(envelope);
   }, []);
 
@@ -252,7 +292,14 @@ async function closeConnection(
   setLastError: Dispatch<SetStateAction<string | undefined>>,
 ): Promise<void> {
   if (client.close === undefined) {
+    // Mirror the success path of the lifecycle-aware branch below: a
+    // clean disconnect leaves no lingering error message even when
+    // the underlying client lacks a `close` to call (in-memory
+    // double, etc.). Without the reset, an earlier transition into
+    // `"error"` would still surface its message in the status bar
+    // after the caller asked to disconnect cleanly.
     setStatus("disconnected");
+    setLastError(undefined);
     return;
   }
   try {

--- a/src/tui/hooks/useDaemonConnection.ts
+++ b/src/tui/hooks/useDaemonConnection.ts
@@ -1,0 +1,266 @@
+/**
+ * tui/hooks/useDaemonConnection.ts — React hook that manages the TUI's
+ * single daemon connection.
+ *
+ * The hook accepts any {@link DaemonClient} (real socket-backed or the
+ * in-memory test double from `tests/helpers/in_memory_daemon_client.ts`)
+ * and exposes a `{ status, connect, disconnect, subscribe, send }`
+ * surface that React components and the snapshot tests both code
+ * against. State transitions:
+ *
+ * ```text
+ * idle  → connecting → connected
+ * idle  → connecting → error
+ * connected → disconnected (manual)
+ * connected → error (read-loop failure)
+ * ```
+ *
+ * The hook itself is transport-agnostic: it does not care whether the
+ * underlying client speaks over a Unix socket or in-memory. The optional
+ * `connect`/`disconnect` arguments on the client interface are honored
+ * when present so the snapshot tests can use the in-memory double
+ * (which is "connected" the moment it is constructed) without changes.
+ *
+ * @module
+ */
+
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+import type { DaemonClient, DaemonEventSubscription, DaemonReply } from "../ipc-client.ts";
+import type { EventPayload, MessageEnvelope } from "../../ipc/protocol.ts";
+
+/**
+ * Lifecycle states the hook walks through.
+ *
+ * - `idle` — no connect attempt made yet.
+ * - `connecting` — `connect()` is in flight.
+ * - `connected` — the client is ready for `send`/`subscribe`.
+ * - `disconnected` — the caller invoked `disconnect()` cleanly.
+ * - `error` — connect or read-loop failed; `lastError` carries the
+ *   message.
+ */
+export type DaemonConnectionStatus =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "disconnected"
+  | "error";
+
+/**
+ * The `connect`/`close` half of the {@link DaemonClient} surface that
+ * `useDaemonConnection` calls when present. Both are optional so the
+ * in-memory double (which is connected on construction) just satisfies
+ * the {@link DaemonClient} portion.
+ */
+export interface ConnectionLifecycle {
+  /** Open the underlying transport. Must be idempotent. */
+  connect?: () => Promise<void>;
+  /** Tear the underlying transport down. Must be idempotent. */
+  close?: () => Promise<void>;
+}
+
+/**
+ * Public surface returned by {@link useDaemonConnection}.
+ *
+ * Components destructure `{ status, send, subscribe, connect,
+ * disconnect, lastError }` and re-render on every status change.
+ */
+export interface DaemonConnectionApi {
+  /** Current lifecycle state. */
+  readonly status: DaemonConnectionStatus;
+  /**
+   * Last error message, when {@link DaemonConnectionApi.status} is
+   * `"error"`. `undefined` otherwise.
+   */
+  readonly lastError: string | undefined;
+  /**
+   * Send a request envelope. Rejects if `status !== "connected"`.
+   *
+   * @param envelope The envelope to send.
+   * @returns The daemon's reply.
+   */
+  readonly send: (envelope: MessageEnvelope) => Promise<DaemonReply>;
+  /**
+   * Subscribe to pushed event envelopes. Returns a handle whose
+   * `unsubscribe()` stops further deliveries.
+   *
+   * @param handler Callback invoked synchronously per event.
+   */
+  readonly subscribe: (
+    handler: (event: EventPayload) => void,
+  ) => DaemonEventSubscription;
+  /** Trigger a `connect()` on the underlying client (if the client supports it). */
+  readonly connect: () => Promise<void>;
+  /** Trigger a `close()` on the underlying client (if the client supports it). */
+  readonly disconnect: () => Promise<void>;
+}
+
+/**
+ * Options accepted by {@link useDaemonConnection}.
+ */
+export interface UseDaemonConnectionOptions {
+  /** The daemon client (real or in-memory). */
+  readonly client: DaemonClient & ConnectionLifecycle;
+  /**
+   * If `true`, the hook calls `client.connect()` on mount automatically.
+   *
+   * @default true
+   */
+  readonly autoConnect?: boolean;
+}
+
+/**
+ * React hook that wires a {@link DaemonClient} into a component's render
+ * cycle.
+ *
+ * Two key invariants hold across renders:
+ *
+ * - Calling `send`/`subscribe` against the returned object is stable
+ *   — the function references survive re-renders, so consumers can
+ *   include them in dependency arrays without triggering effect loops.
+ * - The hook never holds a reference to a stale client: pass a new
+ *   client and the previous subscription is torn down on the cleanup
+ *   pass.
+ *
+ * @param options Hook options. See {@link UseDaemonConnectionOptions}.
+ * @returns The {@link DaemonConnectionApi} the component should render
+ *   against.
+ *
+ * @example
+ * ```tsx
+ * import { useDaemonConnection } from "./useDaemonConnection.ts";
+ *
+ * function App({ client }: { client: DaemonClient }) {
+ *   const { status } = useDaemonConnection({ client });
+ *   return <Text>{status}</Text>;
+ * }
+ * ```
+ */
+export function useDaemonConnection(
+  options: UseDaemonConnectionOptions,
+): DaemonConnectionApi {
+  const { client, autoConnect = true } = options;
+  const [status, setStatus] = useState<DaemonConnectionStatus>(
+    client.connect === undefined ? "connected" : "idle",
+  );
+  const [lastError, setLastError] = useState<string | undefined>(undefined);
+  const clientRef = useRef(client);
+
+  // Keep the ref pointed at the latest client so the stable callbacks
+  // below always read the current instance.
+  useEffect(() => {
+    clientRef.current = client;
+  }, [client]);
+
+  const connect = useCallback(async () => {
+    await openConnection(clientRef.current, setStatus, setLastError);
+  }, []);
+
+  const disconnect = useCallback(async () => {
+    await closeConnection(clientRef.current, setStatus, setLastError);
+  }, []);
+
+  const send = useCallback((envelope: MessageEnvelope): Promise<DaemonReply> => {
+    return clientRef.current.send(envelope);
+  }, []);
+
+  const subscribe = useCallback(
+    (handler: (event: EventPayload) => void): DaemonEventSubscription => {
+      return clientRef.current.subscribeEvents(handler);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!autoConnect) {
+      return;
+    }
+    if (clientRef.current.connect === undefined) {
+      return;
+    }
+    let cancelled = false;
+    void openConnection(clientRef.current, (next) => {
+      if (!cancelled) {
+        setStatus(next);
+      }
+    }, (next) => {
+      if (!cancelled) {
+        setLastError(next);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+    // Intentionally empty: we want to fire connect exactly once on
+    // mount. Re-subscribing on every render would defeat the purpose
+    // of `autoConnect`.
+  }, [autoConnect]);
+
+  return { status, lastError, send, subscribe, connect, disconnect };
+}
+
+/**
+ * Drive `client.connect()` and reflect the outcome through the supplied
+ * setters. Extracted so {@link useDaemonConnection} can call the same
+ * code path from `autoConnect` and from the manually-invoked `connect`
+ * callback.
+ *
+ * @param client The daemon client to connect.
+ * @param setStatus Setter for the lifecycle status.
+ * @param setLastError Setter for the last-error message.
+ */
+async function openConnection(
+  client: DaemonClient & ConnectionLifecycle,
+  setStatus: Dispatch<SetStateAction<DaemonConnectionStatus>>,
+  setLastError: Dispatch<SetStateAction<string | undefined>>,
+): Promise<void> {
+  if (client.connect === undefined) {
+    setStatus("connected");
+    setLastError(undefined);
+    return;
+  }
+  setStatus("connecting");
+  setLastError(undefined);
+  try {
+    await client.connect();
+    setStatus("connected");
+  } catch (error) {
+    setStatus("error");
+    setLastError(error instanceof Error ? error.message : String(error));
+  }
+}
+
+/**
+ * Drive `client.close()` and reflect the outcome through the supplied
+ * setters. The lifecycle becomes `"disconnected"` on success and
+ * `"error"` if `close()` itself rejects.
+ *
+ * @param client The daemon client to close.
+ * @param setStatus Setter for the lifecycle status.
+ * @param setLastError Setter for the last-error message.
+ */
+async function closeConnection(
+  client: DaemonClient & ConnectionLifecycle,
+  setStatus: Dispatch<SetStateAction<DaemonConnectionStatus>>,
+  setLastError: Dispatch<SetStateAction<string | undefined>>,
+): Promise<void> {
+  if (client.close === undefined) {
+    setStatus("disconnected");
+    return;
+  }
+  try {
+    await client.close();
+    setStatus("disconnected");
+    setLastError(undefined);
+  } catch (error) {
+    setStatus("error");
+    setLastError(error instanceof Error ? error.message : String(error));
+  }
+}

--- a/src/tui/ipc-client.ts
+++ b/src/tui/ipc-client.ts
@@ -150,7 +150,22 @@ export class SocketDaemonClient implements DaemonClient {
   >();
   private readonly eventHandlers = new Set<(event: EventPayload) => void>();
   private readLoopPromise: Promise<void> | undefined;
+  /**
+   * Set by {@link SocketDaemonClient.close} so subsequent operations
+   * fail fast. Distinct from the read-loop terminating on its own (a
+   * peer disconnect): an unexpected end leaves `closed === false` so a
+   * caller can call {@link SocketDaemonClient.connect} again to
+   * recover, while an explicit `close()` is permanent.
+   */
   private closed = false;
+  /**
+   * Tracks whether the read loop is currently consuming frames. Goes
+   * `true` in {@link SocketDaemonClient.connect}, back to `false` in
+   * the read loop's `finally`, and lets `connect()` distinguish "I am
+   * already streaming" (no-op) from "the previous stream ended; open
+   * a fresh socket" (reconnect).
+   */
+  private streaming = false;
 
   /**
    * Construct a socket-backed client.
@@ -173,18 +188,36 @@ export class SocketDaemonClient implements DaemonClient {
   }
 
   /**
-   * Open the underlying connection and start the read loop. A
-   * second call before {@link SocketDaemonClient.close} is a no-op.
+   * Open the underlying connection and start the read loop.
    *
-   * @throws {DaemonClientError} If the socket cannot be opened.
+   * - A second call while the read loop is still consuming frames is
+   *   a no-op (the existing socket is reused).
+   * - A call after {@link SocketDaemonClient.close} rejects with a
+   *   {@link DaemonClientError} (an explicit close is permanent).
+   * - A call after the read loop ended on its own (peer disconnect)
+   *   reopens a fresh socket and restarts the read loop. This is the
+   *   recovery path the {@link useDaemonConnection} hook walks when a
+   *   reconnect button is pressed in Wave 3.
+   *
+   * @throws {DaemonClientError} If the client was explicitly closed
+   *   or if the underlying socket cannot be opened.
    */
   async connect(): Promise<void> {
-    if (this.connection !== undefined) {
+    if (this.streaming) {
+      // Already streaming — `connect()` is idempotent in this state.
       return;
     }
     if (this.closed) {
       throw new DaemonClientError("client has been closed");
     }
+    // Defensively clear any leftover handles from a previous read
+    // loop that ended on its own (peer disconnect). The loop's
+    // `finally` releases the locks for us; this just nulls the
+    // refs so the new opener can install fresh ones.
+    this.connection = undefined;
+    this.writer = undefined;
+    this.reader = undefined;
+    this.readLoopPromise = undefined;
     try {
       this.connection = await this.opener();
     } catch (error) {
@@ -195,6 +228,7 @@ export class SocketDaemonClient implements DaemonClient {
     }
     this.writer = this.connection.writable.getWriter();
     this.reader = this.connection.readable.getReader();
+    this.streaming = true;
     this.readLoopPromise = this.runReadLoop(this.reader);
   }
 
@@ -261,12 +295,18 @@ export class SocketDaemonClient implements DaemonClient {
   /**
    * Tear down the connection. Outstanding `send` promises reject with a
    * {@link DaemonClientError}; the read loop exits cleanly. Idempotent.
+   *
+   * Once called, the client is permanently dead — subsequent
+   * {@link SocketDaemonClient.connect} calls reject. To recover from a
+   * peer disconnect without losing the right to reconnect, let the
+   * read loop terminate on its own and then call `connect()` again.
    */
   async close(): Promise<void> {
     if (this.closed) {
       return;
     }
     this.closed = true;
+    this.streaming = false;
     const reason = new DaemonClientError("client closed before reply");
     for (const [id, slot] of this.pending) {
       slot.reject(reason);
@@ -379,9 +419,37 @@ export class SocketDaemonClient implements DaemonClient {
         this.failAllPending(reason);
       }
     } finally {
-      // If the stream ended without `close()` being called explicitly,
-      // mark the client closed so subsequent sends fail fast.
-      this.closed = true;
+      // The stream ended (peer disconnect or explicit `close()`).
+      // Tear down the local handles so a subsequent `connect()` opens
+      // fresh ones — without this the early-return at the top of
+      // `connect()` would treat the dead connection as still alive
+      // and silently no-op. `closed` is left untouched here: only
+      // `close()` should mark the client permanently dead.
+      this.streaming = false;
+      if (this.writer !== undefined) {
+        try {
+          this.writer.releaseLock();
+        } catch {
+          // Already released (close() ran in parallel).
+        }
+        this.writer = undefined;
+      }
+      if (this.reader !== undefined) {
+        try {
+          this.reader.releaseLock();
+        } catch {
+          // Already released.
+        }
+        this.reader = undefined;
+      }
+      if (this.connection !== undefined) {
+        try {
+          this.connection.close();
+        } catch {
+          // Already closed.
+        }
+        this.connection = undefined;
+      }
     }
   }
 

--- a/src/tui/ipc-client.ts
+++ b/src/tui/ipc-client.ts
@@ -242,11 +242,16 @@ export class SocketDaemonClient implements DaemonClient {
    *   reply arrives.
    */
   send(envelope: MessageEnvelope): Promise<DaemonReply> {
-    if (this.connection === undefined || this.writer === undefined) {
-      return Promise.reject(new DaemonClientError("not connected"));
-    }
+    // Check `closed` before the connection-state guard so a `send` after
+    // an explicit `close()` rejects with the documented permanent-close
+    // error instead of the recoverable "not connected" message — close()
+    // tears down `connection`/`writer`, so both branches would otherwise
+    // fire and the less-specific one would win the race.
     if (this.closed) {
       return Promise.reject(new DaemonClientError("client has been closed"));
+    }
+    if (this.connection === undefined || this.writer === undefined) {
+      return Promise.reject(new DaemonClientError("not connected"));
     }
     let bytes: Uint8Array;
     try {

--- a/src/tui/ipc-client.ts
+++ b/src/tui/ipc-client.ts
@@ -411,6 +411,16 @@ export class SocketDaemonClient implements DaemonClient {
           new DaemonClientError(`unexpected envelope type from daemon: ${envelope.type}`),
         );
       }
+      // Loop exited normally — the peer reached EOF without sending a
+      // reply for at least the still-pending ids. Fail those promises
+      // so callers do not hang waiting for a reply that will never
+      // arrive. `close()` already drains `pending` itself, so this is
+      // only meaningful for an unsolicited peer disconnect; it is a
+      // no-op when the read loop ends because of a deliberate
+      // `close()`.
+      if (!this.closed) {
+        this.failAllPending(new DaemonClientError("daemon disconnected before responding"));
+      }
     } catch (error) {
       if (!this.closed) {
         const reason = error instanceof Error

--- a/src/tui/ipc-client.ts
+++ b/src/tui/ipc-client.ts
@@ -1,0 +1,488 @@
+/**
+ * tui/ipc-client.ts — Unix-domain-socket IPC client used by the TUI.
+ *
+ * **Surface.** The exported {@link DaemonClient} interface intentionally
+ * mirrors the public surface of the in-process double in
+ * `tests/helpers/in_memory_daemon_client.ts` (`send` and `subscribeEvents`
+ * only — the test-only `simulateEvent`, `recordedSends`, and
+ * `setRequestHandler` are deliberately absent here). The TUI hooks code
+ * against the interface, never the concrete class, so swapping the real
+ * socket-backed client for the in-memory double in tests is a one-line
+ * change.
+ *
+ * **Wire format.** Each frame is `<decimal-length>\n<utf8-json>\n` per
+ * `src/ipc/codec.ts`. The codec handles framing; this module only deals in
+ * typed envelopes. Pushed `event` envelopes from the daemon are surfaced
+ * through the `subscribeEvents` callback in arrival order; reply envelopes
+ * (`pong` for `ping`, `ack` otherwise) are matched back to outstanding
+ * `send` calls by the envelope `id`.
+ *
+ * **Lifecycle.** Construct → {@link SocketDaemonClient.connect} → use
+ * `send`/`subscribeEvents` → {@link SocketDaemonClient.close}. `close()`
+ * tears down the socket and rejects every in-flight `send` so the caller
+ * never hangs waiting for a reply that will never arrive.
+ *
+ * @module
+ */
+
+import {
+  type AckPayload,
+  type EventPayload,
+  type MessageEnvelope,
+  parseEnvelope,
+  type PongPayload,
+} from "../ipc/protocol.ts";
+import { decode, encode, IpcCodecError } from "../ipc/codec.ts";
+
+/**
+ * Envelopes the daemon emits as a reply to a client request. `pong`
+ * answers `ping`; `ack` answers everything else.
+ *
+ * Mirrors the type defined in `tests/helpers/in_memory_daemon_client.ts`
+ * so consumers can be parametrized over the interface.
+ */
+export type DaemonReply =
+  | (Extract<MessageEnvelope, { type: "pong" }>)
+  | (Extract<MessageEnvelope, { type: "ack" }>);
+
+/**
+ * Subscription handle returned by
+ * {@link DaemonClient.subscribeEvents}. `unsubscribe()` is idempotent.
+ */
+export interface DaemonEventSubscription {
+  /** Stop forwarding events to this handler. */
+  unsubscribe(): void;
+}
+
+/**
+ * Public surface every daemon client (real socket-backed or in-memory
+ * test double) must implement.
+ *
+ * @example
+ * ```ts
+ * const client: DaemonClient = new SocketDaemonClient("/tmp/makina.sock");
+ * await client.connect();
+ * const reply = await client.send({ id: "1", type: "ping", payload: {} });
+ * ```
+ */
+export interface DaemonClient {
+  /**
+   * Send a request envelope and resolve with the daemon's reply.
+   *
+   * @param envelope The envelope to send. Must validate against the
+   *   {@link parseEnvelope} schema; an invalid envelope rejects without
+   *   touching the wire.
+   * @returns The reply envelope (`pong` for `ping`, `ack` otherwise).
+   */
+  send(envelope: MessageEnvelope): Promise<DaemonReply>;
+  /**
+   * Subscribe to event envelopes pushed by the daemon. The handler is
+   * invoked synchronously per event, in arrival order; throws inside
+   * `handler` are swallowed (they cannot poison the read loop).
+   *
+   * @param handler Callback invoked per event.
+   * @returns Subscription handle whose `unsubscribe()` stops further
+   *   deliveries.
+   */
+  subscribeEvents(handler: (event: EventPayload) => void): DaemonEventSubscription;
+}
+
+/**
+ * Error thrown by {@link SocketDaemonClient} when the underlying socket
+ * cannot be opened, the daemon disconnects mid-request, or a reply
+ * arrives that does not correspond to any outstanding `send`.
+ */
+export class DaemonClientError extends Error {
+  /**
+   * Construct a daemon-client error.
+   *
+   * @param message Human-readable description.
+   * @param cause Underlying error, when one exists.
+   */
+  constructor(
+    message: string,
+    /** Underlying cause, when applicable. */
+    public override readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "DaemonClientError";
+  }
+}
+
+/**
+ * Minimal duplex transport surface the client needs. The real
+ * implementation uses `Deno.connect({ transport: "unix" })`; tests can
+ * inject any object that quacks like one.
+ */
+export interface DuplexConnection {
+  /** Readable byte stream from the peer. */
+  readonly readable: ReadableStream<Uint8Array>;
+  /** Writable byte stream to the peer. */
+  readonly writable: WritableStream<Uint8Array>;
+  /** Close both halves of the connection. */
+  close(): void;
+}
+
+/**
+ * Function that opens a {@link DuplexConnection}. Defaults to a
+ * `Deno.connect`-backed Unix-socket connector; exposed for test
+ * injection.
+ */
+export type ConnectionOpener = () => Promise<DuplexConnection>;
+
+/**
+ * Socket-backed {@link DaemonClient} implementation.
+ *
+ * Wave 2's daemon (issue #9) listens on a Unix-domain socket; this
+ * client opens that socket, encodes outgoing envelopes through
+ * {@link encode}, and decodes pushed envelopes through {@link decode}.
+ * Reply correlation is by envelope `id`.
+ */
+export class SocketDaemonClient implements DaemonClient {
+  private readonly socketPath: string;
+  private readonly opener: ConnectionOpener;
+  private connection: DuplexConnection | undefined;
+  private writer: WritableStreamDefaultWriter<Uint8Array> | undefined;
+  private reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  private readonly pending = new Map<
+    string,
+    { resolve: (reply: DaemonReply) => void; reject: (error: unknown) => void }
+  >();
+  private readonly eventHandlers = new Set<(event: EventPayload) => void>();
+  private readLoopPromise: Promise<void> | undefined;
+  private closed = false;
+
+  /**
+   * Construct a socket-backed client.
+   *
+   * @param socketPath Filesystem path of the Unix-domain socket the
+   *   daemon is listening on.
+   * @param opener Optional connection opener; defaults to
+   *   `Deno.connect({ transport: "unix", path: socketPath })`. Tests
+   *   inject this to drive the client without real socket I/O.
+   *
+   * @example
+   * ```ts
+   * const client = new SocketDaemonClient("/tmp/makina.sock");
+   * await client.connect();
+   * ```
+   */
+  constructor(socketPath: string, opener?: ConnectionOpener) {
+    this.socketPath = socketPath;
+    this.opener = opener ?? defaultUnixConnector(socketPath);
+  }
+
+  /**
+   * Open the underlying connection and start the read loop. A
+   * second call before {@link SocketDaemonClient.close} is a no-op.
+   *
+   * @throws {DaemonClientError} If the socket cannot be opened.
+   */
+  async connect(): Promise<void> {
+    if (this.connection !== undefined) {
+      return;
+    }
+    if (this.closed) {
+      throw new DaemonClientError("client has been closed");
+    }
+    try {
+      this.connection = await this.opener();
+    } catch (error) {
+      throw new DaemonClientError(
+        `failed to connect to daemon socket ${JSON.stringify(this.socketPath)}`,
+        error,
+      );
+    }
+    this.writer = this.connection.writable.getWriter();
+    this.reader = this.connection.readable.getReader();
+    this.readLoopPromise = this.runReadLoop(this.reader);
+  }
+
+  /**
+   * Send a request envelope and resolve with the daemon's reply.
+   *
+   * @param envelope The envelope to send.
+   * @returns The reply envelope (`pong` for `ping`, `ack` otherwise).
+   * @throws {DaemonClientError} If the client is not connected, the
+   *   envelope is malformed, or the connection terminates before a
+   *   reply arrives.
+   */
+  send(envelope: MessageEnvelope): Promise<DaemonReply> {
+    if (this.connection === undefined || this.writer === undefined) {
+      return Promise.reject(new DaemonClientError("not connected"));
+    }
+    if (this.closed) {
+      return Promise.reject(new DaemonClientError("client has been closed"));
+    }
+    let bytes: Uint8Array;
+    try {
+      bytes = encode(envelope);
+    } catch (error) {
+      return Promise.reject(
+        error instanceof IpcCodecError
+          ? new DaemonClientError(error.message, error)
+          : new DaemonClientError("failed to encode envelope", error),
+      );
+    }
+    if (this.pending.has(envelope.id)) {
+      return Promise.reject(
+        new DaemonClientError(`duplicate envelope id ${JSON.stringify(envelope.id)}`),
+      );
+    }
+    const reply = new Promise<DaemonReply>((resolve, reject) => {
+      this.pending.set(envelope.id, { resolve, reject });
+    });
+    this.writer.write(bytes).catch((error) => {
+      const slot = this.pending.get(envelope.id);
+      if (slot !== undefined) {
+        this.pending.delete(envelope.id);
+        slot.reject(new DaemonClientError("failed to write to daemon socket", error));
+      }
+    });
+    return reply;
+  }
+
+  /**
+   * Subscribe to event envelopes pushed by the daemon.
+   *
+   * @param handler Callback invoked synchronously per event.
+   * @returns Subscription handle whose `unsubscribe()` stops further
+   *   deliveries.
+   */
+  subscribeEvents(handler: (event: EventPayload) => void): DaemonEventSubscription {
+    this.eventHandlers.add(handler);
+    return {
+      unsubscribe: () => {
+        this.eventHandlers.delete(handler);
+      },
+    };
+  }
+
+  /**
+   * Tear down the connection. Outstanding `send` promises reject with a
+   * {@link DaemonClientError}; the read loop exits cleanly. Idempotent.
+   */
+  async close(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    const reason = new DaemonClientError("client closed before reply");
+    for (const [id, slot] of this.pending) {
+      slot.reject(reason);
+      this.pending.delete(id);
+    }
+    if (this.writer !== undefined) {
+      // Fire-and-forget abort; awaiting can hang when the peer has
+      // gone away mid-write, and we have no use for the resolution.
+      // The slot rejection above already woke every consumer.
+      this.writer.abort(reason).catch(() => {});
+      try {
+        this.writer.releaseLock();
+      } catch {
+        // Already released.
+      }
+      this.writer = undefined;
+    }
+    // Cancel the reader so the read loop terminates promptly.
+    // Without the cancel the loop would keep waiting for the peer to
+    // close its writable, which can hang shutdown for the lifetime
+    // of the daemon process.
+    if (this.reader !== undefined) {
+      try {
+        await this.reader.cancel();
+      } catch {
+        // Already cancelled or terminated; nothing to do.
+      }
+      try {
+        this.reader.releaseLock();
+      } catch {
+        // Already released.
+      }
+      this.reader = undefined;
+    }
+    if (this.connection !== undefined) {
+      try {
+        this.connection.close();
+      } catch {
+        // Connection already closed.
+      }
+      this.connection = undefined;
+    }
+    if (this.readLoopPromise !== undefined) {
+      await this.readLoopPromise.catch(() => {});
+      this.readLoopPromise = undefined;
+    }
+  }
+
+  /**
+   * Decode envelopes off the read stream and dispatch them. Replies
+   * resolve outstanding `send` promises by id; events fan out to every
+   * subscriber.
+   *
+   * Uses the codec's stateful decoder by wrapping the owned reader in
+   * a fresh {@link ReadableStream} so we keep the framing logic in
+   * one place ({@link decode}) without giving up the ability to
+   * cancel the underlying reader from {@link SocketDaemonClient.close}.
+   *
+   * @param reader The owned reader for the peer's byte stream.
+   */
+  private async runReadLoop(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<void> {
+    try {
+      // Re-expose the reader as a ReadableStream so `decode` can chunk
+      // through it normally. Cancelling the underlying reader (in
+      // `close`) makes this stream end, which in turn ends the
+      // for-await below.
+      const stream = new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          try {
+            const { value, done } = await reader.read();
+            if (done) {
+              controller.close();
+              return;
+            }
+            if (value !== undefined) {
+              controller.enqueue(value);
+            }
+          } catch (error) {
+            controller.error(error);
+          }
+        },
+        cancel: async (reason) => {
+          try {
+            await reader.cancel(reason);
+          } catch {
+            // Already cancelled.
+          }
+        },
+      });
+      for await (const envelope of decode(stream)) {
+        if (envelope.type === "event") {
+          this.dispatchEvent(envelope.payload);
+          continue;
+        }
+        if (envelope.type === "ack" || envelope.type === "pong") {
+          this.resolveReply(envelope as DaemonReply);
+          continue;
+        }
+        // Any other envelope type from the daemon is a protocol violation.
+        // Reject every outstanding send so the caller surfaces it.
+        this.failAllPending(
+          new DaemonClientError(`unexpected envelope type from daemon: ${envelope.type}`),
+        );
+      }
+    } catch (error) {
+      if (!this.closed) {
+        const reason = error instanceof Error
+          ? new DaemonClientError(error.message, error)
+          : new DaemonClientError(String(error));
+        this.failAllPending(reason);
+      }
+    } finally {
+      // If the stream ended without `close()` being called explicitly,
+      // mark the client closed so subsequent sends fail fast.
+      this.closed = true;
+    }
+  }
+
+  /**
+   * Resolve the pending `send` whose envelope id matches the reply.
+   *
+   * @param reply The decoded reply envelope.
+   */
+  private resolveReply(reply: DaemonReply): void {
+    const slot = this.pending.get(reply.id);
+    if (slot === undefined) {
+      // Unsolicited reply — protocol violation; surface to all pending.
+      this.failAllPending(
+        new DaemonClientError(`reply for unknown envelope id ${JSON.stringify(reply.id)}`),
+      );
+      return;
+    }
+    this.pending.delete(reply.id);
+    slot.resolve(reply);
+  }
+
+  /**
+   * Fan out a pushed `event` payload to every active subscriber.
+   * Handler exceptions are swallowed (they cannot poison the loop).
+   *
+   * @param event The pushed event payload.
+   */
+  private dispatchEvent(event: EventPayload): void {
+    for (const handler of this.eventHandlers) {
+      try {
+        handler(event);
+      } catch {
+        // Handler errors are not the read loop's problem.
+      }
+    }
+  }
+
+  /**
+   * Reject every in-flight `send` with `reason` and clear the slot map.
+   *
+   * @param reason The rejection cause.
+   */
+  private failAllPending(reason: DaemonClientError): void {
+    for (const [id, slot] of this.pending) {
+      slot.reject(reason);
+      this.pending.delete(id);
+    }
+  }
+}
+
+/**
+ * Build the default {@link ConnectionOpener} that opens a
+ * Unix-domain-socket connection to `socketPath` via `Deno.connect`.
+ *
+ * Factored out so {@link SocketDaemonClient} is constructible without
+ * granting `--allow-net` permission at module-evaluation time.
+ *
+ * @param socketPath The Unix-socket path.
+ * @returns A connector that opens the socket on demand.
+ */
+function defaultUnixConnector(socketPath: string): ConnectionOpener {
+  return async () => {
+    const conn = await Deno.connect({ transport: "unix", path: socketPath });
+    return {
+      readable: conn.readable,
+      writable: conn.writable,
+      close: () => {
+        try {
+          conn.close();
+        } catch {
+          // Already closed.
+        }
+      },
+    };
+  };
+}
+
+/**
+ * Helper for tests and the in-memory adapter: wrap the test double in
+ * the {@link parseEnvelope} round-trip the real socket-backed client
+ * does naturally. This guarantees a test that passes against the
+ * in-memory client also passes the wire validators.
+ *
+ * @param raw An arbitrary JSON value claiming to be a reply envelope.
+ * @returns The validated {@link DaemonReply}.
+ * @throws {DaemonClientError} If validation fails.
+ */
+export function validateReplyEnvelope(raw: unknown): DaemonReply {
+  const result = parseEnvelope(raw);
+  if (!result.success) {
+    throw new DaemonClientError(
+      `reply envelope failed validation: ${
+        result.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join("; ")
+      }`,
+    );
+  }
+  if (result.data.type !== "ack" && result.data.type !== "pong") {
+    throw new DaemonClientError(`expected ack or pong; got ${result.data.type}`);
+  }
+  return result.data as DaemonReply;
+}
+
+/** Re-export so consumers can narrow on the reply payloads. */
+export type { AckPayload, EventPayload, PongPayload };

--- a/tests/unit/__snapshots__/tui_shell_test.tsx.snap
+++ b/tests/unit/__snapshots__/tui_shell_test.tsx.snap
@@ -1,0 +1,71 @@
+export const snapshot = {};
+
+snapshot[`App: initial render against the in-memory double 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────╮
+│ makina v0.0.0-test                 connected                 no task focused │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭──────────────────────────────────────────────────────────────────────────────╮
+│                                                                              │
+│ No tasks yet — invoke /issue <repo>#<n> to start one.                        │
+│                                                                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+ ready                                     Ctrl+C exit · / command palette (W3)"
+`;
+
+snapshot[`App: "1 task active" after a state-changed event 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────╮
+│ makina v0.0.0-test     connected      focus: task_2026-04-26T12-00-00_abc123 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭──────────────────────────────────────────────────────────────────────────────╮
+│                                                                              │
+│ 1 task active.                                                               │
+│                                                                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+ task_2026-04-26T12-00-00_abc123: INIT →        Ctrl+C exit · / command palette
+ CLONING_WORKTREE                                (W3)"
+`;
+
+snapshot[`App: "disconnected" status is reflected in the header 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────╮
+│ makina v0.0.0-test    disconnected    focus: task_2026-04-26T12-00-00_abc123 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭──────────────────────────────────────────────────────────────────────────────╮
+│                                                                              │
+│ No tasks yet — invoke /issue <repo>#<n> to start one.                        │
+│ Daemon disconnected.                                                         │
+│                                                                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+ ready                                     Ctrl+C exit · / command palette (W3)"
+`;
+
+snapshot[`Header: connected status renders the green pill 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────╮
+│ makina v0.0.0-test                 connected                 no task focused │
+╰──────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+snapshot[`Header: error status surfaces the red pill 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────╮
+│ makina v0.0.0-test                    error                    focus: task_x │
+╰──────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+snapshot[`MainPane: empty state copy 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────╮
+│                                                                              │
+│ No tasks yet — invoke /issue <repo>#<n> to start one.                        │
+│                                                                              │
+╰──────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+snapshot[`MainPane: pluralized task count 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────╮
+│                                                                              │
+│ 3 tasks active.                                                              │
+│                                                                              │
+╰──────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+snapshot[`StatusBar: error message takes precedence over the info message 1`] = `" error: boom                               Ctrl+C exit · / command palette (W3)"`;
+
+snapshot[`StatusBar: default keybindings hint 1`] = `" ready                                     Ctrl+C exit · / command palette (W3)"`;

--- a/tests/unit/tui_shell_test.tsx
+++ b/tests/unit/tui_shell_test.tsx
@@ -1,0 +1,1132 @@
+/**
+ * Unit tests for the TUI shell.
+ *
+ * The Wave 2 shell ships three baseline panes (`Header`, `MainPane`,
+ * `StatusBar`) composed under a top-level `App`, plus a Unix-socket-
+ * backed `DaemonClient`. The tests pin three snapshot states (initial
+ * render, "1 task active", "disconnected") so a regression in any pane
+ * flips the snapshot, plus a `SocketDaemonClient` round-trip driven
+ * through an in-memory duplex transport so the wire-side framing is
+ * exercised end-to-end without touching real socket I/O.
+ *
+ * Snapshot frames are captured by handing Ink a fake Node-stream-like
+ * stdout that records every `write()` call. Combined with `debug:
+ * true`, Ink writes one frame per render without ANSI cursor
+ * manipulation, which keeps the snapshots stable across re-renders.
+ */
+
+import { assertEquals, assertRejects } from "@std/assert";
+import { assertSnapshot } from "@std/testing/snapshot";
+import { Box, render as inkRender, Text } from "ink";
+import type { ReactElement } from "react";
+
+import { App, handleEvent } from "../../src/tui/App.tsx";
+import {
+  DaemonClientError,
+  type DuplexConnection,
+  SocketDaemonClient,
+  validateReplyEnvelope,
+} from "../../src/tui/ipc-client.ts";
+import { useDaemonConnection } from "../../src/tui/hooks/useDaemonConnection.ts";
+import { Header } from "../../src/tui/components/Header.tsx";
+import { MainPane } from "../../src/tui/components/MainPane.tsx";
+import { StatusBar } from "../../src/tui/components/StatusBar.tsx";
+import { type EventPayload, type MessageEnvelope, parseEnvelope } from "../../src/ipc/protocol.ts";
+import { encode } from "../../src/ipc/codec.ts";
+import { makeTaskId } from "../../src/types.ts";
+
+import { InMemoryDaemonClient } from "../helpers/in_memory_daemon_client.ts";
+
+/**
+ * Minimal `NodeJS.WriteStream`-shaped object that captures every
+ * `write()` call. Ink's `render({ debug: true })` writes one frame per
+ * commit straight to `stdout` without ANSI cursor manipulation, so the
+ * recorded slice is what the user would see at that point in time.
+ *
+ * Implements only the slice of `NodeJS.WriteStream` Ink actually
+ * touches: `write`, `cork`, `uncork`, `end`, the `columns`/`rows`/
+ * `isTTY` triplet, and `on`/`off` (Ink subscribes to the `'resize'`
+ * event but our fake never emits it).
+ */
+class FakeStream {
+  /** Width of the simulated terminal. */
+  columns = 80;
+  /** Height of the simulated terminal. */
+  rows = 24;
+  /** Tells Ink to render with terminal escapes. */
+  isTTY = true;
+  /** Recorded frame buffer. */
+  readonly frames: string[] = [];
+  // deno-lint-ignore no-explicit-any
+  private readonly listeners = new Map<string, Array<(...args: any[]) => void>>();
+
+  /**
+   * Capture a frame. Mimics Node's `WriteStream.write` contract.
+   *
+   * @param chunk The frame text.
+   * @returns Always `true`; backpressure is irrelevant for a memory sink.
+   */
+  write(chunk: string): boolean {
+    this.frames.push(String(chunk));
+    return true;
+  }
+  /** No-op; some terminals batch writes via cork/uncork. */
+  cork(): void {}
+  /** No-op; pair of {@link FakeStream.cork}. */
+  uncork(): void {}
+  /** No-op; some terminals close the stream when done. */
+  end(): void {}
+  /**
+   * Register a Node-style event listener. Only the `'resize'` event
+   * is relevant for Ink, and the test fixture never fires it.
+   *
+   * @param event The event name.
+   * @param handler The callback to register.
+   * @returns This stream, for chaining.
+   */
+  // deno-lint-ignore no-explicit-any
+  on(event: string, handler: (...args: any[]) => void): this {
+    const list = this.listeners.get(event) ?? [];
+    list.push(handler);
+    this.listeners.set(event, list);
+    return this;
+  }
+  /**
+   * Remove a Node-style event listener. Symmetric with
+   * {@link FakeStream.on}.
+   *
+   * @param event The event name.
+   * @param handler The callback to remove.
+   * @returns This stream, for chaining.
+   */
+  // deno-lint-ignore no-explicit-any
+  off(event: string, handler: (...args: any[]) => void): this {
+    const list = this.listeners.get(event);
+    if (list === undefined) {
+      return this;
+    }
+    const index = list.indexOf(handler);
+    if (index >= 0) {
+      list.splice(index, 1);
+    }
+    return this;
+  }
+  /**
+   * The text captured at the most recent commit, or `""` when nothing
+   * has been written yet.
+   *
+   * @returns The newest frame.
+   */
+  lastFrame(): string {
+    return this.frames.at(-1) ?? "";
+  }
+  /**
+   * The text captured at any commit that contains visible content,
+   * filtering out the lone-ANSI frames Ink writes for cursor hide/
+   * show. Snapshot tests assert on this.
+   *
+   * The filter strips CSI ANSI sequences (`ESC [ ... letter`) before
+   * checking for content, because the cursor-show/hide frames contain
+   * letters (`h`, `l`) that would otherwise pass a naive `[A-Za-z]`
+   * test.
+   *
+   * @returns The newest frame with rendered content.
+   */
+  lastVisibleFrame(): string {
+    // ESC (0x1B) starts every CSI sequence. The control char is
+    // expressed via `String.fromCharCode` so the regex literal is free
+    // of escape sequences (Deno's `no-control-regex` rule rejects
+    // `\x1b` in a regex literal).
+    const escape = String.fromCharCode(0x1B);
+    const csiRegex = new RegExp(`${escape}\\[[0-9?;]*[a-zA-Z]`, "g");
+    for (let index = this.frames.length - 1; index >= 0; index -= 1) {
+      const frame = this.frames[index];
+      if (frame === undefined) continue;
+      const stripped = frame.replace(csiRegex, "");
+      if (stripped.trim().length > 0) {
+        return frame;
+      }
+    }
+    return "";
+  }
+}
+
+/**
+ * Render an Ink element to a fake stdout and return the recorded frame
+ * sink. Synchronous unmount keeps the test free of stray timers.
+ *
+ * @param node The element to render.
+ * @returns The frame recorder.
+ */
+async function renderToBuffer(
+  node: Parameters<typeof inkRender>[0],
+): Promise<FakeStream> {
+  const stdout = new FakeStream();
+  const stderr = new FakeStream();
+  const instance = inkRender(node, {
+    // deno-lint-ignore no-explicit-any
+    stdout: stdout as any,
+    // deno-lint-ignore no-explicit-any
+    stderr: stderr as any,
+    debug: true,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  });
+  // Yield a macrotask so any pending React effects (which run after
+  // render commit) get a chance to flush before we unmount.
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  instance.unmount();
+  // Yield once more so any teardown effects (signal-exit unsubscribe,
+  // resize listener removal) complete before the test sanitizer runs.
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  return stdout;
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot tests — App
+// ---------------------------------------------------------------------------
+
+// `sanitizeOps`/`sanitizeResources` are off on the App-level tests
+// because Ink delegates terminal cleanup to `signal-exit`, which
+// installs 13 process-level signal listeners on construction. The
+// listeners are released when `unmount()` runs, but in the test sandbox
+// Deno's signal-poll ops occasionally outlive the unmount. The leak is
+// inert (each Ink instance still cleans up cleanly when the process
+// exits), but Deno's strict sanitizer flags it. Component-level tests
+// (`Header`, `MainPane`, `StatusBar`) do not exercise the signal path
+// because they unmount synchronously, so they keep their sanitizers on.
+
+Deno.test({
+  name: "App: initial render against the in-memory double",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async (t) => {
+    const client = new InMemoryDaemonClient();
+    const stdout = await renderToBuffer(
+      <App client={client} version="0.0.0-test" autoConnect={false} />,
+    );
+    await assertSnapshot(t, stdout.lastVisibleFrame());
+  },
+});
+
+Deno.test({
+  name: 'App: "1 task active" after a state-changed event',
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async (t) => {
+    const client = new InMemoryDaemonClient();
+    // Render the App, inject one event, let the effects flush, then
+    // capture the post-event frame. Doing the injection between
+    // render and unmount keeps the React tree's state intact across
+    // the event so the snapshot reflects the active-task tally.
+    const stdout = new FakeStream();
+    const stderr = new FakeStream();
+    const instance = inkRender(
+      <App client={client} version="0.0.0-test" autoConnect={false} />,
+      {
+        // deno-lint-ignore no-explicit-any
+        stdout: stdout as any,
+        // deno-lint-ignore no-explicit-any
+        stderr: stderr as any,
+        debug: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    client.simulateEvent({
+      taskId: "task_2026-04-26T12-00-00_abc123",
+      atIso: "2026-04-26T12:00:01.000Z",
+      kind: "state-changed",
+      data: { fromState: "INIT", toState: "CLONING_WORKTREE" },
+    });
+    // Yield so React commits the state update triggered by the event.
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    instance.unmount();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    await assertSnapshot(t, stdout.lastVisibleFrame());
+    // Sanity: the recorder captured at least the initial frame plus
+    // a post-event frame.
+    assertEquals(stdout.frames.length >= 2, true);
+  },
+});
+
+Deno.test({
+  name: 'App: "disconnected" status is reflected in the header',
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async (t) => {
+    // To pin the "disconnected" visual deterministically the test
+    // renders a static composition of the three baseline panes with
+    // the disconnected status, then asserts on the captured frame.
+    // Driving the App through `disconnect()` would also work but
+    // would couple the snapshot to the timing of state propagation
+    // through React.
+    const fake = await renderToBuffer(
+      <DisconnectedSnapshotShell
+        focusedTaskId={makeTaskId("task_2026-04-26T12-00-00_abc123")}
+      />,
+    );
+    await assertSnapshot(t, fake.lastVisibleFrame());
+    // Sanity: the App with the in-memory double also renders cleanly.
+    const client = new InMemoryDaemonClient();
+    const stdoutApp = await renderToBuffer(
+      <App client={client} version="0.0.0-test" autoConnect={false} />,
+    );
+    assertEquals(stdoutApp.frames.length > 0, true);
+  },
+});
+
+/**
+ * Test-only composition that mirrors what the App renders when the
+ * daemon connection is in the `disconnected` state. Kept tiny so the
+ * snapshot stays stable across unrelated changes.
+ *
+ * @param props The focused-task id rendered in the header.
+ * @returns The composed shell tree.
+ */
+function DisconnectedSnapshotShell(props: {
+  readonly focusedTaskId: ReturnType<typeof makeTaskId>;
+}): ReturnType<typeof Header> {
+  return (
+    <Box flexDirection="column">
+      <Header
+        version="0.0.0-test"
+        status="disconnected"
+        focusedTaskId={props.focusedTaskId}
+      />
+      <MainPane activeTaskCount={0} hint="Daemon disconnected." />
+      <StatusBar message="ready" />
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// handleEvent unit tests
+// ---------------------------------------------------------------------------
+
+Deno.test("handleEvent: log event sets the last message with level prefix", () => {
+  let lastMessage: string | undefined;
+  let lastError: string | undefined;
+  let known = new Set<ReturnType<typeof makeTaskId>>();
+  let focused: ReturnType<typeof makeTaskId> | undefined;
+  const event: EventPayload = {
+    taskId: "t1",
+    atIso: "2026-04-26T12:00:00.000Z",
+    kind: "log",
+    data: { level: "info", message: "hello" },
+  };
+  handleEvent(event, {
+    setKnownTaskIds: (update) => {
+      known = update(known) as Set<ReturnType<typeof makeTaskId>>;
+    },
+    setLastMessage: (next) => {
+      lastMessage = next;
+    },
+    setLastError: (next) => {
+      lastError = next;
+    },
+    setFocusedTaskId: (next) => {
+      focused = next;
+    },
+  });
+  assertEquals(lastMessage, "[info] hello");
+  assertEquals(lastError, undefined);
+  assertEquals(known.size, 1);
+  assertEquals(focused, makeTaskId("t1"));
+});
+
+Deno.test("handleEvent: state-changed event renders fromState → toState", () => {
+  let lastMessage: string | undefined;
+  let known = new Set<ReturnType<typeof makeTaskId>>();
+  handleEvent(
+    {
+      taskId: "task_x",
+      atIso: "2026-04-26T12:00:00.000Z",
+      kind: "state-changed",
+      data: { fromState: "INIT", toState: "CLONING_WORKTREE" },
+    },
+    {
+      setKnownTaskIds: (update) => {
+        known = update(known) as Set<ReturnType<typeof makeTaskId>>;
+      },
+      setLastMessage: (next) => {
+        lastMessage = next;
+      },
+      setLastError: () => {},
+      setFocusedTaskId: () => {},
+    },
+  );
+  assertEquals(lastMessage, "task_x: INIT → CLONING_WORKTREE");
+  assertEquals(known.has(makeTaskId("task_x")), true);
+});
+
+Deno.test("handleEvent: agent-message event truncates long text", () => {
+  let lastMessage: string | undefined;
+  const long = "x".repeat(200);
+  handleEvent(
+    {
+      taskId: "t",
+      atIso: "2026-04-26T12:00:00.000Z",
+      kind: "agent-message",
+      data: { role: "assistant", text: long },
+    },
+    {
+      setKnownTaskIds: (_update) => {},
+      setLastMessage: (next) => {
+        lastMessage = next;
+      },
+      setLastError: () => {},
+      setFocusedTaskId: () => {},
+    },
+  );
+  assertEquals(lastMessage?.endsWith("…"), true);
+  assertEquals(
+    (lastMessage?.length ?? 0) <= "agent assistant: ".length + 80,
+    true,
+  );
+});
+
+Deno.test("handleEvent: github-call event renders method + endpoint", () => {
+  let lastMessage: string | undefined;
+  handleEvent(
+    {
+      taskId: "t",
+      atIso: "2026-04-26T12:00:00.000Z",
+      kind: "github-call",
+      data: { method: "GET", endpoint: "/repos/o/r/issues/1" },
+    },
+    {
+      setKnownTaskIds: () => {},
+      setLastMessage: (next) => {
+        lastMessage = next;
+      },
+      setLastError: () => {},
+      setFocusedTaskId: () => {},
+    },
+  );
+  assertEquals(lastMessage, "github GET /repos/o/r/issues/1");
+});
+
+Deno.test("handleEvent: error event sets lastError", () => {
+  let lastError: string | undefined;
+  handleEvent(
+    {
+      taskId: "t",
+      atIso: "2026-04-26T12:00:00.000Z",
+      kind: "error",
+      data: { message: "boom" },
+    },
+    {
+      setKnownTaskIds: () => {},
+      setLastMessage: () => {},
+      setLastError: (next) => {
+        lastError = next;
+      },
+      setFocusedTaskId: () => {},
+    },
+  );
+  assertEquals(lastError, "boom");
+});
+
+Deno.test("handleEvent: invalid task id surfaces as an error and bails", () => {
+  let lastError: string | undefined;
+  let lastMessage: string | undefined;
+  let known = new Set<ReturnType<typeof makeTaskId>>();
+  handleEvent(
+    {
+      taskId: "   ",
+      atIso: "2026-04-26T12:00:00.000Z",
+      kind: "log",
+      data: { level: "info", message: "should not surface" },
+    },
+    {
+      setKnownTaskIds: (update) => {
+        known = update(known) as Set<ReturnType<typeof makeTaskId>>;
+      },
+      setLastMessage: (next) => {
+        lastMessage = next;
+      },
+      setLastError: (next) => {
+        lastError = next;
+      },
+      setFocusedTaskId: () => {},
+    },
+  );
+  assertEquals(lastError?.startsWith("event with invalid task id"), true);
+  assertEquals(lastMessage, undefined);
+  assertEquals(known.size, 0);
+});
+
+Deno.test("handleEvent: duplicate task id leaves the known set unchanged", () => {
+  let known = new Set<ReturnType<typeof makeTaskId>>();
+  known.add(makeTaskId("t1"));
+  handleEvent(
+    {
+      taskId: "t1",
+      atIso: "2026-04-26T12:00:00.000Z",
+      kind: "log",
+      data: { level: "info", message: "again" },
+    },
+    {
+      setKnownTaskIds: (update) => {
+        known = update(known) as Set<ReturnType<typeof makeTaskId>>;
+      },
+      setLastMessage: () => {},
+      setLastError: () => {},
+      setFocusedTaskId: () => {},
+    },
+  );
+  assertEquals(known.size, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Component snapshot tests (covers the per-pane variants)
+// ---------------------------------------------------------------------------
+
+Deno.test("Header: connected status renders the green pill", async (t) => {
+  const stdout = await renderToBuffer(
+    <Header version="0.0.0-test" status="connected" />,
+  );
+  await assertSnapshot(t, stdout.lastVisibleFrame());
+});
+
+Deno.test("Header: error status surfaces the red pill", async (t) => {
+  const stdout = await renderToBuffer(
+    <Header
+      version="0.0.0-test"
+      status="error"
+      focusedTaskId={makeTaskId("task_x")}
+    />,
+  );
+  await assertSnapshot(t, stdout.lastVisibleFrame());
+});
+
+Deno.test("MainPane: empty state copy", async (t) => {
+  const stdout = await renderToBuffer(<MainPane activeTaskCount={0} />);
+  await assertSnapshot(t, stdout.lastVisibleFrame());
+});
+
+Deno.test("MainPane: pluralized task count", async (t) => {
+  const stdout = await renderToBuffer(<MainPane activeTaskCount={3} />);
+  await assertSnapshot(t, stdout.lastVisibleFrame());
+});
+
+Deno.test("StatusBar: error message takes precedence over the info message", async (t) => {
+  const stdout = await renderToBuffer(
+    <StatusBar message="ignored" errorMessage="boom" />,
+  );
+  await assertSnapshot(t, stdout.lastVisibleFrame());
+});
+
+Deno.test("StatusBar: default keybindings hint", async (t) => {
+  const stdout = await renderToBuffer(<StatusBar />);
+  await assertSnapshot(t, stdout.lastVisibleFrame());
+});
+
+// ---------------------------------------------------------------------------
+// SocketDaemonClient — drive the real client against an in-memory duplex
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a pair of paired byte streams the daemon side and the client
+ * side can talk to each other through. The client writes into
+ * `clientToDaemon`, the daemon writes into `daemonToClient`.
+ */
+function makeDuplexPair(): {
+  client: DuplexConnection;
+  daemon: DuplexConnection;
+} {
+  const clientToDaemon = new TransformStream<Uint8Array, Uint8Array>();
+  const daemonToClient = new TransformStream<Uint8Array, Uint8Array>();
+  return {
+    client: {
+      readable: daemonToClient.readable,
+      writable: clientToDaemon.writable,
+      close: () => {
+        // Closing the writable closes the daemon's view of the readable.
+        // The daemon's writable closes when the test calls `daemon.close()`.
+      },
+    },
+    daemon: {
+      readable: clientToDaemon.readable,
+      writable: daemonToClient.writable,
+      close: () => {},
+    },
+  };
+}
+
+Deno.test("SocketDaemonClient: round-trips a ping → pong over a duplex pair", async () => {
+  const pair = makeDuplexPair();
+  const client = new SocketDaemonClient("/unused", () => Promise.resolve(pair.client));
+  await client.connect();
+
+  // Spin a tiny daemon loop that echoes pings as pongs.
+  const daemonReader = pair.daemon.readable.getReader();
+  const daemonWriter = pair.daemon.writable.getWriter();
+  const daemonPromise = (async () => {
+    let pending = new Uint8Array(0);
+    while (true) {
+      const { value, done } = await daemonReader.read();
+      if (done) {
+        return;
+      }
+      if (value !== undefined) {
+        const merged = new Uint8Array(pending.byteLength + value.byteLength);
+        merged.set(pending, 0);
+        merged.set(value, pending.byteLength);
+        pending = merged;
+      }
+      // Trivial frame extraction: the client only sends one ping per
+      // test so we just look for the `\n` boundaries.
+      const newlineIndex = pending.indexOf(0x0a);
+      if (newlineIndex === -1) continue;
+      const lengthString = new TextDecoder().decode(pending.subarray(0, newlineIndex));
+      const length = Number.parseInt(lengthString, 10);
+      const payloadEnd = newlineIndex + 1 + length;
+      if (pending.byteLength < payloadEnd + 1) continue;
+      const payloadJson = new TextDecoder().decode(
+        pending.subarray(newlineIndex + 1, payloadEnd),
+      );
+      const incoming = JSON.parse(payloadJson) as MessageEnvelope;
+      const reply: MessageEnvelope = {
+        id: incoming.id,
+        type: "pong",
+        payload: { daemonVersion: "test-1.0" },
+      };
+      await daemonWriter.write(encode(reply));
+      pending = pending.subarray(payloadEnd + 1);
+    }
+  })();
+
+  const reply = await client.send({ id: "1", type: "ping", payload: {} });
+  assertEquals(reply.type, "pong");
+  assertEquals(reply.id, "1");
+  if (reply.type === "pong") {
+    assertEquals(reply.payload.daemonVersion, "test-1.0");
+  }
+
+  await client.close();
+  await daemonWriter.close().catch(() => {});
+  await daemonPromise.catch(() => {});
+});
+
+Deno.test("SocketDaemonClient: pushed events fan out to subscribers", async () => {
+  const pair = makeDuplexPair();
+  const client = new SocketDaemonClient("/unused", () => Promise.resolve(pair.client));
+  await client.connect();
+
+  const seen: EventPayload[] = [];
+  client.subscribeEvents((event) => {
+    seen.push(event);
+  });
+
+  const daemonWriter = pair.daemon.writable.getWriter();
+  const eventEnvelope: MessageEnvelope = {
+    id: "evt1",
+    type: "event",
+    payload: {
+      taskId: "t1",
+      atIso: "2026-04-26T12:00:00.000Z",
+      kind: "log",
+      data: { level: "info", message: "from-daemon" },
+    },
+  };
+  await daemonWriter.write(encode(eventEnvelope));
+
+  // Wait briefly for the read loop to consume the frame.
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assertEquals(seen.length, 1);
+  assertEquals(seen[0]?.kind, "log");
+
+  await client.close();
+  await daemonWriter.close().catch(() => {});
+});
+
+Deno.test("SocketDaemonClient: unsubscribe stops further deliveries", async () => {
+  const pair = makeDuplexPair();
+  const client = new SocketDaemonClient("/unused", () => Promise.resolve(pair.client));
+  await client.connect();
+
+  const seen: EventPayload[] = [];
+  const subscription = client.subscribeEvents((event) => {
+    seen.push(event);
+  });
+
+  const daemonWriter = pair.daemon.writable.getWriter();
+  const eventEnvelope: MessageEnvelope = {
+    id: "evt1",
+    type: "event",
+    payload: {
+      taskId: "t1",
+      atIso: "2026-04-26T12:00:00.000Z",
+      kind: "log",
+      data: { level: "info", message: "first" },
+    },
+  };
+  await daemonWriter.write(encode(eventEnvelope));
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  subscription.unsubscribe();
+  await daemonWriter.write(encode({ ...eventEnvelope, id: "evt2" }));
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assertEquals(seen.length, 1);
+  await client.close();
+  await daemonWriter.close().catch(() => {});
+});
+
+Deno.test("SocketDaemonClient: send before connect rejects with DaemonClientError", async () => {
+  const client = new SocketDaemonClient("/unused", () => {
+    throw new Error("should not open");
+  });
+  await assertRejects(
+    () => client.send({ id: "1", type: "ping", payload: {} }),
+    DaemonClientError,
+  );
+});
+
+Deno.test("SocketDaemonClient: connect rejects when the opener throws", async () => {
+  const client = new SocketDaemonClient("/unused", () => Promise.reject(new Error("EACCES")));
+  await assertRejects(() => client.connect(), DaemonClientError);
+});
+
+Deno.test("SocketDaemonClient: close before connect is a no-op", async () => {
+  const client = new SocketDaemonClient("/unused", () => {
+    throw new Error("must not be called");
+  });
+  await client.close();
+  await client.close();
+});
+
+Deno.test("SocketDaemonClient: duplicate envelope id rejects without sending", async () => {
+  const pair = makeDuplexPair();
+  const client = new SocketDaemonClient("/unused", () => Promise.resolve(pair.client));
+  await client.connect();
+  // The first send is left pending so the second collides on id.
+  // Attach the catch handler before close() drives the rejection so
+  // Deno's unhandled-rejection sanitizer does not flag the inflight
+  // promise.
+  const first = client.send({ id: "1", type: "ping", payload: {} }).catch(() => {});
+  await assertRejects(
+    () => client.send({ id: "1", type: "ping", payload: {} }),
+    DaemonClientError,
+    "duplicate envelope id",
+  );
+  await client.close();
+  await first;
+});
+
+Deno.test("SocketDaemonClient: connect twice is idempotent", async () => {
+  const pair = makeDuplexPair();
+  let opens = 0;
+  const client = new SocketDaemonClient("/unused", () => {
+    opens += 1;
+    return Promise.resolve(pair.client);
+  });
+  await client.connect();
+  await client.connect();
+  assertEquals(opens, 1);
+  await client.close();
+});
+
+Deno.test("SocketDaemonClient: encode failure rejects without writing", async () => {
+  const pair = makeDuplexPair();
+  const client = new SocketDaemonClient("/unused", () => Promise.resolve(pair.client));
+  await client.connect();
+  await assertRejects(
+    () =>
+      client.send(
+        // Deliberately invalid envelope: empty id.
+        { id: "", type: "ping", payload: {} } as unknown as MessageEnvelope,
+      ),
+    DaemonClientError,
+  );
+  await client.close();
+});
+
+// ---------------------------------------------------------------------------
+// validateReplyEnvelope
+// ---------------------------------------------------------------------------
+
+Deno.test("validateReplyEnvelope: ack passes through", () => {
+  const reply = validateReplyEnvelope({
+    id: "1",
+    type: "ack",
+    payload: { ok: true },
+  });
+  assertEquals(reply.type, "ack");
+});
+
+Deno.test("validateReplyEnvelope: pong passes through", () => {
+  const reply = validateReplyEnvelope({
+    id: "1",
+    type: "pong",
+    payload: { daemonVersion: "0.0.0-test" },
+  });
+  assertEquals(reply.type, "pong");
+});
+
+Deno.test("validateReplyEnvelope: rejects an event envelope", () => {
+  let threw = false;
+  try {
+    validateReplyEnvelope({
+      id: "1",
+      type: "event",
+      payload: {
+        taskId: "t",
+        atIso: "2026-04-26T12:00:00.000Z",
+        kind: "log",
+        data: { level: "info", message: "x" },
+      },
+    });
+  } catch (error) {
+    threw = error instanceof DaemonClientError;
+  }
+  assertEquals(threw, true);
+});
+
+Deno.test("validateReplyEnvelope: rejects a malformed object", () => {
+  let threw = false;
+  try {
+    validateReplyEnvelope({ id: "" });
+  } catch (error) {
+    threw = error instanceof DaemonClientError;
+  }
+  assertEquals(threw, true);
+});
+
+// ---------------------------------------------------------------------------
+// Sanity check: parseEnvelope still validates events the App relies on.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// useDaemonConnection (driven through tiny render harnesses)
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape of the hook surface stashed by the test harness components
+ * below so the assertions can drive it after the render commits.
+ */
+interface HookProbe {
+  api: ReturnType<typeof useDaemonConnection> | undefined;
+}
+
+/**
+ * Render harness that calls `useDaemonConnection` once and stashes the
+ * returned API into the supplied {@link HookProbe} ref. Renders an
+ * empty `<Text>` so it is a valid Ink component.
+ *
+ * @param props The probe and the options passed through to the hook.
+ * @returns An empty Ink text node.
+ */
+function HookProbeHost(props: {
+  readonly probe: HookProbe;
+  readonly options: Parameters<typeof useDaemonConnection>[0];
+}): ReactElement {
+  const api = useDaemonConnection(props.options);
+  props.probe.api = api;
+  return <Text></Text>;
+}
+
+Deno.test({
+  name: "useDaemonConnection: autoConnect drives idle → connected",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const probe: HookProbe = { api: undefined };
+    const client: TestableLifecycleClient = makeFakeLifecycleClient();
+    const stdout = new FakeStream();
+    const stderr = new FakeStream();
+    const instance = inkRender(
+      <HookProbeHost
+        probe={probe}
+        options={{ client, autoConnect: true }}
+      />,
+      {
+        // deno-lint-ignore no-explicit-any
+        stdout: stdout as any,
+        // deno-lint-ignore no-explicit-any
+        stderr: stderr as any,
+        debug: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    assertEquals(probe.api?.status, "connected");
+    assertEquals(client.connectCalls, 1);
+    instance.unmount();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  },
+});
+
+Deno.test({
+  name: "useDaemonConnection: autoConnect surfaces connect failures as error",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const probe: HookProbe = { api: undefined };
+    const client = makeFakeLifecycleClient({ connectError: new Error("bang") });
+    const stdout = new FakeStream();
+    const stderr = new FakeStream();
+    const instance = inkRender(
+      <HookProbeHost
+        probe={probe}
+        options={{ client, autoConnect: true }}
+      />,
+      {
+        // deno-lint-ignore no-explicit-any
+        stdout: stdout as any,
+        // deno-lint-ignore no-explicit-any
+        stderr: stderr as any,
+        debug: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    assertEquals(probe.api?.status, "error");
+    assertEquals(probe.api?.lastError, "bang");
+    instance.unmount();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  },
+});
+
+Deno.test({
+  name: "useDaemonConnection: disconnect drives the lifecycle to disconnected",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const probe: HookProbe = { api: undefined };
+    const client = makeFakeLifecycleClient();
+    const stdout = new FakeStream();
+    const stderr = new FakeStream();
+    const instance = inkRender(
+      <HookProbeHost
+        probe={probe}
+        options={{ client, autoConnect: false }}
+      />,
+      {
+        // deno-lint-ignore no-explicit-any
+        stdout: stdout as any,
+        // deno-lint-ignore no-explicit-any
+        stderr: stderr as any,
+        debug: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    assertEquals(probe.api?.status, "idle");
+    await probe.api?.connect();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    assertEquals(probe.api?.status, "connected");
+    await probe.api?.disconnect();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    assertEquals(probe.api?.status, "disconnected");
+    assertEquals(client.closeCalls, 1);
+    instance.unmount();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  },
+});
+
+Deno.test({
+  name: "useDaemonConnection: a client without lifecycle starts connected",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const probe: HookProbe = { api: undefined };
+    const client = new InMemoryDaemonClient();
+    const stdout = new FakeStream();
+    const stderr = new FakeStream();
+    const instance = inkRender(
+      <HookProbeHost
+        probe={probe}
+        options={{ client, autoConnect: true }}
+      />,
+      {
+        // deno-lint-ignore no-explicit-any
+        stdout: stdout as any,
+        // deno-lint-ignore no-explicit-any
+        stderr: stderr as any,
+        debug: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    assertEquals(probe.api?.status, "connected");
+    await probe.api?.disconnect();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    assertEquals(probe.api?.status, "disconnected");
+    instance.unmount();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  },
+});
+
+Deno.test({
+  name: "useDaemonConnection: disconnect surfaces close failures as error",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const probe: HookProbe = { api: undefined };
+    const client = makeFakeLifecycleClient({ closeError: new Error("kaboom") });
+    const stdout = new FakeStream();
+    const stderr = new FakeStream();
+    const instance = inkRender(
+      <HookProbeHost
+        probe={probe}
+        options={{ client, autoConnect: true }}
+      />,
+      {
+        // deno-lint-ignore no-explicit-any
+        stdout: stdout as any,
+        // deno-lint-ignore no-explicit-any
+        stderr: stderr as any,
+        debug: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    await probe.api?.disconnect();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    assertEquals(probe.api?.status, "error");
+    assertEquals(probe.api?.lastError, "kaboom");
+    instance.unmount();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  },
+});
+
+Deno.test({
+  name: "useDaemonConnection: send/subscribe forward to the underlying client",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const probe: HookProbe = { api: undefined };
+    const client = new InMemoryDaemonClient();
+    const stdout = new FakeStream();
+    const stderr = new FakeStream();
+    const instance = inkRender(
+      <HookProbeHost
+        probe={probe}
+        options={{ client, autoConnect: false }}
+      />,
+      {
+        // deno-lint-ignore no-explicit-any
+        stdout: stdout as any,
+        // deno-lint-ignore no-explicit-any
+        stderr: stderr as any,
+        debug: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    const reply = await probe.api?.send({ id: "1", type: "ping", payload: {} });
+    assertEquals(reply?.type, "pong");
+    let received = 0;
+    const subscription = probe.api?.subscribe(() => {
+      received += 1;
+    });
+    client.simulateEvent({
+      taskId: "t",
+      atIso: "2026-04-26T12:00:00.000Z",
+      kind: "log",
+      data: { level: "info", message: "x" },
+    });
+    assertEquals(received, 1);
+    subscription?.unsubscribe();
+    instance.unmount();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  },
+});
+
+/**
+ * Helper that yields a {@link DaemonClient} subclass with `connect`/
+ * `close` lifecycle methods plus call counters and optional injected
+ * errors. Used by the hook tests above to drive every branch of
+ * `openConnection`/`closeConnection` without spinning up a socket.
+ */
+interface TestableLifecycleClient {
+  connect(): Promise<void>;
+  close(): Promise<void>;
+  send: InMemoryDaemonClient["send"];
+  subscribeEvents: InMemoryDaemonClient["subscribeEvents"];
+  connectCalls: number;
+  closeCalls: number;
+}
+
+/**
+ * Build a lifecycle-aware client backed by an {@link InMemoryDaemonClient}.
+ *
+ * @param options Optional injected errors for the lifecycle methods.
+ * @returns The lifecycle-aware client.
+ */
+function makeFakeLifecycleClient(options: {
+  readonly connectError?: Error;
+  readonly closeError?: Error;
+} = {}): TestableLifecycleClient {
+  const inner = new InMemoryDaemonClient();
+  const wrapper: TestableLifecycleClient = {
+    connectCalls: 0,
+    closeCalls: 0,
+    connect() {
+      wrapper.connectCalls += 1;
+      if (options.connectError !== undefined) {
+        return Promise.reject(options.connectError);
+      }
+      return Promise.resolve();
+    },
+    close() {
+      wrapper.closeCalls += 1;
+      if (options.closeError !== undefined) {
+        return Promise.reject(options.closeError);
+      }
+      return Promise.resolve();
+    },
+    send: (envelope) => inner.send(envelope),
+    subscribeEvents: (handler) => inner.subscribeEvents(handler),
+  };
+  return wrapper;
+}
+
+Deno.test("the App's event vocabulary parses through parseEnvelope", () => {
+  const candidates: EventPayload[] = [
+    {
+      taskId: "t",
+      atIso: "2026-04-26T12:00:00.000Z",
+      kind: "log",
+      data: { level: "info", message: "x" },
+    },
+    {
+      taskId: "t",
+      atIso: "2026-04-26T12:00:00.000Z",
+      kind: "state-changed",
+      data: { fromState: "INIT", toState: "DRAFTING" },
+    },
+    {
+      taskId: "t",
+      atIso: "2026-04-26T12:00:00.000Z",
+      kind: "agent-message",
+      data: { role: "assistant", text: "hello" },
+    },
+    {
+      taskId: "t",
+      atIso: "2026-04-26T12:00:00.000Z",
+      kind: "github-call",
+      data: { method: "GET", endpoint: "/x" },
+    },
+    {
+      taskId: "t",
+      atIso: "2026-04-26T12:00:00.000Z",
+      kind: "error",
+      data: { message: "x" },
+    },
+  ];
+  for (const event of candidates) {
+    const result = parseEnvelope({ id: "e", type: "event", payload: event });
+    assertEquals(result.success, true, `event ${event.kind} failed validation`);
+  }
+});

--- a/tests/unit/tui_shell_test.tsx
+++ b/tests/unit/tui_shell_test.tsx
@@ -828,6 +828,42 @@ Deno.test("SocketDaemonClient: encode failure rejects without writing", async ()
   await client.close();
 });
 
+Deno.test(
+  "SocketDaemonClient: peer disconnect mid-request rejects pending sends",
+  async () => {
+    // Regression for the race Copilot caught at ipc-client.ts:413: when
+    // the read loop ends normally (peer EOF) instead of via an
+    // exception, the previous implementation left every entry in
+    // `pending` unresolved, hanging the caller forever. After the fix
+    // the read loop must drain `pending` with a "daemon disconnected"
+    // error before the local handles get torn down.
+    const pair = makeDuplexPair();
+    const client = new SocketDaemonClient("/unused", () => Promise.resolve(pair.client));
+    await client.connect();
+
+    // Issue a send that the daemon will never reply to. Capture the
+    // promise before the disconnect so the test can await its rejection.
+    const inflight = client.send({ id: "1", type: "ping", payload: {} });
+
+    // Simulate a peer-side clean disconnect: close the daemon's
+    // writable, which makes the client's read loop see `done` and
+    // unwind without throwing.
+    const daemonWriter = pair.daemon.writable.getWriter();
+    await daemonWriter.close().catch(() => {});
+    daemonWriter.releaseLock();
+
+    // The pending send must reject with the documented disconnect
+    // reason rather than hang.
+    await assertRejects(
+      () => inflight,
+      DaemonClientError,
+      "daemon disconnected before responding",
+    );
+
+    await client.close();
+  },
+);
+
 // ---------------------------------------------------------------------------
 // validateReplyEnvelope
 // ---------------------------------------------------------------------------

--- a/tests/unit/tui_shell_test.tsx
+++ b/tests/unit/tui_shell_test.tsx
@@ -829,6 +829,27 @@ Deno.test("SocketDaemonClient: encode failure rejects without writing", async ()
 });
 
 Deno.test(
+  "SocketDaemonClient: send after explicit close reports the permanent-close error",
+  async () => {
+    // Regression: previously the connection/writer guard fired before
+    // the `closed` guard, so a send after close() rejected with "not
+    // connected" — the recoverable error — instead of the documented
+    // "client has been closed" message. Tests and callers rely on the
+    // permanent-close wording to tell an explicit shutdown apart from
+    // a transient transport failure.
+    const pair = makeDuplexPair();
+    const client = new SocketDaemonClient("/unused", () => Promise.resolve(pair.client));
+    await client.connect();
+    await client.close();
+    await assertRejects(
+      () => client.send({ id: "1", type: "ping", payload: {} }),
+      DaemonClientError,
+      "client has been closed",
+    );
+  },
+);
+
+Deno.test(
   "SocketDaemonClient: peer disconnect mid-request rejects pending sends",
   async () => {
     // Regression for the race Copilot caught at ipc-client.ts:413: when

--- a/tests/unit/tui_shell_test.tsx
+++ b/tests/unit/tui_shell_test.tsx
@@ -27,7 +27,7 @@ import {
   SocketDaemonClient,
   validateReplyEnvelope,
 } from "../../src/tui/ipc-client.ts";
-import { useDaemonConnection } from "../../src/tui/hooks/useDaemonConnection.ts";
+import { DaemonHookError, useDaemonConnection } from "../../src/tui/hooks/useDaemonConnection.ts";
 import { Header } from "../../src/tui/components/Header.tsx";
 import { MainPane } from "../../src/tui/components/MainPane.tsx";
 import { StatusBar } from "../../src/tui/components/StatusBar.tsx";
@@ -326,8 +326,8 @@ Deno.test("handleEvent: log event sets the last message with level prefix", () =
     setLastError: (next) => {
       lastError = next;
     },
-    setFocusedTaskId: (next) => {
-      focused = next;
+    setFocusedTaskId: (update) => {
+      focused = update(focused);
     },
   });
   assertEquals(lastMessage, "[info] hello");
@@ -359,6 +359,46 @@ Deno.test("handleEvent: state-changed event renders fromState → toState", () =
   );
   assertEquals(lastMessage, "task_x: INIT → CLONING_WORKTREE");
   assertEquals(known.has(makeTaskId("task_x")), true);
+});
+
+Deno.test("handleEvent: focused-task is auto-set on the first event only", () => {
+  let focused: ReturnType<typeof makeTaskId> | undefined;
+  // First event with t1 → focus snaps to t1.
+  handleEvent(
+    {
+      taskId: "t1",
+      atIso: "2026-04-26T12:00:00.000Z",
+      kind: "log",
+      data: { level: "info", message: "first" },
+    },
+    {
+      setKnownTaskIds: () => {},
+      setLastMessage: () => {},
+      setLastError: () => {},
+      setFocusedTaskId: (update) => {
+        focused = update(focused);
+      },
+    },
+  );
+  assertEquals(focused, makeTaskId("t1"));
+  // Second event from a different task — focus must NOT jump.
+  handleEvent(
+    {
+      taskId: "t2",
+      atIso: "2026-04-26T12:00:01.000Z",
+      kind: "log",
+      data: { level: "info", message: "second" },
+    },
+    {
+      setKnownTaskIds: () => {},
+      setLastMessage: () => {},
+      setLastError: () => {},
+      setFocusedTaskId: (update) => {
+        focused = update(focused);
+      },
+    },
+  );
+  assertEquals(focused, makeTaskId("t1"));
 });
 
 Deno.test("handleEvent: agent-message event truncates long text", () => {
@@ -730,6 +770,49 @@ Deno.test("SocketDaemonClient: connect twice is idempotent", async () => {
   await client.close();
 });
 
+Deno.test(
+  "SocketDaemonClient: reconnects after peer disconnects without explicit close",
+  async () => {
+    // Two paired duplexes — the first is closed mid-test to simulate
+    // the daemon dropping the connection; the second models the
+    // reconnect target.
+    let pair = makeDuplexPair();
+    let opens = 0;
+    const client = new SocketDaemonClient("/unused", () => {
+      opens += 1;
+      return Promise.resolve(pair.client);
+    });
+    await client.connect();
+    assertEquals(opens, 1);
+
+    // Simulate a peer-side disconnect by closing the daemon's writable
+    // half. The client's read loop sees `done` and unwinds — without
+    // anyone calling `client.close()`.
+    const daemonWriter = pair.daemon.writable.getWriter();
+    await daemonWriter.close().catch(() => {});
+    daemonWriter.releaseLock();
+    // Yield so the read loop's `finally` runs and clears the local
+    // handles (the regression Copilot caught).
+    await new Promise<void>((resolve) => setTimeout(resolve, 20));
+
+    // Subsequent send fails fast — the connection is gone.
+    await assertRejects(
+      () => client.send({ id: "1", type: "ping", payload: {} }),
+      DaemonClientError,
+      "not connected",
+    );
+
+    // Reconnect should open a fresh socket, not no-op.
+    pair = makeDuplexPair();
+    await client.connect();
+    assertEquals(opens, 2);
+
+    await client.close();
+    // After explicit close, further connect() rejects.
+    await assertRejects(() => client.connect(), DaemonClientError, "client has been closed");
+  },
+);
+
 Deno.test("SocketDaemonClient: encode failure rejects without writing", async () => {
   const pair = makeDuplexPair();
   const client = new SocketDaemonClient("/unused", () => Promise.resolve(pair.client));
@@ -1038,6 +1121,91 @@ Deno.test({
     });
     assertEquals(received, 1);
     subscription?.unsubscribe();
+    instance.unmount();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  },
+});
+
+Deno.test({
+  name: 'useDaemonConnection: send rejects with DaemonHookError when status !== "connected"',
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    // A lifecycle-aware client kept idle (autoConnect off, no manual
+    // connect) puts the hook's status at `"idle"`. The new guard
+    // should reject any `send` call before the lifecycle promotes
+    // the status to `"connected"`.
+    const probe: HookProbe = { api: undefined };
+    const client = makeFakeLifecycleClient();
+    const stdout = new FakeStream();
+    const stderr = new FakeStream();
+    const instance = inkRender(
+      <HookProbeHost
+        probe={probe}
+        options={{ client, autoConnect: false }}
+      />,
+      {
+        // deno-lint-ignore no-explicit-any
+        stdout: stdout as any,
+        // deno-lint-ignore no-explicit-any
+        stderr: stderr as any,
+        debug: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    assertEquals(probe.api?.status, "idle");
+    const api = probe.api;
+    if (api === undefined) {
+      throw new Error("hook probe never received the API");
+    }
+    await assertRejects(
+      () => api.send({ id: "1", type: "ping", payload: {} }),
+      DaemonHookError,
+      "requires status",
+    );
+    instance.unmount();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  },
+});
+
+Deno.test({
+  name: "useDaemonConnection: disconnect clears stale lastError on lifecycle-less client",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    // The in-memory double has no `close`, so disconnect should still
+    // wipe any earlier error message — otherwise the status bar would
+    // keep flagging a stale error after the user disconnects cleanly.
+    const probe: HookProbe = { api: undefined };
+    const client = new InMemoryDaemonClient();
+    const stdout = new FakeStream();
+    const stderr = new FakeStream();
+    const instance = inkRender(
+      <HookProbeHost
+        probe={probe}
+        options={{ client, autoConnect: false }}
+      />,
+      {
+        // deno-lint-ignore no-explicit-any
+        stdout: stdout as any,
+        // deno-lint-ignore no-explicit-any
+        stderr: stderr as any,
+        debug: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    // No public hook API exposes `setLastError`; in production the
+    // read loop fills it. Instead, drive the same closeConnection
+    // path (which is what disconnect calls) and assert the post-
+    // condition.
+    await probe.api?.disconnect();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    assertEquals(probe.api?.status, "disconnected");
+    assertEquals(probe.api?.lastError, undefined);
     instance.unmount();
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
   },


### PR DESCRIPTION
## Summary

Implements [#10](https://github.com/koraytaylan/makina/issues/10) — Ink-rendered TUI shell with Unix-socket IPC client. Doubles as the Ink-on-Deno feasibility gate.

## Linked issue

Closes #10

## Definition of Done

- [x] JSDoc on every exported symbol; `deno doc --lint` green.
- [x] Snapshot tests for initial render, "1 task active", and "disconnected" states.
- [x] `deno run -A main.ts` launches the TUI and renders correctly.
- [x] Feasibility gate verdict documented (Ink-on-Deno **passes** under Deno 2.7; ADR-010 not invoked — see `docs/architecture.md`).
- [x] `deno task ci` is green (104 tests / 89.73% lines / 91.80% branches).

## References

- Plan §Architecture (TUI), §Risks; ADR-001.