### PR TITLE
feat(#13): Poller with backoff and rate-limit honoring

### DIFF
--- a/docs/adrs/015-poller-cadence-and-backoff.md
+++ b/docs/adrs/015-poller-cadence-and-backoff.md
@@ -1,0 +1,138 @@
+# ADR-015: Poller cadence, backoff, and rate-limit honoring
+
+## Status
+
+Accepted (2026-04-26).
+
+## Context
+
+ADR-006 settled the polling-vs-webhooks question for the stabilize loop: the daemon polls GitHub at
+a fixed cadence rather than standing up a public webhook endpoint. Issue #13 (Wave 3) ships the
+implementation — one timer per task in any `STABILIZING` sub-phase, driven by a `Poller` abstraction
+the supervisor wires up with a per-phase `fetcher`.
+
+The behavioral surface needs to satisfy four constraints simultaneously:
+
+1. **Steady-state cadence.** A successful tick spaces the next call by `intervalMilliseconds`
+   (default `POLL_INTERVAL_MILLISECONDS`, 30 s). Wall-clock-from-completion, not
+   wall-clock-from-issue, so a slow GitHub call does not pile up the next tick on top of itself.
+2. **Honor explicit rate-limit signals.** `GitHubClient` (issue #5, ADR-011) already retries
+   header-driven rate-limit responses internally, so the fetcher the supervisor passes in normally
+   returns a successful payload by the time it reaches the poller. But the request budget the client
+   uses can still surface — the supervisor's per-phase fetcher may throw a typed `PollerError` that
+   carries an explicit `retryAfterMs` the poller must honor before scheduling the next tick.
+3. **Backoff on transient errors.** A fetcher that simply rejects (network blip, transient 5xx,
+   parse error) must not spin: the next tick spaces exponentially with jitter, capped at a sane
+   upper bound, until a successful tick clears the backoff state.
+4. **Clean cancellation.** `AbortSignal.abort()` stops the loop within one pending sleep — no
+   stranded timers, no spurious final fetch, no lingering reference to the supervisor.
+
+The poller also has to be **testable without real time**. Wave 2 ran into trouble when tests reached
+for `Date.now`/`setTimeout` mocks process-wide; ADR-014's persistence work codified the lesson
+("inject the clock; never mutate global timers"). The poller's contract therefore exposes a
+synthetic clock seam, the way `GitHubClient` does for its retry sleep.
+
+## Decision
+
+`createPoller(opts)` returns the W1 `Poller` interface. `poll(args)` schedules a single-flight loop
+per `taskId` and returns a `{ cancel(): void }` handle. The supervisor calls `cancel()` when the
+task leaves a `STABILIZING` sub-phase, and may also pass an `AbortSignal` whose abort event triggers
+the same cancellation path.
+
+### Cadence
+
+After each fetcher resolution the poller sleeps for one of three durations before the next call:
+
+- **Success without `retryAfterMs`** → `intervalMilliseconds`.
+- **Success or `PollerError` carrying `retryAfterMs`** → that value, clamped to
+  `[0, POLLER_BACKOFF_MAX_MILLISECONDS]`. Header-driven rate-limit waits dominate any other signal.
+- **Failure (rejection or `PollerError` without `retryAfterMs`)** → exponential backoff with jitter:
+  `min(POLLER_BACKOFF_BASE_MILLISECONDS * 2^attempt, POLLER_BACKOFF_MAX_MILLISECONDS)` multiplied by
+  a uniform jitter factor in `[1 - POLLER_BACKOFF_JITTER_RATIO, 1 + POLLER_BACKOFF_JITTER_RATIO]`.
+  The attempt counter is per-task and resets to zero on the next successful tick.
+
+`intervalMilliseconds` defaults to `POLL_INTERVAL_MILLISECONDS` when the caller omits it. Callers
+can pass `0` when they want the poller to fire back-to-back (used by the in-memory tests for the
+conversations phase).
+
+### Single-flight per task
+
+The poller keeps at most one in-flight `fetcher` invocation per `taskId`. The supervisor is the only
+caller that should reuse the same task id for overlapping `poll(...)` calls; if it does, the second
+call returns a handle that cancels the prior loop before starting fresh. This matches the
+supervisor's expectation that a stabilize-phase transition tears down and re-arms the poller
+atomically.
+
+### `PollerError` taxonomy
+
+The poller exports `PollerError` extending `Error` with two narrow subclasses (encoded as a
+discriminant `kind`):
+
+- `kind: "rate-limited"` — fetcher exhausted retries inside `GitHubClient` and the supervisor wants
+  the loop to wait `retryAfterMs`. Treated as a successful tick for backoff bookkeeping (the attempt
+  counter does **not** climb), but the next tick is delayed.
+- `kind: "fatal"` — non-retryable error (auth revocation, missing installation). The poller stops
+  the loop and surfaces the error through the optional `onError` callback; without `onError` the
+  error is logged and the loop exits. Either way the supervisor's higher-level state machine decides
+  the task's fate.
+
+Plain `Error` rejections (everything else a fetcher might throw) take the exponential-backoff path:
+the poller assumes the rejection is transient and retries, capped by
+`POLLER_BACKOFF_MAX_MILLISECONDS`.
+
+### Synthetic clock seam
+
+`createPoller` accepts an optional `clock: { now(): number; sleep(ms): Promise<void> }`. Production
+wiring leaves it undefined and the poller uses a `Date.now`/`setTimeout`-backed default; tests
+inject a deterministic clock that records every sleep duration. The clock is the **only** way the
+poller measures time — there is no `Date.now()` call elsewhere in the module, no fall-through to a
+global timer.
+
+### Cancellation
+
+A `cancel()` call (or an `abort` event on the supplied signal) flips a local `cancelled` flag and
+resolves the in-flight `clock.sleep` promise via `AbortController`-coordinated `clock.sleep`. The
+default sleep implementation listens for the abort signal and resolves immediately on abort;
+injected test clocks do the same. After cancellation the poller makes no further calls to `fetcher`
+or `onResult`.
+
+## Consequences
+
+**Positive:**
+
+- The supervisor sees a single, narrow surface (the W1 `Poller` interface) regardless of which
+  stabilize phase drives the loop. No per-phase backoff math leaks into the supervisor.
+- Header-driven rate-limit waits live with the GitHub client (ADR-011) while the poller respects the
+  _resolved_ wait surfaced as `retryAfterMs`. The two layers compose without duplicating header
+  parsing.
+- The synthetic-clock seam keeps tests under a millisecond each — no real timers, no `Date.now`
+  global mutation. Coverage is straightforward even for the jitter branch (the test injects a
+  deterministic `random()` source through the same options bag).
+- Cancellation is observable within one pending sleep. The TUI's "stop task" button does not have to
+  wait the full poll interval before the stabilize loop quiesces.
+
+**Negative:**
+
+- The poller is intentionally minimalist about retry policy: it does not distinguish 5xx from
+  network errors from parse errors. A fetcher that wraps non-HTTP failures as exceptions still takes
+  the backoff path, which is correct for transient hazards but adds latency on truly fatal bugs (a
+  parse-error bug retries until the supervisor times out the phase). Mitigated by
+  `PollerError(kind: "fatal")` — fetchers that _know_ an error is non-retryable can short-circuit
+  the loop.
+- The exponential cap is global. Per-phase tuning (CI vs. conversations) would need additional
+  knobs; deferred until a real use case shows up. The current cap
+  (`POLLER_BACKOFF_MAX_MILLISECONDS`) is wide enough that both phases are comfortable inside it.
+
+## Alternatives considered
+
+- **Honor headers in the poller.** Rejected: the GitHub client already parses `Retry-After` /
+  `X-RateLimit-Reset` (ADR-011). Re-doing it in the poller would mean every fetcher had to plumb
+  headers through, and fetchers that aren't GitHub-backed (the conversations phase reads the
+  in-memory event log of agent-runner output too) have no headers to forward. Surfacing the resolved
+  wait as `retryAfterMs` keeps the decision colocated with the layer that knows the protocol.
+- **Use `setInterval`.** Rejected: `setInterval` does not wait for the prior tick to settle, which
+  can pile up calls when the fetcher occasionally takes longer than `intervalMilliseconds`. The
+  await-then-sleep loop is one line longer and avoids the failure mode entirely.
+- **Cancel by throwing inside the fetcher.** Rejected: makes cancellation observable only after the
+  next fetcher resolution. An `AbortSignal`-backed sleep cancels mid-wait, which is what the TUI
+  expects.

--- a/docs/adrs/017-poller-cadence-and-backoff.md
+++ b/docs/adrs/017-poller-cadence-and-backoff.md
@@ -62,11 +62,19 @@ phase).
 
 ### Single-flight per task
 
-The poller keeps at most one in-flight `fetcher` invocation per `taskId`. The supervisor is the only
-caller that should reuse the same task id for overlapping `poll(...)` calls; if it does, the second
-call returns a handle that cancels the prior loop before starting fresh. This matches the
-supervisor's expectation that a stabilize-phase transition tears down and re-arms the poller
-atomically.
+The poller keeps at most one _active_ poll loop per `taskId`. The supervisor is the only caller that
+should reuse the same task id for overlapping `poll(...)` calls; if it does, the second call returns
+a handle that cancels the prior loop before starting fresh. This matches the supervisor's
+expectation that a stabilize-phase transition tears down and re-arms the poller atomically.
+
+The current `fetcher` contract does **not** accept an `AbortSignal`, so a supersession that lands
+while a previous `fetcher()` promise is still pending cannot abort the in-flight call — the new
+loop's first `fetcher()` may run concurrently with the old loop's last one. This is acceptable
+because (a) the cancelled loop drops its result on resolution (the `isCancelled()` guard short-
+circuits before `onResult`/`onError` run), and (b) the supervisor's `fetcher` implementations are
+read-only against GitHub. If a future `fetcher` needs to mutate state, the contract will need an
+`AbortSignal` parameter and an ADR amendment; the synthetic clock seam is already abortable, so the
+extension is mechanical.
 
 ### `PollerError` taxonomy
 
@@ -87,11 +95,18 @@ the poller assumes the rejection is transient and retries, capped by
 
 ### Synthetic clock seam
 
-`createPoller` accepts an optional `clock: { now(): number; sleep(ms): Promise<void> }`. Production
-wiring leaves it undefined and the poller uses a `Date.now`/`setTimeout`-backed default; tests
-inject a deterministic clock that records every sleep duration. The clock is the **only** way the
-poller measures time — there is no `Date.now()` call elsewhere in the module, no fall-through to a
-global timer.
+`createPoller` accepts an optional
+`clock: { now(): number; sleep(ms, signal?: PollerSleepAbort): Promise<void> }`. Production wiring
+leaves it undefined and the poller uses a `Date.now`/`setTimeout`-backed default; tests inject a
+deterministic clock that records every sleep duration. The clock is the **only** way the poller
+measures time — there is no `Date.now()` call elsewhere in the module, no fall-through to a global
+timer.
+
+The `signal` argument on `sleep` is the cancellation seam: `cancel()` (and external `AbortSignal`
+abort events) flip an internal flag and call `controller.abort()`, which the default sleep wakes on.
+Implementations must resolve immediately when `signal.aborted === true` at entry and on the first
+abort event after entry, and must resolve immediately for `milliseconds <= 0` (or non-finite)
+without scheduling a real timer.
 
 ### Cancellation
 

--- a/docs/adrs/017-poller-cadence-and-backoff.md
+++ b/docs/adrs/017-poller-cadence-and-backoff.md
@@ -47,13 +47,18 @@ After each fetcher resolution the poller sleeps for one of three durations befor
 - **Success or `PollerError` carrying `retryAfterMs`** → that value, clamped to
   `[0, POLLER_BACKOFF_MAX_MILLISECONDS]`. Header-driven rate-limit waits dominate any other signal.
 - **Failure (rejection or `PollerError` without `retryAfterMs`)** → exponential backoff with jitter:
-  `min(POLLER_BACKOFF_BASE_MILLISECONDS * 2^attempt, POLLER_BACKOFF_MAX_MILLISECONDS)` multiplied by
-  a uniform jitter factor in `[1 - POLLER_BACKOFF_JITTER_RATIO, 1 + POLLER_BACKOFF_JITTER_RATIO]`.
-  The attempt counter is per-task and resets to zero on the next successful tick.
+  `min(POLLER_BACKOFF_BASE_MILLISECONDS * 2^(attempt - 1), POLLER_BACKOFF_MAX_MILLISECONDS)`
+  multiplied by a uniform jitter factor in
+  `[1 - POLLER_BACKOFF_JITTER_RATIO, 1 + POLLER_BACKOFF_JITTER_RATIO]`. The attempt counter is the
+  per-task consecutive-failure count starting at 1 (so the first backoff is exactly the base) and
+  resets to zero on the next successful tick. The exponent is internally capped at
+  `POLLER_BACKOFF_MAX_ATTEMPT_EXPONENT` (30) to keep `Math.pow(2, …)` away from `Infinity`; with the
+  default `MAX` of five minutes the series saturates well before that cap.
 
-`intervalMilliseconds` defaults to `POLL_INTERVAL_MILLISECONDS` when the caller omits it. Callers
-can pass `0` when they want the poller to fire back-to-back (used by the in-memory tests for the
-conversations phase).
+`intervalMilliseconds` is required on the `poll(...)` call; the supervisor passes
+`POLL_INTERVAL_MILLISECONDS` from `src/constants.ts` (the per-phase default). Callers can pass `0`
+when they want the poller to fire back-to-back (used by the in-memory tests for the conversations
+phase).
 
 ### Single-flight per task
 

--- a/docs/adrs/017-poller-cadence-and-backoff.md
+++ b/docs/adrs/017-poller-cadence-and-backoff.md
@@ -1,4 +1,4 @@
-# ADR-015: Poller cadence, backoff, and rate-limit honoring
+# ADR-017: Poller cadence, backoff, and rate-limit honoring
 
 ## Status
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -218,7 +218,7 @@ export const HOME_PREFIX = "~/";
  * inside one poll interval, and long enough that we do not pound a
  * struggling GitHub.
  *
- * See {@link https://github.com/koraytaylan/makina/blob/develop/docs/adrs/015-poller-cadence-and-backoff.md ADR-015}.
+ * See {@link https://github.com/koraytaylan/makina/blob/develop/docs/adrs/017-poller-cadence-and-backoff.md ADR-017}.
  */
 export const POLLER_BACKOFF_BASE_MILLISECONDS = 1_000;
 
@@ -231,7 +231,7 @@ export const POLLER_BACKOFF_BASE_MILLISECONDS = 1_000;
  * comfortably above any realistic GitHub `Retry-After` and well below
  * the supervisor's settling-window upper bound.
  *
- * See {@link https://github.com/koraytaylan/makina/blob/develop/docs/adrs/015-poller-cadence-and-backoff.md ADR-015}.
+ * See {@link https://github.com/koraytaylan/makina/blob/develop/docs/adrs/017-poller-cadence-and-backoff.md ADR-017}.
  */
 export const POLLER_BACKOFF_MAX_MILLISECONDS = 5 * 60 * 1_000;
 
@@ -245,6 +245,6 @@ export const POLLER_BACKOFF_MAX_MILLISECONDS = 5 * 60 * 1_000;
  * shape and is small enough that the steady-state cadence stays
  * recognisable.
  *
- * See {@link https://github.com/koraytaylan/makina/blob/develop/docs/adrs/015-poller-cadence-and-backoff.md ADR-015}.
+ * See {@link https://github.com/koraytaylan/makina/blob/develop/docs/adrs/017-poller-cadence-and-backoff.md ADR-017}.
  */
 export const POLLER_BACKOFF_JITTER_RATIO = 0.2;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -207,3 +207,44 @@ export const RADIX_DECIMAL = 10;
  * rather than a bare numeric `2`.
  */
 export const HOME_PREFIX = "~/";
+
+/**
+ * Base sleep used by the {@link Poller} when retrying after a transient
+ * fetcher rejection, in milliseconds.
+ *
+ * The actual wait is `min(BASE * 2^attempt, MAX) * jitter`, where
+ * `attempt` is the run of consecutive failures since the last successful
+ * tick. One second is short enough that a single transient blip recovers
+ * inside one poll interval, and long enough that we do not pound a
+ * struggling GitHub.
+ *
+ * See {@link https://github.com/koraytaylan/makina/blob/develop/docs/adrs/015-poller-cadence-and-backoff.md ADR-015}.
+ */
+export const POLLER_BACKOFF_BASE_MILLISECONDS = 1_000;
+
+/**
+ * Upper bound on a single {@link Poller} sleep, in milliseconds.
+ *
+ * Caps both the exponential backoff series and a `retryAfterMs` value
+ * surfaced by a fetcher (e.g. from an upstream rate-limit response) so a
+ * runaway value cannot stall the supervisor for an hour. Five minutes is
+ * comfortably above any realistic GitHub `Retry-After` and well below
+ * the supervisor's settling-window upper bound.
+ *
+ * See {@link https://github.com/koraytaylan/makina/blob/develop/docs/adrs/015-poller-cadence-and-backoff.md ADR-015}.
+ */
+export const POLLER_BACKOFF_MAX_MILLISECONDS = 5 * 60 * 1_000;
+
+/**
+ * Jitter ratio applied to each {@link Poller} backoff sleep.
+ *
+ * The exponential delay is multiplied by a uniform random factor in
+ * `[1 - ratio, 1 + ratio]` so a fleet of pollers that all hit a transient
+ * outage at the same wall-clock instant do not retry in lockstep. A
+ * 20% spread is the AWS architecture-blog default for the same problem
+ * shape and is small enough that the steady-state cadence stays
+ * recognisable.
+ *
+ * See {@link https://github.com/koraytaylan/makina/blob/develop/docs/adrs/015-poller-cadence-and-backoff.md ADR-015}.
+ */
+export const POLLER_BACKOFF_JITTER_RATIO = 0.2;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -269,3 +269,29 @@ export const POLLER_BACKOFF_JITTER_RATIO = 0.2;
  * series further — the cap dominates first.
  */
 export const POLLER_BACKOFF_MAX_ATTEMPT_EXPONENT = 30;
+
+/**
+ * Radix used in the {@link Poller}'s exponential-backoff formula.
+ *
+ * `min(BASE * RADIX^(attempt - 1), MAX) * jitter` — the radix is `2` to
+ * yield a doubling series (industry default for transient-failure
+ * backoff). Centralised so the bare numeric `2` does not appear inside
+ * `computeBackoff`'s `Math.pow(...)` call (per the bare-literal rule at
+ * the top of this file).
+ *
+ * See {@link https://github.com/koraytaylan/makina/blob/develop/docs/adrs/017-poller-cadence-and-backoff.md ADR-017}.
+ */
+export const POLLER_BACKOFF_EXPONENT_RADIX = 2;
+
+/**
+ * Width of the symmetric jitter window applied to a {@link Poller}
+ * backoff sleep, expressed as a multiplier of
+ * {@link POLLER_BACKOFF_JITTER_RATIO}.
+ *
+ * The factor is uniform in `[1 - ratio, 1 + ratio]`, so the window is
+ * `2 * ratio` wide; the `2` is centralised here so `computeBackoff` reads
+ * `JITTER_WINDOW_MULTIPLIER * jitterRatio` instead of a bare literal.
+ *
+ * See {@link https://github.com/koraytaylan/makina/blob/develop/docs/adrs/017-poller-cadence-and-backoff.md ADR-017}.
+ */
+export const POLLER_BACKOFF_JITTER_WINDOW_MULTIPLIER = 2;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -212,11 +212,12 @@ export const HOME_PREFIX = "~/";
  * Base sleep used by the {@link Poller} when retrying after a transient
  * fetcher rejection, in milliseconds.
  *
- * The actual wait is `min(BASE * 2^attempt, MAX) * jitter`, where
+ * The actual wait is `min(BASE * 2^(attempt - 1), MAX) * jitter`, where
  * `attempt` is the run of consecutive failures since the last successful
- * tick. One second is short enough that a single transient blip recovers
- * inside one poll interval, and long enough that we do not pound a
- * struggling GitHub.
+ * tick (1 on the first failure, so the first backoff is exactly `BASE`).
+ * One second is short enough that a single transient blip recovers inside
+ * one poll interval, and long enough that we do not pound a struggling
+ * GitHub.
  *
  * See {@link https://github.com/koraytaylan/makina/blob/develop/docs/adrs/017-poller-cadence-and-backoff.md ADR-017}.
  */
@@ -248,3 +249,23 @@ export const POLLER_BACKOFF_MAX_MILLISECONDS = 5 * 60 * 1_000;
  * See {@link https://github.com/koraytaylan/makina/blob/develop/docs/adrs/017-poller-cadence-and-backoff.md ADR-017}.
  */
 export const POLLER_BACKOFF_JITTER_RATIO = 0.2;
+
+/**
+ * Internal ceiling on the consecutive-failure count fed into the
+ * {@link Poller}'s `2^(attempt - 1)` exponent.
+ *
+ * `Math.pow(2, 1023)` is the largest power-of-two finite double; beyond
+ * that the multiplication overflows to `Infinity`. The poller's outer
+ * `clamp` would still saturate the result to `POLLER_BACKOFF_MAX_MILLISECONDS`,
+ * but capping the exponent keeps the math debuggable and avoids a flicker
+ * of `Infinity` in trace logs. Thirty is comfortably above the saturation
+ * point for every realistic `(base, max)` pair: with the default
+ * `BASE = 1 s` and `MAX = 5 min`, the series saturates at attempt nine
+ * (`1 s * 2^8 = 256 s`); even a `MAX` of one hour saturates at attempt
+ * twelve.
+ *
+ * Callers configuring an unusually large `backoffMaxMilliseconds` should
+ * note that increasing `MAX` past `BASE * 2^29` will not lengthen the
+ * series further — the cap dominates first.
+ */
+export const POLLER_BACKOFF_MAX_ATTEMPT_EXPONENT = 30;

--- a/src/daemon/poller.ts
+++ b/src/daemon/poller.ts
@@ -561,12 +561,20 @@ async function runLoop<TResult>(args: LoopArgs<TResult>): Promise<void> {
           // otherwise fall back to the steady-state interval. Failure
           // counter does not climb because the upstream told us a
           // precise wait; the next tick is *delayed*, not an *error*.
+          //
+          // Only the explicit `retryAfterMs` is capped at `backoffMax` —
+          // the interval fallback must be respected as-is so the cadence
+          // is consistent with the success path (which also sleeps
+          // `args.interval` without applying the backoff cap). Clamping
+          // the fallback would silently shorten the interval whenever
+          // `interval > backoffMax`, which is a configuration the caller
+          // explicitly chose.
           invokeOnError(args, caught);
-          nextWait = clamp(
-            caught.retryAfterMs ?? args.interval,
-            0,
-            args.backoffMax,
-          );
+          if (caught.retryAfterMs !== undefined) {
+            nextWait = clamp(caught.retryAfterMs, 0, args.backoffMax);
+          } else {
+            nextWait = args.interval;
+          }
         } else {
           // Generic rejection: exponential backoff with jitter.
           invokeOnError(args, caught);
@@ -702,8 +710,14 @@ function stringifyError(caught: unknown): string {
  * Pulled out as a separate factory so the poller's main body holds no
  * `Date.now()` or `setTimeout` reference — that lives entirely in this
  * function and is bypassed in every test that injects a clock.
+ *
+ * Exported so unit tests can drive the real-time clock directly with
+ * lightweight {@link PollerSleepAbort} doubles to cover races that a
+ * native `AbortSignal` cannot reach (e.g. an abort fired synchronously
+ * between the entry-check and the listener registration). Production
+ * code paths construct the clock through {@link createPoller}.
  */
-function defaultClock(): PollerClock {
+export function defaultClock(): PollerClock {
   return {
     now(): number {
       return Date.now();
@@ -746,6 +760,19 @@ function defaultClock(): PollerClock {
           resolve();
         }, wait);
         signal?.addEventListener("abort", abortListener);
+        // Re-check `signal.aborted` *after* attaching the listener.
+        // `AbortSignal` does not replay an abort that fired between the
+        // top-of-function fast path and `addEventListener`, so an abort
+        // landing in that synchronous gap would otherwise be missed and
+        // the sleep would wait the full `wait`, violating the contract
+        // that abort after entry resolves early. The check here is
+        // racing against nothing — the listener handles aborts that fire
+        // *after* this point — so it is safe to read once and trigger
+        // the same cleanup path explicitly.
+        if (signal?.aborted === true) {
+          abortListener();
+          return;
+        }
         // `setTimeout` in Deno returns a numeric handle; `unref` is not
         // available on every runtime. We do not block daemon shutdown on
         // a pending poll sleep — the supervisor's cancel paths abort the

--- a/src/daemon/poller.ts
+++ b/src/daemon/poller.ts
@@ -52,6 +52,7 @@ import { getLogger } from "@std/log";
 import {
   POLLER_BACKOFF_BASE_MILLISECONDS,
   POLLER_BACKOFF_JITTER_RATIO,
+  POLLER_BACKOFF_MAX_ATTEMPT_EXPONENT,
   POLLER_BACKOFF_MAX_MILLISECONDS,
 } from "../constants.ts";
 import type { Poller, TaskId } from "../types.ts";
@@ -556,6 +557,11 @@ async function runLoop<TResult>(args: LoopArgs<TResult>): Promise<void> {
  * after a success, 2 for the next, …). The returned value is
  * `min(base * 2^(attempt-1), max) * jitter`, where `jitter` is uniform
  * in `[1 - ratio, 1 + ratio]`. Clamped from above by `max`.
+ *
+ * The exponent is also capped at {@link POLLER_BACKOFF_MAX_ATTEMPT_EXPONENT}
+ * to keep `Math.pow(2, …)` clear of `Infinity`; with realistic
+ * `(base, max)` pairs the outer `min(…, max)` saturates the series long
+ * before the cap takes effect (see the constant's JSDoc).
  */
 function computeBackoff(
   attempt: number,
@@ -564,11 +570,7 @@ function computeBackoff(
   jitterRatio: number,
   random: () => number,
 ): number {
-  // 2^53 is the JavaScript safe-integer ceiling. We never get anywhere
-  // near that with realistic backoff bases, but `Math.pow(2, 1024)`
-  // returns `Infinity`, which `clamp` handles, but capping the exponent
-  // keeps the math debuggable.
-  const safeAttempt = Math.min(attempt, 30);
+  const safeAttempt = Math.min(attempt, POLLER_BACKOFF_MAX_ATTEMPT_EXPONENT);
   const exponential = base * Math.pow(2, safeAttempt - 1);
   const capped = Math.min(exponential, max);
   if (jitterRatio === 0) {
@@ -663,14 +665,10 @@ function defaultClock(): PollerClock {
           return;
         }
         let resolved = false;
-        const timeout = setTimeout(() => {
-          if (resolved) return;
-          resolved = true;
-          if (signal !== undefined && abortListener !== undefined) {
-            signal.removeEventListener("abort", abortListener);
-          }
-          resolve();
-        }, wait);
+        // `abortListener` is declared up-front so the `setTimeout`
+        // callback (and the listener itself) can both reference it
+        // without tripping the temporal-dead-zone — and so the cleanup
+        // path is plain to read without forward references.
         const abortListener = (): void => {
           if (resolved) return;
           resolved = true;
@@ -678,6 +676,12 @@ function defaultClock(): PollerClock {
           signal?.removeEventListener("abort", abortListener);
           resolve();
         };
+        const timeout = setTimeout(() => {
+          if (resolved) return;
+          resolved = true;
+          signal?.removeEventListener("abort", abortListener);
+          resolve();
+        }, wait);
         signal?.addEventListener("abort", abortListener);
         // `setTimeout` in Deno returns a numeric handle; `unref` is not
         // available on every runtime. We do not block daemon shutdown on

--- a/src/daemon/poller.ts
+++ b/src/daemon/poller.ts
@@ -1,0 +1,705 @@
+/**
+ * daemon/poller.ts — single-flight per-task poll loop with backoff.
+ *
+ * The supervisor (Wave 4) drives the stabilize loop's CI and conversations
+ * phases by handing this module a `fetcher` and an `onResult` callback;
+ * the poller spaces the calls, surfaces results synchronously through the
+ * callback, and stops cleanly on cancel. The W1 `Poller` interface in
+ * `src/types.ts` is the contract every caller (the supervisor, the
+ * stabilize loop's per-phase wirings, the unit tests' in-memory drivers)
+ * binds to.
+ *
+ * The behavior split between this module and {@link GitHubClientImpl}
+ * mirrors ADR-006 + ADR-011 + ADR-015:
+ *
+ * - The GitHub client honors header-driven rate-limit waits (`Retry-After`,
+ *   `X-RateLimit-Reset`) **inside** the fetch wrapper, so a single
+ *   logical call returns the resolved payload after at most one retry.
+ * - The poller is responsible for the **cadence** and the **inter-tick**
+ *   backoff. A fetcher rejection takes the exponential-backoff path; a
+ *   `PollerError(kind: "rate-limited")` carrying `retryAfterMs` short-
+ *   circuits the cadence to honor an upstream wait the client did not
+ *   absorb.
+ *
+ * **Single-flight per task.** Calling {@link Poller.poll} a second time
+ * with the same `taskId` cancels the prior loop before starting fresh.
+ * The supervisor relies on this when a stabilize-phase transition tears
+ * down and re-arms the poller atomically.
+ *
+ * **Synthetic clock seam.** `createPoller` accepts a
+ * `clock: { now(): number; sleep(ms): Promise<void> }` so tests never
+ * touch the real clock. The default implementation uses `Date.now`
+ * and `setTimeout`; tests inject a deterministic clock that records
+ * every sleep duration. The clock is the **only** way the module
+ * measures time. Per ADR-015, no `Date.now()` call lives outside the
+ * default-clock factory.
+ *
+ * **Cancellation.** Both the returned `cancel()` handle and a caller-
+ * provided `AbortSignal` flip the same internal flag and abort the in-
+ * flight `clock.sleep`. After cancellation the poller makes no further
+ * calls to `fetcher` or `onResult`.
+ *
+ * The cadence semantics, the `PollerError` taxonomy, and the synthetic-
+ * clock contract are captured in
+ * `docs/adrs/015-poller-cadence-and-backoff.md`. Any change to those
+ * shapes is a contract change and needs an ADR amendment.
+ *
+ * @module
+ */
+
+import { getLogger } from "@std/log";
+
+import {
+  POLLER_BACKOFF_BASE_MILLISECONDS,
+  POLLER_BACKOFF_JITTER_RATIO,
+  POLLER_BACKOFF_MAX_MILLISECONDS,
+} from "../constants.ts";
+import type { Poller, TaskId } from "../types.ts";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminant kinds of {@link PollerError}.
+ *
+ * - `"rate-limited"` — the fetcher already exhausted its own retries and
+ *   wants the poller to wait `retryAfterMs` before the next tick. The
+ *   poller treats this as a successful tick for backoff bookkeeping
+ *   (the consecutive-failure counter does **not** climb), but the next
+ *   tick is delayed.
+ * - `"fatal"` — the fetcher hit a non-retryable error (auth revocation,
+ *   missing installation, malformed response). The poller stops the loop
+ *   and surfaces the error through {@link PollerOptions.onError}; without
+ *   `onError` the error is logged and the loop exits.
+ */
+export const POLLER_ERROR_KINDS = ["rate-limited", "fatal"] as const;
+
+/** Discriminant union of valid {@link PollerError.kind} values. */
+export type PollerErrorKind = typeof POLLER_ERROR_KINDS[number];
+
+/**
+ * Domain error a fetcher may throw to signal one of two narrow outcomes
+ * the poller treats specially: a known rate-limit wait or a fatal
+ * non-retryable failure. Plain `Error` rejections take the exponential-
+ * backoff path instead — the poller assumes they are transient.
+ *
+ * @example
+ * ```ts
+ * // fetcher signals an upstream rate-limit wait
+ * throw new PollerError("rate-limited", "GitHub primary rate limit", {
+ *   retryAfterMs: 30_000,
+ * });
+ *
+ * // fetcher signals a fatal failure
+ * throw new PollerError("fatal", "installation token revoked");
+ * ```
+ */
+export class PollerError extends Error {
+  /**
+   * Build a poller domain error.
+   *
+   * @param kind The classification controlling poller behavior.
+   * @param message Human-readable description.
+   * @param options Optional payload fields.
+   * @param options.retryAfterMs Sleep, in milliseconds, the poller honors
+   *   before the next tick when `kind === "rate-limited"`. Ignored on
+   *   `"fatal"`. Negative values clamp to 0.
+   * @param options.cause Underlying error to chain via the standard
+   *   `Error.cause` field.
+   *
+   * @throws Never; the constructor only assembles fields.
+   */
+  constructor(
+    public readonly kind: PollerErrorKind,
+    message: string,
+    options: { readonly retryAfterMs?: number; readonly cause?: unknown } = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = "PollerError";
+    if (options.retryAfterMs !== undefined) {
+      this.retryAfterMs = options.retryAfterMs;
+    }
+  }
+
+  /**
+   * When `kind === "rate-limited"`, the inter-tick wait the poller honors,
+   * in milliseconds. `undefined` (or unset) when the fetcher does not
+   * have a precise wait to share — the poller falls back to its default
+   * cadence on rate-limited tickets without `retryAfterMs`.
+   */
+  public readonly retryAfterMs?: number;
+}
+
+/**
+ * Synthetic clock seam used by {@link createPoller}.
+ *
+ * The poller calls only `now()` (for jitter seeding diagnostics, never
+ * for cadence math) and `sleep()` (between ticks). Tests inject a
+ * deterministic implementation that records every sleep without touching
+ * real time. The default clock uses `Date.now` and a `setTimeout`-backed
+ * sleep that respects {@link PollerSleepAbort}.
+ */
+export interface PollerClock {
+  /**
+   * Current wall-clock value in milliseconds since the Unix epoch.
+   * The poller does not subtract one `now()` from another — the value
+   * is only used for diagnostics (e.g. log lines a future caller may
+   * want), so a non-monotonic test clock is acceptable.
+   */
+  now(): number;
+  /**
+   * Sleep for `milliseconds`. Resolves early when `signal` aborts.
+   *
+   * @param milliseconds Duration to wait. Implementations must clamp
+   *   negative values to zero and resolve immediately for `0`.
+   * @param signal Optional abort signal. When it aborts (already-aborted
+   *   counts), the sleep must resolve on the next microtask without
+   *   throwing. The poller never observes the abort reason — the
+   *   resolution itself is the cancellation signal.
+   */
+  sleep(milliseconds: number, signal?: PollerSleepAbort): Promise<void>;
+}
+
+/**
+ * Subset of {@link AbortSignal} the poller passes to the clock's `sleep`.
+ *
+ * Mirrors the two methods the default implementation uses so tests can
+ * inject lightweight doubles without constructing a real
+ * `AbortController`. Production wiring uses real `AbortSignal`s.
+ */
+export interface PollerSleepAbort {
+  /** Whether the underlying signal has already aborted. */
+  readonly aborted: boolean;
+  /**
+   * Subscribe to the abort event. Implementations must invoke `listener`
+   * exactly once on the first transition to aborted; subsequent abort
+   * events are no-ops.
+   */
+  addEventListener(type: "abort", listener: () => void): void;
+  /** Unsubscribe a previously-added abort listener. */
+  removeEventListener(type: "abort", listener: () => void): void;
+}
+
+/**
+ * Narrow logger surface used by the poller. The `@std/log` `Logger` class
+ * satisfies this shape (its `warn` accepts a string), but the narrower
+ * interface lets tests inject a recording double without matching the
+ * SDK's full overload signature.
+ */
+export interface PollerLogger {
+  /** Emit a warning. */
+  warn(message: string): void;
+}
+
+/**
+ * Optional callback taxonomy on {@link Poller.poll}'s extended options.
+ *
+ * The W1 `Poller.poll` signature only accepts `onResult`; production
+ * wiring also wants to learn about errors and rate-limited backoff
+ * episodes. {@link PollerImpl.poll} widens the surface with these
+ * optional callbacks; existing callers binding to the W1 interface
+ * keep working unchanged.
+ */
+export interface PollerCallbacks<TResult> {
+  /**
+   * Invoked synchronously with each successful fetcher resolution.
+   *
+   * A throw inside `onResult` is caught at the loop boundary, logged at
+   * `warn`, and the loop continues. The poller does not retry the tick
+   * — `onResult` is the supervisor's responsibility and any side-effect
+   * failure there is independent of the fetcher's success.
+   */
+  readonly onResult: (result: TResult) => void;
+  /**
+   * Invoked once per fetcher rejection (including
+   * {@link PollerError}-typed rejections). The poller still applies the
+   * appropriate backoff/cadence on top of the callback.
+   *
+   * A throw inside `onError` is caught and logged the same way as
+   * `onResult`.
+   */
+  readonly onError?: (error: unknown) => void;
+}
+
+/**
+ * Construction options for {@link createPoller}.
+ *
+ * Every field is optional; the default values reproduce real-world
+ * behavior. The `clock`, `random`, and `logger` hooks exist so the unit
+ * tests can drive the cadence and jitter branches deterministically.
+ */
+export interface PollerOptions {
+  /**
+   * Synthetic clock seam. Defaults to a `Date.now`/`setTimeout`-backed
+   * implementation. Tests inject a recording clock so cadence assertions
+   * are deterministic.
+   */
+  readonly clock?: PollerClock;
+  /**
+   * Source of uniform `[0, 1)` randomness for jitter. Defaults to
+   * `Math.random`. Tests pin this to a constant so the jittered backoff
+   * is exact.
+   */
+  readonly random?: () => number;
+  /**
+   * Lower bound on the exponential backoff base, in milliseconds.
+   * Defaults to {@link POLLER_BACKOFF_BASE_MILLISECONDS}.
+   */
+  readonly backoffBaseMilliseconds?: number;
+  /**
+   * Upper bound on a single sleep (both `retryAfterMs` and the
+   * exponential series). Defaults to
+   * {@link POLLER_BACKOFF_MAX_MILLISECONDS}.
+   */
+  readonly backoffMaxMilliseconds?: number;
+  /**
+   * Symmetric jitter ratio applied to every backoff sleep. Must lie in
+   * `[0, 1)`; values outside that range raise {@link RangeError}. A
+   * value of `0` disables jitter (useful in tests). Defaults to
+   * {@link POLLER_BACKOFF_JITTER_RATIO}.
+   */
+  readonly backoffJitterRatio?: number;
+  /**
+   * Logger used for handler-throws and per-task supersession warnings.
+   * Defaults to `getLogger()` from `@std/log` (the default-namespace
+   * logger), adapted to the {@link PollerLogger} surface.
+   */
+  readonly logger?: PollerLogger;
+}
+
+/**
+ * Concrete return type of {@link createPoller}. Widens the W1
+ * {@link Poller} contract with:
+ *
+ *  - an `onError` callback alongside `onResult`;
+ *  - an externally-supplied `AbortSignal` that triggers the same
+ *    cancellation path as the returned `cancel()` handle;
+ *  - an extension hook for per-task single-flight bookkeeping the
+ *    supervisor relies on.
+ *
+ * The wider surface stays out of the cross-wave contract file
+ * (`src/types.ts`) so consumer waves not in the supervisor (TUI,
+ * persistence) are not coupled to it.
+ */
+export interface PollerImpl extends Poller {
+  /**
+   * Begin polling. Same shape as {@link Poller.poll} from `src/types.ts`,
+   * widened with optional callbacks and a caller-provided abort signal.
+   *
+   * @param args Polling configuration.
+   * @param args.taskId Task this loop drives. The poller keeps at most
+   *   one in-flight invocation per `taskId`; a second call with the same
+   *   id cancels the prior loop before starting fresh.
+   * @param args.intervalMilliseconds Steady-state spacing between
+   *   successful ticks, in milliseconds. Negative values clamp to zero;
+   *   `0` is allowed and is used by some tests to fire back-to-back.
+   * @param args.fetcher Async callable invoked once per tick. May throw
+   *   {@link PollerError} for rate-limit waits or fatal exits, or any
+   *   other rejection for the exponential-backoff path.
+   * @param args.onResult Synchronous callback invoked with each
+   *   successful fetcher resolution. Throws inside `onResult` are caught
+   *   and logged.
+   * @param args.onError Optional synchronous callback invoked with each
+   *   fetcher rejection (including {@link PollerError}). Throws inside
+   *   `onError` are caught and logged.
+   * @param args.signal Optional {@link AbortSignal} whose abort event
+   *   triggers the same cancellation path as the returned `cancel()`
+   *   handle. An already-aborted signal is honored: the poller exits
+   *   without a single call to `fetcher`.
+   * @returns Cancellation handle; calling `cancel()` is idempotent.
+   */
+  poll<TResult>(args: {
+    readonly taskId: TaskId;
+    readonly intervalMilliseconds: number;
+    readonly fetcher: () => Promise<TResult>;
+    readonly onResult: (result: TResult) => void;
+    readonly onError?: (error: unknown) => void;
+    readonly signal?: AbortSignal;
+  }): { cancel(): void };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Construct a {@link PollerImpl}.
+ *
+ * The returned poller drives one loop per task with the cadence and
+ * backoff policy spelled out in
+ * `docs/adrs/015-poller-cadence-and-backoff.md`. See the module doc
+ * for the full contract.
+ *
+ * @param options Optional configuration overrides.
+ * @returns A fresh poller ready to wire into the supervisor.
+ *
+ * @throws RangeError if `backoffJitterRatio` is outside `[0, 1)` or any
+ *   numeric option is `NaN`/non-finite.
+ *
+ * @example
+ * ```ts
+ * import { createPoller, PollerError } from "./poller.ts";
+ *
+ * const poller = createPoller();
+ * const handle = poller.poll({
+ *   taskId,
+ *   intervalMilliseconds: POLL_INTERVAL_MILLISECONDS,
+ *   fetcher: () => client.getCombinedStatus(repo, sha),
+ *   onResult: (status) => supervisor.observeCi(taskId, status),
+ *   onError: (err) => supervisor.observeCiFailure(taskId, err),
+ * });
+ * // …later
+ * handle.cancel();
+ * ```
+ */
+export function createPoller(options: PollerOptions = {}): PollerImpl {
+  const clock = options.clock ?? defaultClock();
+  const random = options.random ?? Math.random;
+  const backoffBase = validatePositiveDuration(
+    options.backoffBaseMilliseconds ?? POLLER_BACKOFF_BASE_MILLISECONDS,
+    "backoffBaseMilliseconds",
+  );
+  const backoffMax = validatePositiveDuration(
+    options.backoffMaxMilliseconds ?? POLLER_BACKOFF_MAX_MILLISECONDS,
+    "backoffMaxMilliseconds",
+  );
+  if (backoffMax < backoffBase) {
+    throw new RangeError(
+      `backoffMaxMilliseconds (${backoffMax}) must be ≥ backoffBaseMilliseconds (${backoffBase})`,
+    );
+  }
+  const jitterRatio = validateJitterRatio(
+    options.backoffJitterRatio ?? POLLER_BACKOFF_JITTER_RATIO,
+  );
+  const logger = options.logger ?? defaultLogger();
+
+  /**
+   * Per-task supersession bookkeeping. A second `poll(...)` call with an
+   * id already present in this map cancels the prior loop before starting
+   * fresh. Entries are removed when their loop exits (cancelled, fatal,
+   * or signal abort).
+   */
+  const inFlight = new Map<TaskId, () => void>();
+
+  return {
+    poll<TResult>(args: {
+      readonly taskId: TaskId;
+      readonly intervalMilliseconds: number;
+      readonly fetcher: () => Promise<TResult>;
+      readonly onResult: (result: TResult) => void;
+      readonly onError?: (error: unknown) => void;
+      readonly signal?: AbortSignal;
+    }): { cancel(): void } {
+      const interval = Math.max(0, args.intervalMilliseconds);
+
+      // Single-flight: cancel any prior loop for the same task before
+      // installing the new one. The cancel call below resolves the prior
+      // sleep on its next microtask — the prior loop exits without an
+      // additional fetch.
+      const previous = inFlight.get(args.taskId);
+      if (previous !== undefined) {
+        logger.warn(
+          `poller: superseding in-flight poll for ${stringifyTaskId(args.taskId)}`,
+        );
+        previous();
+      }
+
+      const abortController = new AbortController();
+      let cancelled = false;
+      const cancel = (): void => {
+        if (cancelled) return;
+        cancelled = true;
+        abortController.abort();
+        // Only remove the bookkeeping entry if the slot still belongs to
+        // *this* loop. A later `poll(...)` for the same task would have
+        // overwritten the entry with its own canceller; we must not
+        // delete that one.
+        if (inFlight.get(args.taskId) === cancel) {
+          inFlight.delete(args.taskId);
+        }
+      };
+      inFlight.set(args.taskId, cancel);
+
+      // Honor an already-aborted external signal without calling fetcher.
+      if (args.signal?.aborted === true) {
+        cancel();
+        return { cancel };
+      }
+      // Wire external signal abort into our internal cancel path.
+      const externalAbortListener = (): void => {
+        cancel();
+      };
+      args.signal?.addEventListener("abort", externalAbortListener);
+
+      // Detached loop: failures inside the loop are surfaced through
+      // `onError`/`logger.warn` per the contract; this `.catch` is
+      // defensive only.
+      runLoop({
+        clock,
+        random,
+        backoffBase,
+        backoffMax,
+        jitterRatio,
+        logger,
+        interval,
+        fetcher: args.fetcher,
+        onResult: args.onResult,
+        onError: args.onError,
+        abortSignal: abortController.signal,
+        isCancelled: () => cancelled,
+        cleanup: () => {
+          args.signal?.removeEventListener("abort", externalAbortListener);
+          if (inFlight.get(args.taskId) === cancel) {
+            inFlight.delete(args.taskId);
+          }
+        },
+      }).catch((caught: unknown) => {
+        logger.warn(
+          `poller: loop exited unexpectedly for ${stringifyTaskId(args.taskId)}: ${
+            stringifyError(caught)
+          }`,
+        );
+      });
+
+      return { cancel };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+interface LoopArgs<TResult> {
+  readonly clock: PollerClock;
+  readonly random: () => number;
+  readonly backoffBase: number;
+  readonly backoffMax: number;
+  readonly jitterRatio: number;
+  readonly logger: PollerLogger;
+  readonly interval: number;
+  readonly fetcher: () => Promise<TResult>;
+  readonly onResult: (result: TResult) => void;
+  readonly onError: ((error: unknown) => void) | undefined;
+  readonly abortSignal: AbortSignal;
+  readonly isCancelled: () => boolean;
+  readonly cleanup: () => void;
+}
+
+/**
+ * The actual await-then-sleep loop. Pulled out as a free function so
+ * `createPoller`'s closure stays small and the loop's local state
+ * (consecutive failures, attempt counter) does not leak into the
+ * factory's lexical scope across `poll(...)` calls.
+ */
+async function runLoop<TResult>(args: LoopArgs<TResult>): Promise<void> {
+  let consecutiveFailures = 0;
+  try {
+    while (!args.isCancelled()) {
+      let nextWait: number;
+      try {
+        const result = await args.fetcher();
+        if (args.isCancelled()) return;
+        // Success resets the backoff series.
+        consecutiveFailures = 0;
+        safeInvoke(() => args.onResult(result), "onResult", args.logger);
+        nextWait = args.interval;
+      } catch (caught) {
+        if (args.isCancelled()) return;
+        if (caught instanceof PollerError) {
+          if (caught.kind === "fatal") {
+            // Surface and exit; the supervisor's higher-level state
+            // machine decides what to do next (typically NEEDS_HUMAN).
+            invokeOnError(args, caught);
+            return;
+          }
+          // kind: "rate-limited" — honor the explicit wait when present,
+          // otherwise fall back to the steady-state interval. Failure
+          // counter does not climb because the upstream told us a
+          // precise wait; the next tick is *delayed*, not an *error*.
+          invokeOnError(args, caught);
+          nextWait = clamp(
+            caught.retryAfterMs ?? args.interval,
+            0,
+            args.backoffMax,
+          );
+        } else {
+          // Generic rejection: exponential backoff with jitter.
+          invokeOnError(args, caught);
+          consecutiveFailures += 1;
+          nextWait = computeBackoff(
+            consecutiveFailures,
+            args.backoffBase,
+            args.backoffMax,
+            args.jitterRatio,
+            args.random,
+          );
+        }
+      }
+
+      if (args.isCancelled()) return;
+      // The clock's sleep resolves on abort; we re-check `isCancelled`
+      // after to break the loop without scheduling another fetch.
+      await args.clock.sleep(nextWait, args.abortSignal);
+    }
+  } finally {
+    args.cleanup();
+  }
+}
+
+/**
+ * Compute the next backoff sleep, in milliseconds, given the consecutive-
+ * failure count.
+ *
+ * `attempt` is the *consecutive failure* count (1 for the first failure
+ * after a success, 2 for the next, …). The returned value is
+ * `min(base * 2^(attempt-1), max) * jitter`, where `jitter` is uniform
+ * in `[1 - ratio, 1 + ratio]`. Clamped from above by `max`.
+ */
+function computeBackoff(
+  attempt: number,
+  base: number,
+  max: number,
+  jitterRatio: number,
+  random: () => number,
+): number {
+  // 2^53 is the JavaScript safe-integer ceiling. We never get anywhere
+  // near that with realistic backoff bases, but `Math.pow(2, 1024)`
+  // returns `Infinity`, which `clamp` handles, but capping the exponent
+  // keeps the math debuggable.
+  const safeAttempt = Math.min(attempt, 30);
+  const exponential = base * Math.pow(2, safeAttempt - 1);
+  const capped = Math.min(exponential, max);
+  if (jitterRatio === 0) {
+    return capped;
+  }
+  // Uniform jitter in [1 - ratio, 1 + ratio].
+  const factor = 1 - jitterRatio + random() * (2 * jitterRatio);
+  return clamp(capped * factor, 0, max);
+}
+
+function invokeOnError<TResult>(
+  args: LoopArgs<TResult>,
+  caught: unknown,
+): void {
+  if (args.onError === undefined) {
+    args.logger.warn(`poller: fetcher rejected: ${stringifyError(caught)}`);
+    return;
+  }
+  safeInvoke(() => args.onError?.(caught), "onError", args.logger);
+}
+
+function safeInvoke(
+  call: () => void,
+  label: string,
+  logger: PollerLogger,
+): void {
+  try {
+    call();
+  } catch (caught) {
+    logger.warn(`poller: ${label} threw; loop continues. error=${stringifyError(caught)}`);
+  }
+}
+
+function clamp(value: number, lower: number, upper: number): number {
+  if (Number.isNaN(value)) return lower;
+  if (value < lower) return lower;
+  if (value > upper) return upper;
+  return value;
+}
+
+function validatePositiveDuration(value: number, field: string): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new RangeError(
+      `${field} must be a positive finite number; got ${value}`,
+    );
+  }
+  return value;
+}
+
+function validateJitterRatio(value: number): number {
+  if (!Number.isFinite(value) || value < 0 || value >= 1) {
+    throw new RangeError(
+      `backoffJitterRatio must be in [0, 1); got ${value}`,
+    );
+  }
+  return value;
+}
+
+function stringifyTaskId(taskId: TaskId): string {
+  return `task:${taskId}`;
+}
+
+function stringifyError(caught: unknown): string {
+  if (caught instanceof Error) {
+    return `${caught.name}: ${caught.message}`;
+  }
+  return String(caught);
+}
+
+// ---------------------------------------------------------------------------
+// Default clock and logger factories
+// ---------------------------------------------------------------------------
+
+/**
+ * The default {@link PollerClock} backed by `Date.now` and a
+ * `setTimeout`-based sleep that resolves early on `signal.abort()`.
+ *
+ * Pulled out as a separate factory so the poller's main body holds no
+ * `Date.now()` or `setTimeout` reference — that lives entirely in this
+ * function and is bypassed in every test that injects a clock.
+ */
+function defaultClock(): PollerClock {
+  return {
+    now(): number {
+      return Date.now();
+    },
+    sleep(milliseconds: number, signal?: PollerSleepAbort): Promise<void> {
+      const wait = milliseconds <= 0 ? 0 : milliseconds;
+      return new Promise<void>((resolve) => {
+        if (signal?.aborted === true) {
+          resolve();
+          return;
+        }
+        let resolved = false;
+        const timeout = setTimeout(() => {
+          if (resolved) return;
+          resolved = true;
+          if (signal !== undefined && abortListener !== undefined) {
+            signal.removeEventListener("abort", abortListener);
+          }
+          resolve();
+        }, wait);
+        const abortListener = (): void => {
+          if (resolved) return;
+          resolved = true;
+          clearTimeout(timeout);
+          signal?.removeEventListener("abort", abortListener);
+          resolve();
+        };
+        signal?.addEventListener("abort", abortListener);
+        // `setTimeout` in Deno returns a numeric handle; `unref` is not
+        // available on every runtime. We do not block daemon shutdown on
+        // a pending poll sleep — the supervisor's cancel paths abort the
+        // signal first.
+        const maybeUnref = timeout as unknown as { unref?: () => void };
+        if (typeof maybeUnref.unref === "function") {
+          maybeUnref.unref();
+        }
+      });
+    },
+  };
+}
+
+function defaultLogger(): PollerLogger {
+  // `getLogger()` returns the default-namespace logger from `@std/log`.
+  // Its `warn` overload accepts a plain string, but TypeScript needs a
+  // thin adapter to project the SDK's shape onto our narrow surface.
+  const inner = getLogger();
+  return {
+    warn(message: string): void {
+      inner.warn(message);
+    },
+  };
+}

--- a/src/daemon/poller.ts
+++ b/src/daemon/poller.ts
@@ -51,7 +51,9 @@ import { getLogger } from "@std/log";
 
 import {
   POLLER_BACKOFF_BASE_MILLISECONDS,
+  POLLER_BACKOFF_EXPONENT_RADIX,
   POLLER_BACKOFF_JITTER_RATIO,
+  POLLER_BACKOFF_JITTER_WINDOW_MULTIPLIER,
   POLLER_BACKOFF_MAX_ATTEMPT_EXPONENT,
   POLLER_BACKOFF_MAX_MILLISECONDS,
 } from "../constants.ts";
@@ -119,7 +121,14 @@ export class PollerError extends Error {
     super(message, options.cause === undefined ? undefined : { cause: options.cause });
     this.name = "PollerError";
     if (options.retryAfterMs !== undefined) {
-      this.retryAfterMs = options.retryAfterMs;
+      // The JSDoc above commits to a non-negative `retryAfterMs` on the
+      // public surface. Clamp here (rather than only at the loop boundary)
+      // so `onError` consumers reading `err.retryAfterMs` see the same
+      // contract the docstring promises. NaN/non-finite values are clamped
+      // to 0 as well — they cannot be honored as a wait, and propagating
+      // them would silently surprise downstream consumers.
+      const raw = options.retryAfterMs;
+      this.retryAfterMs = Number.isFinite(raw) && raw > 0 ? raw : 0;
     }
   }
 
@@ -295,6 +304,9 @@ export interface PollerImpl extends Poller {
    * @param args.intervalMilliseconds Steady-state spacing between
    *   successful ticks, in milliseconds. Negative values clamp to zero;
    *   `0` is allowed and is used by some tests to fire back-to-back.
+   *   Non-finite values (`NaN`, `Infinity`) raise {@link RangeError} —
+   *   they cannot represent a meaningful sleep duration and would either
+   *   spin instantly or hang forever if propagated to `clock.sleep`.
    * @param args.fetcher Async callable invoked once per tick. May throw
    *   {@link PollerError} for rate-limit waits or fatal exits, or any
    *   other rejection for the exponential-backoff path.
@@ -392,6 +404,15 @@ export function createPoller(options: PollerOptions = {}): PollerImpl {
       readonly onError?: (error: unknown) => void;
       readonly signal?: AbortSignal;
     }): { cancel(): void } {
+      // `Math.max(0, x)` propagates `NaN` and `Infinity`; both would feed
+      // straight into `clock.sleep(...)` and either spin instantly (NaN)
+      // or hang forever (Infinity). Reject non-finite values up-front the
+      // same way `createPoller` rejects non-finite numeric options.
+      if (!Number.isFinite(args.intervalMilliseconds)) {
+        throw new RangeError(
+          `intervalMilliseconds must be a finite number; got ${args.intervalMilliseconds}`,
+        );
+      }
       const interval = Math.max(0, args.intervalMilliseconds);
 
       // Single-flight: cancel any prior loop for the same task before
@@ -408,10 +429,23 @@ export function createPoller(options: PollerOptions = {}): PollerImpl {
 
       const abortController = new AbortController();
       let cancelled = false;
+      // Hoisted so `cancel()` can detach the external listener even if the
+      // in-flight `fetcher()` never settles and the loop never reaches
+      // `cleanup()`. Assigned later, after the early-aborted branch.
+      let externalAbortListener: (() => void) | undefined;
       const cancel = (): void => {
         if (cancelled) return;
         cancelled = true;
         abortController.abort();
+        // Detach the external signal listener immediately. If we waited
+        // for `cleanup()` (only fired when the loop body unwinds), a hung
+        // `fetcher()` would keep this listener attached after `cancel()`
+        // — a leak that survives the supersession path the supervisor
+        // relies on.
+        if (externalAbortListener !== undefined) {
+          args.signal?.removeEventListener("abort", externalAbortListener);
+          externalAbortListener = undefined;
+        }
         // Only remove the bookkeeping entry if the slot still belongs to
         // *this* loop. A later `poll(...)` for the same task would have
         // overwritten the entry with its own canceller; we must not
@@ -428,7 +462,7 @@ export function createPoller(options: PollerOptions = {}): PollerImpl {
         return { cancel };
       }
       // Wire external signal abort into our internal cancel path.
-      const externalAbortListener = (): void => {
+      externalAbortListener = (): void => {
         cancel();
       };
       args.signal?.addEventListener("abort", externalAbortListener);
@@ -450,7 +484,15 @@ export function createPoller(options: PollerOptions = {}): PollerImpl {
         abortSignal: abortController.signal,
         isCancelled: () => cancelled,
         cleanup: () => {
-          args.signal?.removeEventListener("abort", externalAbortListener);
+          // `cancel()` already detaches `externalAbortListener` on the
+          // cancel path; this handles the loop-exits-on-its-own paths
+          // (fatal `PollerError`, naturally-completed iterations) where
+          // `cancel()` was never called. Idempotent: a second
+          // `removeEventListener` with a stale reference is a no-op.
+          if (externalAbortListener !== undefined) {
+            args.signal?.removeEventListener("abort", externalAbortListener);
+            externalAbortListener = undefined;
+          }
           if (inFlight.get(args.taskId) === cancel) {
             inFlight.delete(args.taskId);
           }
@@ -571,13 +613,16 @@ function computeBackoff(
   random: () => number,
 ): number {
   const safeAttempt = Math.min(attempt, POLLER_BACKOFF_MAX_ATTEMPT_EXPONENT);
-  const exponential = base * Math.pow(2, safeAttempt - 1);
+  const exponential = base *
+    Math.pow(POLLER_BACKOFF_EXPONENT_RADIX, safeAttempt - 1);
   const capped = Math.min(exponential, max);
   if (jitterRatio === 0) {
     return capped;
   }
-  // Uniform jitter in [1 - ratio, 1 + ratio].
-  const factor = 1 - jitterRatio + random() * (2 * jitterRatio);
+  // Uniform jitter in [1 - ratio, 1 + ratio]; window width is
+  // `JITTER_WINDOW_MULTIPLIER * ratio` (i.e. `2 * ratio`).
+  const factor = 1 - jitterRatio +
+    random() * (POLLER_BACKOFF_JITTER_WINDOW_MULTIPLIER * jitterRatio);
   return clamp(capped * factor, 0, max);
 }
 
@@ -586,7 +631,13 @@ function invokeOnError<TResult>(
   caught: unknown,
 ): void {
   if (args.onError === undefined) {
-    args.logger.warn(`poller: fetcher rejected: ${stringifyError(caught)}`);
+    // Sample the synthetic clock for the diagnostic log line. This is the
+    // documented use of `clock.now()` (jitter seeding diagnostics; never
+    // cadence math) — the value is informational only, so a non-monotonic
+    // test clock is acceptable.
+    args.logger.warn(
+      `poller: fetcher rejected at ${args.clock.now()}: ${stringifyError(caught)}`,
+    );
     return;
   }
   safeInvoke(() => args.onError?.(caught), "onError", args.logger);
@@ -658,12 +709,24 @@ function defaultClock(): PollerClock {
       return Date.now();
     },
     sleep(milliseconds: number, signal?: PollerSleepAbort): Promise<void> {
-      const wait = milliseconds <= 0 ? 0 : milliseconds;
+      // Already-aborted signal: resolve on the next microtask without
+      // touching `setTimeout`. Per the {@link PollerClock.sleep} contract,
+      // the resolution itself is the cancellation signal.
+      if (signal?.aborted === true) {
+        return Promise.resolve();
+      }
+      // Zero-or-non-finite wait: short-circuit to avoid scheduling a real
+      // timer for a sleep that is meant to be observed as "no wait" — the
+      // interface contract asks implementations to resolve immediately
+      // for `0`, and the same applies to negative or `NaN` inputs (which
+      // cannot represent a meaningful future deadline). `Promise.resolve()`
+      // resolves on the next microtask, matching the abort-already-fired
+      // path above.
+      if (!Number.isFinite(milliseconds) || milliseconds <= 0) {
+        return Promise.resolve();
+      }
+      const wait = milliseconds;
       return new Promise<void>((resolve) => {
-        if (signal?.aborted === true) {
-          resolve();
-          return;
-        }
         let resolved = false;
         // `abortListener` is declared up-front so the `setTimeout`
         // callback (and the listener itself) can both reference it

--- a/src/daemon/poller.ts
+++ b/src/daemon/poller.ts
@@ -10,7 +10,7 @@
  * binds to.
  *
  * The behavior split between this module and {@link GitHubClientImpl}
- * mirrors ADR-006 + ADR-011 + ADR-015:
+ * mirrors ADR-006 + ADR-011 + ADR-017:
  *
  * - The GitHub client honors header-driven rate-limit waits (`Retry-After`,
  *   `X-RateLimit-Reset`) **inside** the fetch wrapper, so a single
@@ -31,7 +31,7 @@
  * touch the real clock. The default implementation uses `Date.now`
  * and `setTimeout`; tests inject a deterministic clock that records
  * every sleep duration. The clock is the **only** way the module
- * measures time. Per ADR-015, no `Date.now()` call lives outside the
+ * measures time. Per ADR-017, no `Date.now()` call lives outside the
  * default-clock factory.
  *
  * **Cancellation.** Both the returned `cancel()` handle and a caller-
@@ -41,7 +41,7 @@
  *
  * The cadence semantics, the `PollerError` taxonomy, and the synthetic-
  * clock contract are captured in
- * `docs/adrs/015-poller-cadence-and-backoff.md`. Any change to those
+ * `docs/adrs/017-poller-cadence-and-backoff.md`. Any change to those
  * shapes is a contract change and needs an ADR amendment.
  *
  * @module
@@ -328,7 +328,7 @@ export interface PollerImpl extends Poller {
  *
  * The returned poller drives one loop per task with the cadence and
  * backoff policy spelled out in
- * `docs/adrs/015-poller-cadence-and-backoff.md`. See the module doc
+ * `docs/adrs/017-poller-cadence-and-backoff.md`. See the module doc
  * for the full contract.
  *
  * @param options Optional configuration overrides.

--- a/tests/unit/poller_test.ts
+++ b/tests/unit/poller_test.ts
@@ -1,0 +1,936 @@
+/**
+ * Unit tests for `src/daemon/poller.ts`. Drives the poll loop with a
+ * synthetic clock so the cadence, backoff, and cancellation branches are
+ * deterministic without touching real time.
+ *
+ * The synthetic clock here is **not** a global mock: every test
+ * constructs its own `RecordingClock` and injects it through
+ * `PollerOptions.clock`. Per the Wave 2 lessons, the tests never call
+ * `mock.install` on `Date.now`, `setTimeout`, `Deno.env`, or any other
+ * process-global. A test that wants the default-clock branch exercised
+ * for coverage uses a microsecond-scale interval against the real clock,
+ * cancelled before the next tick — that is the *only* place the file
+ * touches real time.
+ *
+ * Coverage map:
+ *
+ *  - Steady-state cadence (success after success spaces by `interval`).
+ *  - Backoff on `PollerError(kind: "rate-limited", retryAfterMs)`.
+ *  - Backoff on transient rejections (exponential, jitter applied).
+ *  - Backoff cap honors `backoffMaxMilliseconds`.
+ *  - Backoff resets to zero after a successful tick.
+ *  - `PollerError(kind: "fatal")` exits the loop without retry.
+ *  - `cancel()` stops the loop and resolves a pending sleep.
+ *  - External `AbortSignal` triggers the same path.
+ *  - Already-aborted signal exits without a single `fetcher` call.
+ *  - Single-flight: a second `poll(...)` for the same task supersedes
+ *    the prior loop and the prior loop sees no further fetches.
+ *  - `onError` and `onResult` throws are caught and logged.
+ *  - Construction-time validation rejects bad option values.
+ *  - Default clock is exercised end-to-end.
+ */
+
+import {
+  assertEquals,
+  assertGreaterOrEqual,
+  assertInstanceOf,
+  assertLessOrEqual,
+  assertStrictEquals,
+  assertThrows,
+} from "@std/assert";
+
+import {
+  POLLER_BACKOFF_BASE_MILLISECONDS,
+  POLLER_BACKOFF_JITTER_RATIO,
+  POLLER_BACKOFF_MAX_MILLISECONDS,
+} from "../../src/constants.ts";
+import {
+  createPoller,
+  POLLER_ERROR_KINDS,
+  PollerError,
+  type PollerOptions,
+  type PollerSleepAbort,
+} from "../../src/daemon/poller.ts";
+import { makeTaskId } from "../../src/types.ts";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Recording logger that captures every `warn` call. */
+function recordingLogger(): { warn: (message: string) => void; messages: string[] } {
+  const messages: string[] = [];
+  return {
+    messages,
+    warn(message: string): void {
+      messages.push(message);
+    },
+  };
+}
+
+/**
+ * Synthetic clock used by every test except the explicit "default clock"
+ * coverage check. Records the duration of every `sleep()` call and
+ * resolves immediately (or on abort), so a poll loop runs as fast as the
+ * microtask queue can drain.
+ */
+class RecordingClock {
+  readonly sleeps: number[] = [];
+  private currentMilliseconds = 1_700_000_000_000;
+
+  now = (): number => this.currentMilliseconds;
+
+  sleep = (
+    milliseconds: number,
+    signal?: PollerSleepAbort,
+  ): Promise<void> => {
+    this.sleeps.push(milliseconds);
+    if (signal?.aborted === true) {
+      this.currentMilliseconds += milliseconds;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      const onAbort = () => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve();
+      };
+      signal?.addEventListener("abort", onAbort);
+      // Synthetic time advances by the requested amount and resolves on
+      // the next microtask. The poll loop's `await sleep(...)` therefore
+      // yields exactly once before the next iteration.
+      this.currentMilliseconds += milliseconds;
+      queueMicrotask(() => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve();
+      });
+    });
+  };
+}
+
+/**
+ * Yield enough microtasks for `iterations` poll-loop turns to drain.
+ * The poll loop is `await fetcher() → await sleep(0)` so every iteration
+ * needs two microtask flushes. We round up generously.
+ */
+async function flushIterations(iterations: number): Promise<void> {
+  // `await Promise.resolve()` yields one microtask.
+  for (let i = 0; i < iterations * 4; i++) {
+    await Promise.resolve();
+  }
+}
+
+const TASK = makeTaskId("task_poller_test");
+
+interface BuildArgs {
+  readonly clock?: RecordingClock;
+  readonly random?: () => number;
+  readonly logger?: { warn(message: string): void; messages: string[] };
+  readonly options?: Omit<PollerOptions, "clock" | "random" | "logger">;
+}
+
+function buildPoller(args: BuildArgs = {}) {
+  const clock = args.clock ?? new RecordingClock();
+  const logger = args.logger ?? recordingLogger();
+  const options: PollerOptions = {
+    clock,
+    logger,
+    ...(args.random !== undefined ? { random: args.random } : {}),
+    ...(args.options ?? {}),
+  };
+  const poller = createPoller(options);
+  return { poller, clock, logger };
+}
+
+/**
+ * A fetcher script: each invocation pops the next entry and either
+ * resolves with the value or rejects with the error. Useful for driving
+ * exact tick-by-tick behavior.
+ */
+function scriptedFetcher<T>(script: ReadonlyArray<{ ok: T } | { err: unknown }>) {
+  let index = 0;
+  const calls: number[] = [];
+  return {
+    calls,
+    fetcher: (): Promise<T> => {
+      const i = index++;
+      calls.push(i);
+      const next = script[i];
+      if (next === undefined) {
+        // No more scripted answers → block forever; tests that need this
+        // branch cancel before the next call.
+        return new Promise<T>(() => {});
+      }
+      if ("ok" in next) {
+        return Promise.resolve(next.ok);
+      }
+      return Promise.reject(next.err);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Steady-state cadence
+// ---------------------------------------------------------------------------
+
+Deno.test("poll: steady-state cadence spaces successful ticks by interval", async () => {
+  const { poller, clock } = buildPoller();
+  const { fetcher, calls } = scriptedFetcher([
+    { ok: "a" },
+    { ok: "b" },
+    { ok: "c" },
+  ]);
+  const results: string[] = [];
+
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 30_000,
+    fetcher,
+    onResult: (r) => results.push(r),
+  });
+
+  await flushIterations(4);
+  handle.cancel();
+
+  // Three ticks delivered; clock saw exactly three sleeps of `interval`.
+  assertEquals(results, ["a", "b", "c"]);
+  assertGreaterOrEqual(calls.length, 3);
+  // The first three sleeps are the inter-tick delays after each success.
+  assertEquals(clock.sleeps.slice(0, 3), [30_000, 30_000, 30_000]);
+});
+
+Deno.test("poll: clamps negative intervalMilliseconds to zero", async () => {
+  const { poller, clock } = buildPoller();
+  const { fetcher } = scriptedFetcher([{ ok: 1 }, { ok: 2 }]);
+  const seen: number[] = [];
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: -500,
+    fetcher,
+    onResult: (r) => seen.push(r),
+  });
+  await flushIterations(3);
+  handle.cancel();
+  assertEquals(seen.slice(0, 2), [1, 2]);
+  // Clamped to 0, not negative.
+  assertEquals(clock.sleeps[0], 0);
+});
+
+// ---------------------------------------------------------------------------
+// Rate-limited backoff (PollerError kind: "rate-limited")
+// ---------------------------------------------------------------------------
+
+Deno.test("poll: PollerError(rate-limited) honors retryAfterMs without climbing failure counter", async () => {
+  const { poller, clock } = buildPoller({ random: () => 0.5 });
+  const errors: unknown[] = [];
+  const results: string[] = [];
+
+  // First call rate-limited (60s wait), then two successes spaced by
+  // interval. The failure counter must NOT climb from the rate-limit
+  // branch — the second sleep should still be `interval`, not exp(1).
+  const { fetcher } = scriptedFetcher<string>([
+    { err: new PollerError("rate-limited", "primary", { retryAfterMs: 60_000 }) },
+    { ok: "first" },
+    { ok: "second" },
+  ]);
+
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 30_000,
+    fetcher,
+    onResult: (r) => results.push(r),
+    onError: (e) => errors.push(e),
+  });
+  await flushIterations(4);
+  handle.cancel();
+
+  assertEquals(results, ["first", "second"]);
+  assertEquals(errors.length, 1);
+  assertInstanceOf(errors[0], PollerError);
+  // Sleeps: rate-limit 60s, then interval 30s, then interval 30s.
+  assertEquals(clock.sleeps.slice(0, 3), [60_000, 30_000, 30_000]);
+});
+
+Deno.test("poll: PollerError(rate-limited) without retryAfterMs falls back to interval", async () => {
+  const { poller, clock } = buildPoller();
+  const { fetcher } = scriptedFetcher<string>([
+    { err: new PollerError("rate-limited", "no header") },
+    { ok: "after" },
+  ]);
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 25_000,
+    fetcher,
+    onResult: () => {},
+    onError: () => {},
+  });
+  await flushIterations(3);
+  handle.cancel();
+  // Fallback to interval, not the backoff series.
+  assertEquals(clock.sleeps[0], 25_000);
+});
+
+Deno.test("poll: PollerError(rate-limited) clamps retryAfterMs above the max", async () => {
+  const { poller, clock } = buildPoller({
+    options: { backoffMaxMilliseconds: 60_000 },
+  });
+  const { fetcher } = scriptedFetcher<string>([
+    {
+      err: new PollerError("rate-limited", "huge wait", { retryAfterMs: 9_999_999 }),
+    },
+    { ok: "after" },
+  ]);
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 1_000,
+    fetcher,
+    onResult: () => {},
+    onError: () => {},
+  });
+  await flushIterations(3);
+  handle.cancel();
+  assertEquals(clock.sleeps[0], 60_000);
+});
+
+Deno.test("poll: PollerError(rate-limited) clamps negative retryAfterMs to zero", async () => {
+  const { poller, clock } = buildPoller();
+  const { fetcher } = scriptedFetcher<string>([
+    { err: new PollerError("rate-limited", "negative", { retryAfterMs: -42 }) },
+    { ok: "after" },
+  ]);
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 1_000,
+    fetcher,
+    onResult: () => {},
+    onError: () => {},
+  });
+  await flushIterations(3);
+  handle.cancel();
+  assertEquals(clock.sleeps[0], 0);
+});
+
+// ---------------------------------------------------------------------------
+// Exponential backoff on transient rejections
+// ---------------------------------------------------------------------------
+
+Deno.test("poll: transient rejection triggers exponential backoff with jitter", async () => {
+  // Pin random() to 0.5 → jitter factor = 1.0 (mid of [0.8, 1.2]).
+  const { poller, clock } = buildPoller({
+    random: () => 0.5,
+    options: {
+      backoffBaseMilliseconds: 1_000,
+      backoffMaxMilliseconds: 60_000,
+      backoffJitterRatio: 0.2,
+    },
+  });
+  const { fetcher } = scriptedFetcher<string>([
+    { err: new Error("blip 1") },
+    { err: new Error("blip 2") },
+    { err: new Error("blip 3") },
+    { ok: "recovered" },
+  ]);
+  const errors: unknown[] = [];
+  const results: string[] = [];
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 30_000,
+    fetcher,
+    onResult: (r) => results.push(r),
+    onError: (e) => errors.push(e),
+  });
+  await flushIterations(5);
+  handle.cancel();
+
+  assertEquals(results, ["recovered"]);
+  assertEquals(errors.length, 3);
+  // base * 2^(attempt-1) * 1.0 = 1000, 2000, 4000 then interval after success.
+  assertEquals(clock.sleeps.slice(0, 4), [1_000, 2_000, 4_000, 30_000]);
+});
+
+Deno.test("poll: backoff respects jitter low/high ends", async () => {
+  // Drive jitter at both extremes to confirm clamping.
+  // random()=0 → factor=0.8; random()=0.999 → factor ≈ 1.2.
+  let r = 0;
+  const sequence = [0, 0.999];
+  const { poller, clock } = buildPoller({
+    random: () => sequence[r++ % sequence.length] ?? 0.5,
+    options: {
+      backoffBaseMilliseconds: 1_000,
+      backoffMaxMilliseconds: 60_000,
+      backoffJitterRatio: 0.2,
+    },
+  });
+  const { fetcher } = scriptedFetcher<string>([
+    { err: new Error("a") },
+    { err: new Error("b") },
+    { ok: "c" },
+  ]);
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 30_000,
+    fetcher,
+    onResult: () => {},
+    onError: () => {},
+  });
+  await flushIterations(4);
+  handle.cancel();
+
+  // First failure: factor=0.8 → 800 ms.
+  assertEquals(clock.sleeps[0], 800);
+  // Second failure: factor≈1.2, base*2 = 2000 → ≈ 2_399.something.
+  // We assert the band rather than the exact float to avoid pinning to
+  // the random() cursor's exact return.
+  const second = clock.sleeps[1] ?? 0;
+  assertGreaterOrEqual(second, 2_000 * 0.8);
+  assertLessOrEqual(second, 2_000 * 1.2);
+});
+
+Deno.test("poll: backoff caps at backoffMaxMilliseconds even at deep attempt counts", async () => {
+  const { poller, clock } = buildPoller({
+    random: () => 0.5,
+    options: {
+      backoffBaseMilliseconds: 1_000,
+      backoffMaxMilliseconds: 5_000,
+      backoffJitterRatio: 0,
+    },
+  });
+  const { fetcher } = scriptedFetcher<string>(
+    Array.from({ length: 6 }, () => ({ err: new Error("never") })),
+  );
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 30_000,
+    fetcher,
+    onResult: () => {},
+    onError: () => {},
+  });
+  await flushIterations(7);
+  handle.cancel();
+
+  // 1000, 2000, 4000, 5000 (capped), 5000, 5000.
+  assertEquals(clock.sleeps.slice(0, 6), [1_000, 2_000, 4_000, 5_000, 5_000, 5_000]);
+});
+
+Deno.test("poll: a successful tick resets the backoff series to zero", async () => {
+  const { poller, clock } = buildPoller({
+    random: () => 0.5,
+    options: { backoffJitterRatio: 0 },
+  });
+  const { fetcher } = scriptedFetcher<string>([
+    { err: new Error("a") },
+    { err: new Error("b") },
+    { ok: "ok" },
+    { err: new Error("c") },
+    { ok: "fine" },
+  ]);
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 10_000,
+    fetcher,
+    onResult: () => {},
+    onError: () => {},
+  });
+  await flushIterations(6);
+  handle.cancel();
+
+  // Sleeps: 1000 (fail#1), 2000 (fail#2), interval 10000 (success), 1000
+  // (fail#3 — counter reset), interval 10000 (success).
+  assertEquals(clock.sleeps.slice(0, 5), [1_000, 2_000, 10_000, 1_000, 10_000]);
+});
+
+// ---------------------------------------------------------------------------
+// Fatal error path
+// ---------------------------------------------------------------------------
+
+Deno.test("poll: PollerError(fatal) exits the loop without further calls", async () => {
+  const { poller } = buildPoller();
+  const { fetcher, calls } = scriptedFetcher<string>([
+    { err: new PollerError("fatal", "auth revoked") },
+    { ok: "should-never-fire" },
+  ]);
+  const errors: unknown[] = [];
+  const results: string[] = [];
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 10_000,
+    fetcher,
+    onResult: (r) => results.push(r),
+    onError: (e) => errors.push(e),
+  });
+  await flushIterations(4);
+  handle.cancel();
+
+  assertEquals(calls.length, 1);
+  assertEquals(results, []);
+  assertEquals(errors.length, 1);
+  assertInstanceOf(errors[0], PollerError);
+  assertEquals((errors[0] as PollerError).kind, "fatal");
+});
+
+Deno.test("poll: PollerError(fatal) without onError logs and exits", async () => {
+  const logger = recordingLogger();
+  const { poller } = buildPoller({ logger });
+  const { fetcher, calls } = scriptedFetcher<string>([
+    { err: new PollerError("fatal", "boom") },
+  ]);
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 10_000,
+    fetcher,
+    onResult: () => {},
+  });
+  await flushIterations(2);
+  handle.cancel();
+  assertEquals(calls.length, 1);
+  // Without `onError`, the fatal error funnels into a warn line.
+  const warns = logger.messages.filter((m) => m.includes("fetcher rejected"));
+  assertEquals(warns.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Cancellation
+// ---------------------------------------------------------------------------
+
+Deno.test("poll: cancel() stops the loop and prevents further fetcher calls", async () => {
+  const { poller, clock } = buildPoller();
+  let pending: () => void = () => {};
+  const blockingFetcher = (): Promise<string> => {
+    return new Promise<string>((resolve) => {
+      pending = () => resolve("delayed");
+    });
+  };
+  const calls: number[] = [];
+  let i = 0;
+  const fetcher = (): Promise<string> => {
+    calls.push(i++);
+    if (calls.length === 1) {
+      return Promise.resolve("first");
+    }
+    return blockingFetcher();
+  };
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 1_000,
+    fetcher,
+    onResult: () => {},
+  });
+
+  // Drain the first tick and let the second fetch start blocking.
+  await flushIterations(2);
+  handle.cancel();
+  // Resolve the blocking fetcher to make sure cancel still wins.
+  pending();
+  await flushIterations(2);
+
+  // After cancel: at most the two fetches the first two iterations
+  // launched, and no subsequent ones. The exact number depends on
+  // microtask ordering; we just assert no growth past a small bound.
+  const callsAtCancel = calls.length;
+  await flushIterations(4);
+  assertEquals(calls.length, callsAtCancel);
+  // At least the inter-tick sleep was issued; no need to be exact about
+  // count beyond that.
+  assertGreaterOrEqual(clock.sleeps.length, 1);
+});
+
+Deno.test("poll: cancel() is idempotent", async () => {
+  const { poller } = buildPoller();
+  const { fetcher } = scriptedFetcher([{ ok: 1 }]);
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 1_000,
+    fetcher,
+    onResult: () => {},
+  });
+  await flushIterations(1);
+  handle.cancel();
+  handle.cancel(); // No-op, must not throw.
+});
+
+Deno.test("poll: external AbortSignal triggers cancel", async () => {
+  const { poller, clock } = buildPoller();
+  const controller = new AbortController();
+  const { fetcher, calls } = scriptedFetcher<string>([
+    { ok: "first" },
+    { ok: "second" },
+    { ok: "third" },
+  ]);
+  poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 5_000,
+    fetcher,
+    onResult: () => {},
+    signal: controller.signal,
+  });
+
+  await flushIterations(2);
+  controller.abort();
+  const callsAtAbort = calls.length;
+  await flushIterations(4);
+  assertEquals(calls.length, callsAtAbort);
+  assertGreaterOrEqual(clock.sleeps.length, 1);
+});
+
+Deno.test("poll: already-aborted signal exits without calling fetcher", async () => {
+  const { poller } = buildPoller();
+  const controller = new AbortController();
+  controller.abort();
+  let called = 0;
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 1_000,
+    fetcher: () => {
+      called += 1;
+      return Promise.resolve("ok");
+    },
+    onResult: () => {},
+    signal: controller.signal,
+  });
+  await flushIterations(3);
+  handle.cancel();
+  assertEquals(called, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Single-flight / supersession
+// ---------------------------------------------------------------------------
+
+Deno.test("poll: a second poll() for the same task supersedes the prior loop", async () => {
+  const logger = recordingLogger();
+  const { poller } = buildPoller({ logger });
+  const callsA: number[] = [];
+  const callsB: number[] = [];
+
+  const handleA = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 1_000,
+    fetcher: () => {
+      callsA.push(1);
+      return Promise.resolve("a");
+    },
+    onResult: () => {},
+  });
+  await flushIterations(2);
+  const callsAAtSupersede = callsA.length;
+
+  const handleB = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 1_000,
+    fetcher: () => {
+      callsB.push(1);
+      return Promise.resolve("b");
+    },
+    onResult: () => {},
+  });
+  await flushIterations(3);
+  handleA.cancel();
+  handleB.cancel();
+
+  // Loop A made no further calls after supersession.
+  assertEquals(callsA.length, callsAAtSupersede);
+  // Loop B made at least one.
+  assertGreaterOrEqual(callsB.length, 1);
+  // A warn line was logged about the supersession.
+  const warns = logger.messages.filter((m) => m.includes("superseding"));
+  assertEquals(warns.length, 1);
+});
+
+Deno.test("poll: distinct taskIds run independent loops in parallel", async () => {
+  const { poller } = buildPoller();
+  const callsA: string[] = [];
+  const callsB: string[] = [];
+  const idA = makeTaskId("task_a");
+  const idB = makeTaskId("task_b");
+
+  const hA = poller.poll({
+    taskId: idA,
+    intervalMilliseconds: 1_000,
+    fetcher: () => Promise.resolve("a"),
+    onResult: (r) => callsA.push(r),
+  });
+  const hB = poller.poll({
+    taskId: idB,
+    intervalMilliseconds: 1_000,
+    fetcher: () => Promise.resolve("b"),
+    onResult: (r) => callsB.push(r),
+  });
+  await flushIterations(3);
+  hA.cancel();
+  hB.cancel();
+
+  assertGreaterOrEqual(callsA.length, 1);
+  assertGreaterOrEqual(callsB.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// onResult / onError throw isolation
+// ---------------------------------------------------------------------------
+
+Deno.test("poll: onResult that throws does not stop the loop", async () => {
+  const logger = recordingLogger();
+  const { poller } = buildPoller({ logger });
+  const seen: number[] = [];
+  let calls = 0;
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 1_000,
+    fetcher: () => Promise.resolve(calls++),
+    onResult: (r) => {
+      seen.push(r);
+      if (r === 0) throw new Error("oops");
+    },
+  });
+  await flushIterations(4);
+  handle.cancel();
+  // The loop continued even though onResult threw on tick 0.
+  assertGreaterOrEqual(seen.length, 2);
+  const warns = logger.messages.filter((m) => m.includes("onResult threw"));
+  assertEquals(warns.length, 1);
+});
+
+Deno.test("poll: onError that throws does not stop the loop", async () => {
+  const logger = recordingLogger();
+  const { poller } = buildPoller({
+    logger,
+    options: { backoffJitterRatio: 0, backoffBaseMilliseconds: 1, backoffMaxMilliseconds: 100 },
+  });
+  const { fetcher } = scriptedFetcher<string>([
+    { err: new Error("blip") },
+    { err: new Error("blip") },
+    { ok: "ok" },
+  ]);
+  let throws = 0;
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 1_000,
+    fetcher,
+    onResult: () => {},
+    onError: () => {
+      throws++;
+      throw new Error("oops");
+    },
+  });
+  await flushIterations(5);
+  handle.cancel();
+  assertEquals(throws, 2);
+  const warns = logger.messages.filter((m) => m.includes("onError threw"));
+  assertEquals(warns.length, 2);
+});
+
+Deno.test("poll: rejection without onError logs a warn line", async () => {
+  const logger = recordingLogger();
+  const { poller } = buildPoller({ logger });
+  const { fetcher } = scriptedFetcher<string>([
+    { err: new Error("a") },
+    { ok: "after" },
+  ]);
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 1_000,
+    fetcher,
+    onResult: () => {},
+  });
+  await flushIterations(3);
+  handle.cancel();
+  const warns = logger.messages.filter((m) => m.includes("fetcher rejected"));
+  assertEquals(warns.length, 1);
+});
+
+Deno.test("poll: non-Error rejection is stringified for the warn line", async () => {
+  const logger = recordingLogger();
+  const { poller } = buildPoller({ logger });
+  let i = 0;
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 1_000,
+    fetcher: () => {
+      i++;
+      // Throwing a literal exercises the non-Error branch of stringify.
+      return Promise.reject("stringly typed");
+    },
+    onResult: () => {},
+  });
+  await flushIterations(2);
+  handle.cancel();
+  assertGreaterOrEqual(i, 1);
+  const warn = logger.messages.find((m) => m.includes("stringly typed"));
+  assertEquals(warn !== undefined, true);
+});
+
+// ---------------------------------------------------------------------------
+// Construction-time validation
+// ---------------------------------------------------------------------------
+
+Deno.test("createPoller: rejects non-positive backoffBaseMilliseconds", () => {
+  assertThrows(
+    () => createPoller({ backoffBaseMilliseconds: 0 }),
+    RangeError,
+    "backoffBaseMilliseconds",
+  );
+  assertThrows(
+    () => createPoller({ backoffBaseMilliseconds: -1 }),
+    RangeError,
+    "backoffBaseMilliseconds",
+  );
+  assertThrows(
+    () => createPoller({ backoffBaseMilliseconds: Number.NaN }),
+    RangeError,
+    "backoffBaseMilliseconds",
+  );
+});
+
+Deno.test("createPoller: rejects backoffMaxMilliseconds below the base", () => {
+  assertThrows(
+    () =>
+      createPoller({
+        backoffBaseMilliseconds: 1_000,
+        backoffMaxMilliseconds: 500,
+      }),
+    RangeError,
+    "backoffMaxMilliseconds",
+  );
+});
+
+Deno.test("createPoller: rejects backoffJitterRatio outside [0, 1)", () => {
+  assertThrows(
+    () => createPoller({ backoffJitterRatio: -0.1 }),
+    RangeError,
+    "backoffJitterRatio",
+  );
+  assertThrows(
+    () => createPoller({ backoffJitterRatio: 1 }),
+    RangeError,
+    "backoffJitterRatio",
+  );
+  assertThrows(
+    () => createPoller({ backoffJitterRatio: Number.NaN }),
+    RangeError,
+    "backoffJitterRatio",
+  );
+});
+
+Deno.test("createPoller: defaults survive when no options are passed", () => {
+  // End-to-end no-injection construction proves the default-clock /
+  // default-logger / default-random branches all wire up. We immediately
+  // cancel so nothing reaches the real `setTimeout`.
+  const poller = createPoller();
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 5,
+    fetcher: () => Promise.resolve("x"),
+    onResult: () => {},
+  });
+  handle.cancel();
+});
+
+// ---------------------------------------------------------------------------
+// Default clock coverage (one real-time pass)
+// ---------------------------------------------------------------------------
+
+Deno.test("default clock: real setTimeout-backed sleep cancels promptly on abort", async () => {
+  // The only test that exercises the default `setTimeout`-backed clock.
+  // We use a microsecond-scale interval and abort almost immediately so
+  // the test still runs in well under a millisecond on real time. The
+  // inner `setTimeout` is not blocking the daemon — it would `unref`
+  // anyway — so `Deno.test` does not flag a leak.
+  const poller = createPoller(); // Uses the default clock.
+  const calls: number[] = [];
+  const controller = new AbortController();
+  const handle = poller.poll({
+    taskId: makeTaskId("task_default_clock"),
+    intervalMilliseconds: 50_000, // Large enough that abort would race.
+    fetcher: () => {
+      calls.push(1);
+      return Promise.resolve("x");
+    },
+    onResult: () => {},
+    signal: controller.signal,
+  });
+  // Yield once to let the first fetcher() run, then abort and cancel.
+  await flushIterations(2);
+  controller.abort();
+  handle.cancel();
+  // After cancellation no further calls happen even if we wait briefly.
+  await flushIterations(4);
+  assertGreaterOrEqual(calls.length, 1);
+});
+
+Deno.test("default clock: already-aborted signal at sleep entry resolves immediately", async () => {
+  // Arrange a fetcher that succeeds, then abort *before* the sleep would
+  // start. We assert the loop ends without scheduling a real timer. This
+  // covers the `signal?.aborted === true` early-resolve branch in the
+  // default clock's `sleep` factory.
+  const poller = createPoller();
+  const controller = new AbortController();
+  let calls = 0;
+  poller.poll({
+    taskId: makeTaskId("task_pre_aborted_sleep"),
+    intervalMilliseconds: 60_000,
+    fetcher: () => {
+      calls++;
+      // Abort synchronously inside the fetcher so the post-tick sleep
+      // sees an already-aborted signal.
+      queueMicrotask(() => controller.abort());
+      return Promise.resolve("x");
+    },
+    onResult: () => {},
+    signal: controller.signal,
+  });
+  await flushIterations(6);
+  assertGreaterOrEqual(calls, 1);
+});
+
+// ---------------------------------------------------------------------------
+// PollerError shape sanity
+// ---------------------------------------------------------------------------
+
+Deno.test("PollerError: kinds catalog matches POLLER_ERROR_KINDS", () => {
+  assertEquals([...POLLER_ERROR_KINDS], ["rate-limited", "fatal"]);
+});
+
+Deno.test("PollerError: chains cause via Error.cause", () => {
+  const cause = new Error("underlying");
+  const err = new PollerError("fatal", "wrapped", { cause });
+  assertEquals(err.message, "wrapped");
+  assertEquals(err.kind, "fatal");
+  assertStrictEquals((err as Error).cause, cause);
+});
+
+Deno.test("PollerError: rate-limited carries retryAfterMs", () => {
+  const err = new PollerError("rate-limited", "wait", { retryAfterMs: 1_500 });
+  assertEquals(err.retryAfterMs, 1_500);
+});
+
+// ---------------------------------------------------------------------------
+// Defaults from constants are visible at construction time
+// ---------------------------------------------------------------------------
+
+Deno.test("createPoller: defaults match the exported constants", () => {
+  // Indirect: build a poller with the defaults, then drive it with a
+  // jitter=0 override only. The first failure sleep should equal the
+  // exported BASE constant.
+  const clock = new RecordingClock();
+  const logger = recordingLogger();
+  const poller = createPoller({
+    clock,
+    logger,
+    random: () => 0.5,
+    backoffJitterRatio: 0,
+  });
+  const handle = poller.poll({
+    taskId: TASK,
+    intervalMilliseconds: 30_000,
+    fetcher: () => Promise.reject(new Error("a")),
+    onResult: () => {},
+    onError: () => {},
+  });
+  // Drain one full tick and cancel.
+  return flushIterations(2).then(() => {
+    handle.cancel();
+    assertEquals(clock.sleeps[0], POLLER_BACKOFF_BASE_MILLISECONDS);
+    // Sanity: max constant matches what the module exports too.
+    assertGreaterOrEqual(POLLER_BACKOFF_MAX_MILLISECONDS, POLLER_BACKOFF_BASE_MILLISECONDS);
+    // Jitter constant is in the documented band.
+    assertGreaterOrEqual(POLLER_BACKOFF_JITTER_RATIO, 0);
+  });
+});

--- a/tests/unit/poller_test.ts
+++ b/tests/unit/poller_test.ts
@@ -46,6 +46,7 @@ import {
 } from "../../src/constants.ts";
 import {
   createPoller,
+  defaultClock,
   POLLER_ERROR_KINDS,
   PollerError,
   type PollerOptions,
@@ -880,6 +881,57 @@ Deno.test("default clock: already-aborted signal at sleep entry resolves immedia
   });
   await flushIterations(6);
   assertGreaterOrEqual(calls, 1);
+});
+
+Deno.test("default clock: abort fired between entry-check and addEventListener still resolves immediately", async () => {
+  // Regression for the abort-race. The default clock reads
+  // `signal.aborted` once on entry and then attaches a listener; if an
+  // abort lands in the synchronous gap between those two operations,
+  // the listener will never fire (AbortSignal does not replay aborts
+  // for already-aborted signals). The fix re-checks `signal.aborted`
+  // *after* attaching the listener, so this case must resolve early
+  // rather than waiting the full `wait` duration.
+  //
+  // We can not exercise this race with a real `AbortSignal` because no
+  // attacker code runs between the two synchronous lines inside the
+  // executor. We exercise it with a `PollerSleepAbort` double whose
+  // `aborted` reads `false` for the entry check and flips to `true`
+  // exactly when `addEventListener` is invoked — modeling the race
+  // window — and which intentionally never *calls* the listener (the
+  // exact missed-replay symptom the bug describes).
+  const clock = defaultClock();
+  let aborted = false;
+  let listenerInvocations = 0;
+  const racingSignal: PollerSleepAbort = {
+    get aborted(): boolean {
+      return aborted;
+    },
+    addEventListener(_type: "abort", listener: () => void): void {
+      // Flip to aborted *during* registration, but do not deliver the
+      // event — exactly the missed-replay scenario.
+      aborted = true;
+      // Track listener calls so we can assert the post-attach re-check
+      // path drove the resolution (not a stray future delivery).
+      void listener;
+    },
+    removeEventListener(_type: "abort", _listener: () => void): void {
+      listenerInvocations++;
+    },
+  };
+  // Picked far longer than the test runner's slowest reasonable
+  // resolution so a wait-the-full-duration regression would be obvious
+  // (the test would hang on the runner's hard timeout). On the fixed
+  // path the sleep resolves on the next microtask via the post-attach
+  // re-check.
+  const start = Date.now();
+  await clock.sleep(60_000, racingSignal);
+  const elapsed = Date.now() - start;
+  // The post-attach re-check must have triggered the cleanup path,
+  // which `removeEventListener`s the listener exactly once.
+  assertEquals(listenerInvocations, 1);
+  // The whole sleep must complete promptly — orders of magnitude
+  // faster than the requested 60 s wait.
+  assertLessOrEqual(elapsed, 1_000);
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/poller_test.ts
+++ b/tests/unit/poller_test.ts
@@ -8,9 +8,9 @@
  * `PollerOptions.clock`. Per the Wave 2 lessons, the tests never call
  * `mock.install` on `Date.now`, `setTimeout`, `Deno.env`, or any other
  * process-global. A test that wants the default-clock branch exercised
- * for coverage uses a microsecond-scale interval against the real clock,
- * cancelled before the next tick — that is the *only* place the file
- * touches real time.
+ * for coverage runs against the real clock and cancels almost
+ * immediately so the configured interval is irrelevant — that is the
+ * *only* place the file touches real time.
  *
  * Coverage map:
  *
@@ -829,10 +829,12 @@ Deno.test("createPoller: defaults survive when no options are passed", () => {
 
 Deno.test("default clock: real setTimeout-backed sleep cancels promptly on abort", async () => {
   // The only test that exercises the default `setTimeout`-backed clock.
-  // We use a microsecond-scale interval and abort almost immediately so
-  // the test still runs in well under a millisecond on real time. The
-  // inner `setTimeout` is not blocking the daemon — it would `unref`
-  // anyway — so `Deno.test` does not flag a leak.
+  // We pass a deliberately large 50 s `intervalMilliseconds` and abort
+  // almost immediately so the test still finishes in well under a
+  // millisecond on real time — the speed comes from the abort path
+  // resolving the pending sleep, not from a small interval. The inner
+  // `setTimeout` is not blocking the daemon — it would `unref` anyway —
+  // so `Deno.test` does not flag a leak.
   const poller = createPoller(); // Uses the default clock.
   const calls: number[] = [];
   const controller = new AbortController();


### PR DESCRIPTION
## Summary

- One timer per task with single-flight `poll(...)` loop in `src/daemon/poller.ts`; spaces successful ticks by `intervalMilliseconds` (default `POLL_INTERVAL_MILLISECONDS`), honors `PollerError(kind: "rate-limited", retryAfterMs)`, applies exponential backoff + jitter on transient rejections, and exits cleanly on `cancel()` or `AbortSignal.abort()`.
- `PollerError` carries the discriminated `"rate-limited" | "fatal"` taxonomy from ADR-015; plain `Error` rejections take the exponential path. Failure counter resets on the next successful tick.
- Synthetic clock seam (`PollerClock`) so tests never touch `Date.now`/`setTimeout` process-globally; default clock uses `setTimeout` and resolves early on `AbortSignal.abort()`.
- ADR-015 captures the cadence, taxonomy, and clock-injection contract.

Closes #13.

## Test plan

- [x] `deno task ci` green locally (fmt, lint, doc:lint, type-check, tests, coverage gate, smoke build).
- [x] 32 new unit tests covering cadence, header-driven backoff, exponential backoff (with jitter band assertions), fatal exit, cancel/signal/already-aborted/supersession paths, onResult/onError isolation, and construction-time validation.
- [x] `src/daemon/poller.ts` coverage: 87.9% lines / 93.9% branches / 91.3% functions (over the 80% gate).
- [ ] Remote CI green.
- [ ] Copilot review clean (re-request review until merged or unresolved comments addressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)