### PR TITLE
feat(#11): AgentRunner wrapping @anthropic-ai/claude-agent-sdk

### DIFF
--- a/docs/adrs/015-agent-runner-sdk-projection.md
+++ b/docs/adrs/015-agent-runner-sdk-projection.md
@@ -1,0 +1,157 @@
+# ADR-015: AgentRunner — narrow SDK projection, append-mode system prompt, structural query injection
+
+## Status
+
+Accepted (2026-04-26).
+
+## Context
+
+Issue #11 (Wave 3) ships `src/daemon/agent-runner.ts`, the supervisor's only entry point into the
+Claude Agent SDK. The runner wraps `query()` from `@anthropic-ai/claude-agent-sdk`, streams
+`SDKMessage`s as `TaskEvent`s onto the event bus, and persists the SDK-assigned `sessionId` so the
+supervisor can carry model context across CI / review / rebase iterations.
+
+Three load-bearing design questions came up during implementation that warrant pinning down before
+the supervisor (#12), the stabilize loop (Wave 4), or any future agent-side work depends on the
+runner's exact contract:
+
+1. **What shape does the runner expose to the rest of the daemon?** The SDK's `SDKMessage` is a wide
+   discriminated union (28+ variants — `assistant`, `user`, `result`, `system/init`,
+   `tool_progress`, `task_started`, …) backed by a multi-megabyte native CLI binary per platform.
+   The supervisor doesn't need most of that surface; the TUI definitely doesn't.
+2. **How does the runner inject the conventional-commits commit-message contract** (ADR-009) into
+   the agent's behavior without rewriting the SDK's preset system prompt?
+3. **How do tests drive the runner without spawning the real `claude` CLI subprocess?** Wave 2's
+   `tests/helpers/mock_agent_runner.ts` already addresses the supervisor side; this ADR is about the
+   runner module itself.
+
+The W1 contract in `src/types.ts` froze the `AgentRunner` interface at
+`runAgent(...) → AsyncIterable<AgentRunnerMessage>` where `AgentRunnerMessage = { role, text }`.
+That is a deliberately narrow projection of `SDKMessage`. This ADR captures the rationale for the
+projection plus two implementation decisions made on top of it.
+
+## Decision
+
+### 1. Narrow SDK projection: `AgentRunnerMessage = { role, text }`
+
+The runner adapts the SDK's `SDKMessage` into the W1 `AgentRunnerMessage` shape and **never lets the
+SDK type leak past its own module boundary**. Concretely:
+
+- `assistant` messages: concatenate every `text` block; emit `tool_use` blocks as a single line of
+  the form `[tool <name>] <json input>`. The `text` projection is what the TUI's transcript shows;
+  the `role` is `"assistant"`.
+- `user` messages: concatenate every `text` block. The `role` is `"user"`.
+- `result` messages: take the final `result` string. The `role` is `"system"` (the supervisor never
+  branches on `result`; it wants the text on the bus and the session id captured).
+- `tool_use` standalone messages: `role` `"tool-use"`, `text` rendered the same way as the embedded
+  tool block.
+- `tool_result` standalone messages: `role` `"tool-result"`.
+- Everything else (`system/init`, `tool_progress`, `task_started`, `task_updated`, …): `role`
+  `"system"`, `text` the SDK type wrapped in square brackets (`[task_progress]`). The discriminant
+  alone is more useful than nothing, and the supervisor never branches on these variants today.
+
+The projection is implemented inside the agent-runner module so a future SDK release that adds new
+`SDKMessage` variants is absorbed by extending `mapSdkTypeToRole` and `renderSdkMessageText` locally
+— no change to `AgentRunnerMessage`, no propagation to the supervisor, the persistence layer, or the
+TUI. **The W1 contract surface is the seam; the SDK is hidden behind it.**
+
+The truncation budget on the bus side is `AGENT_MESSAGE_TEXT_TRUNCATION_CODE_UNITS = 8192`. Long
+tool inputs and long outputs would otherwise balloon every subscriber's queue depth, run subscribers
+up against `EVENT_BUS_DEFAULT_BUFFER_SIZE = 256` more often, and bloat persistence snapshots that
+include recent events. Eight kilobytes is generous for the supervisor's prose-and-summary workload
+while still bounding pathological cases. Truncated text is suffixed with `…` so consumers can tell
+rendering from a hard cap.
+
+### Alternatives considered
+
+- **Pass `SDKMessage` through verbatim.** Rejected. Two concrete costs: the supervisor and the TUI
+  pull in the SDK's full type definitions (multi-thousand lines of d.ts) just to discriminate on
+  `type`; new SDK variants land as breaking type changes for every consumer rather than being
+  absorbed locally.
+- **Per-variant projections** (e.g. `AgentToolUseMessage`, `AgentResultMessage`). Rejected. The
+  consumers don't branch on the variant — they render the text and log the role. A finer projection
+  is solving a problem we don't have, and it makes the bus-event payload's discriminator harder to
+  type.
+
+### 2. System-prompt addendum via the SDK's `append` field
+
+The supervisor passes the GitHub issue number; the runner builds an addendum that instructs the
+agent to author commits in `<type>(#<issueNumber>): <subject>` Conventional Commits format (ADR-009)
+and forwards it via `Options.systemPrompt = { type: 'preset', preset: 'claude_code',
+append: ... }`.
+The exact wording is unit-tested by snapshot in `tests/unit/agent_runner_test.ts` so silent drift is
+caught on every PR.
+
+The decision rationale:
+
+- **`append` over `customSystemPrompt`.** The SDK's `customSystemPrompt` (now
+  `systemPrompt: string
+  | string[]`) replaces the default Claude Code prompt entirely. We want the
+  model to retain every piece of CLI-shipped guidance (tool-use protocol, Bash safety, file-edit
+  conventions); we are only adding one constraint. `append` does exactly that and keeps the static
+  prefix prompt-cacheable across runs.
+- **Issue number formatted into the addendum, not into `extraArgs`.** The runner is responsible for
+  the conventional-commits contract; the supervisor passes the number through `runAgent`'s
+  `issueNumber` argument and never has to hand-format the prompt itself.
+- **Snapshot-tested wording.** A small text drift (a different word, a missing example) is the kind
+  of regression that doesn't fail the build but fails the agent at commit time. The snapshot is the
+  cheapest line of defense.
+
+### 3. Structural query injection for tests; lazy SDK import in production
+
+The factory accepts an `opts.query` parameter typed as `SdkQueryFunction`, a structural projection
+of the SDK's real `query` signature. Tests pass a scripted stub that yields a controlled stream of
+`SdkMessageProjection` values; production code leaves `opts.query` undefined and the runner _lazily
+imports_ `@anthropic-ai/claude-agent-sdk` on first use, memoizing the import.
+
+The rationale:
+
+- **No global mutation in tests** (Wave 2 lessons learned #3). We could have wrapped the SDK in a
+  module-scope binding and reassigned it in tests; that's the kind of cross-test contamination the
+  W2 review rounds rejected. Constructor injection keeps the substitute strictly scoped.
+- **Lazy import.** The SDK's npm package brings a per-platform native binary
+  (`claude-agent-sdk-darwin-arm64`, `…-linux-x64-musl`, …). Eagerly importing it on module load
+  would extend the daemon's startup time and load native code on every test that touches
+  `src/daemon/agent-runner.ts` even if it doesn't reach the SDK code path. Lazy + memoized cuts the
+  cost.
+- **Executable discovery is also injectable.** `opts.resolveExecutable` defaults to a thin
+  `Deno.Command("which", [name])` wrapper; tests pass a stub. Same rationale: no `Deno.Command`
+  override, no race with sibling tests, no platform-specific harness setup.
+
+### Alternatives considered
+
+- **Wrap `query` in a module-scope mutable**
+  (`let queryImpl = realQuery; export function
+  setQueryForTests(...)`). Rejected. Lessons learned
+  #3: global mutation in tests caused 8 review rounds across W2.
+- **Subprocess-mock the `claude` binary directly.** Rejected. The SDK's process management is
+  intricate (stdin/stdout framing, MCP, hooks, lifecycle messages); a mock binary that satisfies
+  every check would be more code than the runner itself, and it would not exercise the unit's real
+  responsibility (adapting the SDK projection onto the bus). The integration test already covers the
+  real-binary path behind `AGENT_RUNNER_REAL_TEST=1`.
+
+## Consequences
+
+- The supervisor and TUI consume `AgentRunnerMessage` exclusively. Adding new SDK variants is a
+  one-file change inside the runner.
+- The agent's commit format is a snapshot-tested invariant. Any future change to the wording (e.g.
+  expanding the type list or relaxing the subject limit) is a deliberate, reviewable diff.
+- The runner is testable without spawning a subprocess. The unit test suite in
+  `tests/unit/agent_runner_test.ts` runs in milliseconds and exercises every adapter branch.
+- The integration test in `tests/integration/agent_runner_real_test.ts` is opt-in via
+  `AGENT_RUNNER_REAL_TEST=1`. CI does not run it by default; an operator who installs the `claude`
+  CLI on their host can flip the gate to validate the production path.
+- A future SDK release that renames `query()` or breaks the `Options` shape will fail the lazy
+  import or the structural type check at first use. The runner surfaces this through
+  `AgentRunnerError.operation = "loadSdk"` so the diagnostic is precise.
+
+## References
+
+- `src/daemon/agent-runner.ts` — implementation.
+- `src/types.ts` — frozen `AgentRunner` and `AgentRunnerMessage` contracts.
+- `tests/unit/agent_runner_test.ts` — adapter branches, snapshot, error paths.
+- `tests/integration/agent_runner_real_test.ts` — gated end-to-end run.
+- ADR-009 (`docs/adrs/009-conventional-commits-and-git-cliff.md`) — commit format the addendum
+  enforces.
+- ADR-012 (`docs/adrs/012-event-bus-backpressure-and-sync-callbacks.md`) — backpressure model the
+  runner publishes against.

--- a/docs/adrs/015-agent-runner-sdk-projection.md
+++ b/docs/adrs/015-agent-runner-sdk-projection.md
@@ -28,7 +28,11 @@ runner's exact contract:
 The W1 contract in `src/types.ts` froze the `AgentRunner` interface at
 `runAgent(...) → AsyncIterable<AgentRunnerMessage>` where `AgentRunnerMessage = { role, text }`.
 That is a deliberately narrow projection of `SDKMessage`. This ADR captures the rationale for the
-projection plus two implementation decisions made on top of it.
+projection plus two implementation decisions made on top of it. Note: issue scoping (the
+`issueNumber` the supervisor passes) is **not** part of the frozen `AgentRunner` contract; the
+runner exposes it on a widened `RunAgentArgs` and treats it as optional so the implementation
+remains assignable to the W1 interface (see "System-prompt addendum" below for the degraded
+rendering when `issueNumber` is absent).
 
 ## Decision
 
@@ -93,6 +97,13 @@ The decision rationale:
 - **Issue number formatted into the addendum, not into `extraArgs`.** The runner is responsible for
   the conventional-commits contract; the supervisor passes the number through `runAgent`'s
   `issueNumber` argument and never has to hand-format the prompt itself.
+- **`issueNumber` is _optional_ on `RunAgentArgs`.** The W1 `AgentRunner` interface in
+  `src/types.ts` does not include `issueNumber`; making the field required on `RunAgentArgs` would
+  break the assignability `AgentRunnerImpl extends AgentRunner` claims. So the field is optional and
+  the runner degrades gracefully: when omitted, `buildSystemPromptAddendum()` drops the `(#<n>)`
+  scope and renders the format as `<type>: <subject>`. The supervisor (the only production caller)
+  always passes the issue number; the optional shape exists so a generic `AgentRunner` consumer
+  cannot accidentally produce a `#undefined` literal in the prompt.
 - **Snapshot-tested wording.** A small text drift (a different word, a missing example) is the kind
   of regression that doesn't fail the build but fails the agent at commit time. The snapshot is the
   cheapest line of defense.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -295,3 +295,22 @@ export const POLLER_BACKOFF_EXPONENT_RADIX = 2;
  * See {@link https://github.com/koraytaylan/makina/blob/develop/docs/adrs/017-poller-cadence-and-backoff.md ADR-017}.
  */
 export const POLLER_BACKOFF_JITTER_WINDOW_MULTIPLIER = 2;
+
+/**
+ * Truncation budget applied to `agent-message` payloads before they are
+ * published on the event bus, in UTF-16 code units.
+ *
+ * The Claude Agent SDK can emit very large `assistant` blobs (long tool
+ * inputs, multi-page command outputs). Forwarding the full text onto the
+ * bus would balloon every subscriber's queue depth, run subscribers up
+ * against {@link EVENT_BUS_DEFAULT_BUFFER_SIZE} more often, and bloat
+ * persistence snapshots that include recent events. Eight kilobytes is
+ * generous for the supervisor's prose-and-summary workload while still
+ * bounding pathological cases. Truncated text is suffixed with an
+ * ellipsis token so consumers can tell rendering from a hard cap.
+ *
+ * The cut is by code units (matching `String.prototype.slice`), which is
+ * good enough for the ASCII-heavy agent stream and tolerated by the TUI's
+ * Ink renderer when a surrogate pair lands on the boundary.
+ */
+export const AGENT_MESSAGE_TEXT_TRUNCATION_CODE_UNITS = 8_192;

--- a/src/daemon/agent-runner.ts
+++ b/src/daemon/agent-runner.ts
@@ -1,0 +1,809 @@
+/**
+ * daemon/agent-runner.ts — wraps `query()` from
+ * `npm:@anthropic-ai/claude-agent-sdk` and surfaces a deterministic,
+ * supervisor-friendly streaming interface.
+ *
+ * The supervisor (Wave 3) drives every agent iteration through this module:
+ *
+ *  1. Mint or recover a {@link Task}'s `sessionId`.
+ *  2. Call {@link AgentRunnerImpl.runAgent} with the per-task
+ *     {@link Task.worktreePath} pinned as `cwd`.
+ *  3. Iterate the returned async iterable. Each yielded
+ *     {@link AgentRunnerMessage} is also published onto the injected
+ *     {@link EventBus} as a `task-event` of kind `agent-message`,
+ *     **tagged with the same {@link TaskId}** so TUI subscribers can
+ *     correlate.
+ *  4. Persist {@link AgentRunResult.sessionId} after the iterable settles
+ *     and pass it back on subsequent calls so model context carries
+ *     forward across the CI / review / rebase loop.
+ *
+ * **Auto-discovery.** The Claude Code CLI binary is resolved once per
+ * factory via `which claude` (the path can be overridden through
+ * {@link AgentRunnerOptions.pathToClaudeCodeExecutable}). Discovery is
+ * lazy: the first `runAgent` call awaits the lookup, subsequent calls
+ * reuse the memoized path. If `claude` is not on PATH and no override was
+ * passed, the call rejects with an {@link AgentRunnerError} carrying a
+ * remediation hint.
+ *
+ * **System-prompt addendum.** The runner appends a short paragraph to the
+ * SDK preset's system prompt (via the `append` field of `systemPrompt`)
+ * that instructs the agent to author commits in the
+ * `<type>(#<issueNumber>): <subject>` Conventional Commits format that
+ * Wave 0's {@link https://github.com/koraytaylan/makina/blob/develop/docs/adrs/009-conventional-commits-and-git-cliff.md ADR-009}
+ * standardises across the codebase. The supervisor passes the issue
+ * number; the runner formats the addendum.
+ *
+ * **Session resumption.** When `sessionId` is provided to `runAgent`, the
+ * runner forwards it as `Options.resume` so the SDK reattaches to the
+ * persisted JSONL session. The first message that arrives carries the
+ * SDK-assigned `session_id`, which the runner returns to the caller via
+ * {@link AgentRunResult.sessionId}.
+ *
+ * **Test seam.** The factory accepts an optional `query` injection so unit
+ * tests drive the runner against a scripted async iterable instead of
+ * spawning the real CLI subprocess. The integration test in
+ * `tests/integration/agent_runner_real_test.ts` exercises the production
+ * path end-to-end and is gated behind `AGENT_RUNNER_REAL_TEST=1`.
+ *
+ * @module
+ */
+
+import { getLogger } from "@std/log";
+
+import { AGENT_MESSAGE_TEXT_TRUNCATION_CODE_UNITS } from "../constants.ts";
+import type {
+  AgentRunner,
+  AgentRunnerMessage,
+  EventBus,
+  IssueNumber,
+  TaskEvent,
+  TaskId,
+} from "../types.ts";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Narrow projection of `SDKMessage` from `@anthropic-ai/claude-agent-sdk`.
+ *
+ * The SDK's `SDKMessage` is a wide discriminated union (28+ variants:
+ * `assistant`, `user`, `result`, `system/init`, `tool_progress`, …). The
+ * runner only consumes the few fields below; defining the structural type
+ * here means tests can drive the runner with a scripted iterable without
+ * importing the SDK from the test graph (the SDK ships a multi-megabyte
+ * native binary per platform).
+ *
+ * The `type` discriminant matches the SDK's wire-level field; the runner
+ * preserves it verbatim so the TUI can dispatch on it. Any field the
+ * runner does not use is permitted via the index signature so a richer
+ * SDK message still satisfies the type at the call site.
+ */
+export interface SdkMessageProjection {
+  /**
+   * SDK-level discriminant. The values used by the runner today are
+   * `"assistant"`, `"user"`, `"result"`, `"system"`,
+   * `"tool_progress"`, and `"tool_use_summary"`; any other string is
+   * tolerated and surfaces as a `system` agent-message kind.
+   */
+  readonly type: string;
+  /** SDK-assigned session id; populated on every message. */
+  readonly session_id?: string;
+  /**
+   * The model's response payload for `type === "assistant"` messages.
+   * Mirrors the SDK's `BetaMessage` shape; only `content` is consumed.
+   */
+  readonly message?: {
+    readonly content?: ReadonlyArray<SdkContentBlockProjection>;
+  };
+  /**
+   * The user's payload for `type === "user"` messages. Mirrors the SDK's
+   * `MessageParam` shape; only `content` is consumed.
+   */
+  readonly result?: string;
+  /** Free-form fields that may exist on richer SDK message variants. */
+  readonly [key: string]: unknown;
+}
+
+/**
+ * One content block inside an assistant message. Only `text` and
+ * `tool_use` blocks contribute to the rendered text projection; everything
+ * else is ignored.
+ */
+export interface SdkContentBlockProjection {
+  /** Block discriminant: `"text"`, `"tool_use"`, etc. */
+  readonly type: string;
+  /** Rendered text for `text` blocks. */
+  readonly text?: string;
+  /** Tool name for `tool_use` blocks. */
+  readonly name?: string;
+  /** Tool input for `tool_use` blocks. */
+  readonly input?: unknown;
+}
+
+/**
+ * Subset of the SDK's `Options` surface the runner forwards to `query()`.
+ *
+ * The runner only sets the fields it needs; everything else is left at the
+ * SDK default. The shape is intentionally structural so a stub `query`
+ * implementation in tests can match it without importing the SDK.
+ */
+export interface SdkQueryOptions {
+  /** Working directory for the agent. */
+  readonly cwd: string;
+  /** JavaScript runtime executing Claude Code. */
+  readonly executable: "deno" | "node" | "bun";
+  /** Permission mode applied to tool calls. */
+  readonly permissionMode: "default" | "acceptEdits" | "bypassPermissions" | "plan" | "dontAsk";
+  /** Anthropic model id, e.g. `"claude-sonnet-4-6"`. */
+  readonly model: string;
+  /** Resolved path to the `claude` CLI binary. */
+  readonly pathToClaudeCodeExecutable: string;
+  /** SDK session id to resume from, when present. */
+  readonly resume?: string;
+  /** System-prompt configuration; the runner appends the commit-format addendum. */
+  readonly systemPrompt: {
+    readonly type: "preset";
+    readonly preset: "claude_code";
+    readonly append: string;
+  };
+}
+
+/**
+ * Structural projection of the SDK's `query()` function. Tests pass a stub
+ * matching this shape; production code passes the SDK's real `query`.
+ *
+ * The return value is iterated as an `AsyncIterable<SdkMessageProjection>`.
+ * The SDK's `Query` extends `AsyncGenerator<SDKMessage, void>`, which
+ * trivially satisfies this signature.
+ */
+export type SdkQueryFunction = (params: {
+  readonly prompt: string;
+  readonly options: SdkQueryOptions;
+}) => AsyncIterable<SdkMessageProjection>;
+
+/**
+ * Construction options for {@link createAgentRunner}.
+ */
+export interface AgentRunnerOptions {
+  /** Event bus to publish `agent-message` events onto. */
+  readonly eventBus: EventBus;
+  /**
+   * Override the path to the `claude` CLI binary. When omitted, the
+   * runner discovers it via `which claude` on the first call and memoizes
+   * the result.
+   */
+  readonly pathToClaudeCodeExecutable?: string;
+  /**
+   * Inject the SDK's `query` function. Production code leaves this
+   * undefined and the factory imports the real `query` from
+   * `@anthropic-ai/claude-agent-sdk` the first time a run starts.
+   *
+   * Tests pass a scripted stub so no real subprocess is spawned.
+   */
+  readonly query?: SdkQueryFunction;
+  /**
+   * Inject the `which`-style executable resolver. The default uses
+   * `Deno.Command("which", [name])`; tests pass a stub that returns a
+   * synthetic path (or rejects with `Deno.errors.NotFound` to drive the
+   * "claude not on PATH" branch). Always preferred over global mutation
+   * (lessons learned #3).
+   */
+  readonly resolveExecutable?: ExecutableResolver;
+  /**
+   * Logger used for non-fatal warnings (e.g. an event-bus publish that
+   * threw because a subscriber misbehaved). Defaults to `getLogger()`
+   * from `@std/log`, adapted to the {@link AgentRunnerLogger} surface.
+   */
+  readonly logger?: AgentRunnerLogger;
+  /**
+   * Wall-clock source used to stamp event-bus publishes. Defaults to
+   * `() => new Date().toISOString()`. Tests inject a deterministic clock
+   * to keep snapshots stable.
+   */
+  readonly nowIso?: () => string;
+}
+
+/**
+ * Resolves an executable name to an absolute path, mirroring the success
+ * subset of POSIX `which(1)`.
+ */
+export type ExecutableResolver = (name: string) => Promise<string>;
+
+/**
+ * Narrow logger surface used by the agent runner. The `@std/log` `Logger`
+ * class satisfies this shape (its `warn` accepts a string), but the
+ * narrower interface lets tests inject a recording double without
+ * matching the SDK's full overload signature.
+ */
+export interface AgentRunnerLogger {
+  /** Emit a warning. */
+  warn(message: string): void;
+}
+
+/**
+ * Arguments accepted by {@link AgentRunnerImpl.runAgent}.
+ *
+ * Mirrors the {@link AgentRunner.runAgent} contract from `src/types.ts`
+ * and adds `issueNumber`, which the runner uses to format the
+ * conventional-commits system-prompt addendum.
+ */
+export interface RunAgentArgs {
+  /** Task this run belongs to; events are published tagged with this id. */
+  readonly taskId: TaskId;
+  /** GitHub issue number; embedded into the system-prompt addendum. */
+  readonly issueNumber: IssueNumber;
+  /** Absolute path of the per-task git worktree; pinned as `cwd`. */
+  readonly worktreePath: string;
+  /** Prompt to send to the model. */
+  readonly prompt: string;
+  /**
+   * SDK session id to resume; omit on the first iteration of a task. The
+   * runner returns the SDK-assigned session id via the resolved
+   * {@link AgentRunResult}.
+   */
+  readonly sessionId?: string;
+  /** Anthropic model id, e.g. `"claude-sonnet-4-6"`. */
+  readonly model: string;
+}
+
+/**
+ * Settled result of a `runAgent` call.
+ *
+ * Returned by {@link AgentRunnerImpl.runAgent} once the async iterable is
+ * exhausted. The supervisor stores `sessionId` on the {@link Task} so the
+ * next iteration can resume.
+ */
+export interface AgentRunResult {
+  /**
+   * SDK-assigned session id observed during the run. Present when at
+   * least one SDK message carrying a `session_id` was observed; absent
+   * when the SDK rejected before producing any message (e.g. the `claude`
+   * binary is missing — the SDK emits a single `result/error` first; we
+   * still surface its session id when present).
+   */
+  readonly sessionId?: string;
+  /** Number of SDK messages observed across the run. */
+  readonly messageCount: number;
+}
+
+/**
+ * Concrete return type of {@link createAgentRunner}.
+ *
+ * Widens the W1 {@link AgentRunner} contract with a `runAndCollect`
+ * helper that exhausts the iterable and returns the
+ * {@link AgentRunResult} so the supervisor never has to manage the
+ * `sessionId` plumbing twice.
+ */
+export interface AgentRunnerImpl extends AgentRunner {
+  /**
+   * Run the agent and return the settled {@link AgentRunResult}.
+   *
+   * Equivalent to iterating {@link AgentRunner.runAgent} to exhaustion and
+   * tracking the last observed SDK session id; the helper exists so the
+   * supervisor's hot path is one call.
+   *
+   * @param args Run arguments. See {@link RunAgentArgs}.
+   * @returns Resolves with the SDK session id (when observed) and the
+   *   total message count.
+   * @throws {AgentRunnerError} when the SDK rejects, the executable cannot
+   *   be discovered, or the runner is asked to run with empty arguments.
+   *
+   * @example
+   * ```ts
+   * const runner = createAgentRunner({ eventBus });
+   * const result = await runner.runAndCollect({
+   *   taskId,
+   *   issueNumber: makeIssueNumber(42),
+   *   worktreePath: "/var/lib/makina/worktrees/owner__name/issue-42",
+   *   prompt: "Implement the feature.",
+   *   model: "claude-sonnet-4-6",
+   * });
+   * task.sessionId = result.sessionId;
+   * ```
+   */
+  runAndCollect(args: RunAgentArgs): Promise<AgentRunResult>;
+
+  /**
+   * Run the agent. Yields the SDK messages as they arrive, also
+   * publishing each one onto the {@link EventBus} as an `agent-message`
+   * tagged with `args.taskId`.
+   *
+   * The yielded messages are the runner's structural projection of the
+   * SDK type — the supervisor and the TUI never see the raw SDK shape.
+   *
+   * @param args Run arguments. See {@link RunAgentArgs}.
+   * @returns Async iterable of {@link AgentRunnerMessage}s.
+   * @throws {AgentRunnerError} when the SDK rejects, the executable cannot
+   *   be discovered, or the runner is asked to run with empty arguments.
+   */
+  runAgent(args: RunAgentArgs): AsyncIterable<AgentRunnerMessage>;
+}
+
+/**
+ * Domain error raised when the runner cannot complete a `runAgent` call.
+ *
+ * Wraps the underlying cause (executable lookup failure, SDK exception)
+ * and carries the operation name plus the offending field so the
+ * supervisor can render a precise event without unpacking the cause
+ * chain.
+ */
+export class AgentRunnerError extends Error {
+  /**
+   * Build an agent-runner error.
+   *
+   * @param message Human-readable description.
+   * @param operation Short name of the operation that failed
+   *   (e.g. `"resolveExecutable"`, `"sdkQuery"`, `"validateArgs"`).
+   * @param field Optional argument field that failed validation
+   *   (e.g. `"worktreePath"`, `"prompt"`, `"model"`).
+   * @param cause Underlying error chained for diagnostics.
+   */
+  constructor(
+    message: string,
+    public readonly operation: string,
+    public readonly field?: string,
+    public override readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "AgentRunnerError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Construct an {@link AgentRunnerImpl}.
+ *
+ * The factory does not perform any IO; it returns an object whose methods
+ * lazily resolve the `claude` binary and the SDK `query` function the
+ * first time `runAgent` is called. This keeps construction cheap and
+ * makes the runner trivial to instantiate inside tests.
+ *
+ * @param opts Configuration. See {@link AgentRunnerOptions}.
+ * @returns A fresh {@link AgentRunnerImpl}.
+ * @throws {RangeError} when `opts.eventBus` is missing.
+ *
+ * @example
+ * ```ts
+ * import { createAgentRunner } from "./agent-runner.ts";
+ * import { createEventBus } from "./event-bus.ts";
+ *
+ * const eventBus = createEventBus();
+ * const runner = createAgentRunner({ eventBus });
+ * for await (const msg of runner.runAgent({
+ *   taskId, issueNumber, worktreePath, prompt, model,
+ * })) {
+ *   console.log(msg.role, msg.text);
+ * }
+ * ```
+ */
+export function createAgentRunner(opts: AgentRunnerOptions): AgentRunnerImpl {
+  if (opts.eventBus === undefined) {
+    throw new RangeError("AgentRunnerOptions.eventBus is required");
+  }
+  const eventBus = opts.eventBus;
+  const logger = opts.logger ?? defaultLogger();
+  const nowIso = opts.nowIso ?? defaultNowIso;
+  const resolveExecutable = opts.resolveExecutable ?? defaultResolveExecutable;
+  const overrideExecutablePath = opts.pathToClaudeCodeExecutable;
+  const overrideQuery = opts.query;
+
+  // Memoized resolutions. Both are populated lazily on the first run; a
+  // failure during the first run is *not* cached, so a transient `which`
+  // failure does not poison subsequent calls.
+  let memoizedExecutablePath: string | undefined = overrideExecutablePath;
+  let memoizedQuery: SdkQueryFunction | undefined = overrideQuery;
+
+  async function resolveClaudeExecutable(): Promise<string> {
+    if (memoizedExecutablePath !== undefined) {
+      return memoizedExecutablePath;
+    }
+    try {
+      const path = await resolveExecutable("claude");
+      memoizedExecutablePath = path;
+      return path;
+    } catch (caught) {
+      throw new AgentRunnerError(
+        "Could not locate the `claude` CLI on PATH. " +
+          "Install Claude Code (https://docs.anthropic.com/en/docs/claude-code) " +
+          "or pass `pathToClaudeCodeExecutable` to createAgentRunner().",
+        "resolveExecutable",
+        "pathToClaudeCodeExecutable",
+        caught,
+      );
+    }
+  }
+
+  async function resolveSdkQuery(): Promise<SdkQueryFunction> {
+    if (memoizedQuery !== undefined) {
+      return memoizedQuery;
+    }
+    // The SDK is heavyweight; defer the import to first use so the
+    // module load cost is paid only when the runner is actually invoked.
+    // The cast is structural: the SDK's `query` returns a `Query` that
+    // is `AsyncGenerator<SDKMessage, void>`, which matches our narrower
+    // `AsyncIterable<SdkMessageProjection>` projection.
+    let imported: { query: unknown };
+    try {
+      imported = await import("@anthropic-ai/claude-agent-sdk");
+    } catch (caught) {
+      throw new AgentRunnerError(
+        "Failed to load `@anthropic-ai/claude-agent-sdk`. " +
+          "Run `deno task ci` to ensure the npm dependency is cached.",
+        "loadSdk",
+        undefined,
+        caught,
+      );
+    }
+    if (typeof imported.query !== "function") {
+      throw new AgentRunnerError(
+        "`@anthropic-ai/claude-agent-sdk` did not export a `query` function. " +
+          "The SDK's surface may have changed; pin a compatible version in deno.json.",
+        "loadSdk",
+      );
+    }
+    const queryFn = imported.query as SdkQueryFunction;
+    memoizedQuery = queryFn;
+    return queryFn;
+  }
+
+  function validateArgs(args: RunAgentArgs): void {
+    if (args.worktreePath.length === 0) {
+      throw new AgentRunnerError(
+        "RunAgentArgs.worktreePath must be a non-empty absolute path",
+        "validateArgs",
+        "worktreePath",
+      );
+    }
+    if (args.prompt.length === 0) {
+      throw new AgentRunnerError(
+        "RunAgentArgs.prompt must be a non-empty string",
+        "validateArgs",
+        "prompt",
+      );
+    }
+    if (args.model.length === 0) {
+      throw new AgentRunnerError(
+        "RunAgentArgs.model must be a non-empty string",
+        "validateArgs",
+        "model",
+      );
+    }
+  }
+
+  /**
+   * Build the SDK options that bind the agent to the per-task worktree
+   * and append the conventional-commits addendum.
+   */
+  function buildSdkOptions(args: RunAgentArgs, executablePath: string): SdkQueryOptions {
+    const base = {
+      cwd: args.worktreePath,
+      executable: "deno" as const,
+      permissionMode: "acceptEdits" as const,
+      model: args.model,
+      pathToClaudeCodeExecutable: executablePath,
+      systemPrompt: {
+        type: "preset" as const,
+        preset: "claude_code" as const,
+        append: buildSystemPromptAddendum(args.issueNumber),
+      },
+    };
+    return args.sessionId === undefined ? base : { ...base, resume: args.sessionId };
+  }
+
+  /**
+   * Adapt one SDK message into the runner's projection plus the bus event.
+   * Returns the projection (yielded to the iterable consumer) and the
+   * session id (if observed).
+   */
+  function adaptMessage(
+    sdkMessage: SdkMessageProjection,
+  ): { readonly projection: AgentRunnerMessage; readonly sessionId: string | undefined } {
+    const role = mapSdkTypeToRole(sdkMessage.type);
+    const text = renderSdkMessageText(sdkMessage);
+    const truncated = truncateForBus(text);
+    return {
+      projection: { role, text: truncated },
+      sessionId: typeof sdkMessage.session_id === "string" ? sdkMessage.session_id : undefined,
+    };
+  }
+
+  /**
+   * Publish an `agent-message` event tagged with `taskId`. Caller is the
+   * runner; subscribers see the same projection consumers iterate.
+   */
+  function publishMessage(taskId: TaskId, projection: AgentRunnerMessage): void {
+    const event: TaskEvent = {
+      taskId,
+      atIso: nowIso(),
+      kind: "agent-message",
+      data: projection,
+    };
+    try {
+      eventBus.publish(event);
+    } catch (caught) {
+      // The bus contract isolates handler failures inside the pump;
+      // reaching this branch means a synchronous publisher-side throw
+      // (e.g. an enqueue-side bug). We log and continue so a flaky bus
+      // does not abort the agent loop.
+      logger.warn(
+        `agent-runner: event-bus publish threw, continuing. error=${stringifyError(caught)}`,
+      );
+    }
+  }
+
+  async function* runAgentInternal(
+    args: RunAgentArgs,
+    onResult: (result: AgentRunResult) => void,
+  ): AsyncIterable<AgentRunnerMessage> {
+    validateArgs(args);
+    const [executablePath, queryFn] = await Promise.all([
+      resolveClaudeExecutable(),
+      resolveSdkQuery(),
+    ]);
+    const options = buildSdkOptions(args, executablePath);
+
+    let messageCount = 0;
+    let observedSessionId: string | undefined = args.sessionId;
+
+    const stream = queryFn({ prompt: args.prompt, options });
+    try {
+      for await (const sdkMessage of stream) {
+        messageCount += 1;
+        const adapted = adaptMessage(sdkMessage);
+        if (adapted.sessionId !== undefined) {
+          observedSessionId = adapted.sessionId;
+        }
+        publishMessage(args.taskId, adapted.projection);
+        yield adapted.projection;
+      }
+    } catch (caught) {
+      throw new AgentRunnerError(
+        `Claude Agent SDK query failed: ${stringifyError(caught)}`,
+        "sdkQuery",
+        undefined,
+        caught,
+      );
+    }
+    onResult(
+      observedSessionId === undefined ? { messageCount } : {
+        sessionId: observedSessionId,
+        messageCount,
+      },
+    );
+  }
+
+  function runAgent(args: RunAgentArgs): AsyncIterable<AgentRunnerMessage> {
+    // The supervisor's hot path doesn't read the AgentRunResult; the
+    // helper below does. Pass a no-op so the iterable contract is the
+    // {@link AgentRunner.runAgent} signature.
+    return runAgentInternal(args, () => {});
+  }
+
+  async function runAndCollect(args: RunAgentArgs): Promise<AgentRunResult> {
+    let captured: AgentRunResult | undefined;
+    const iterable = runAgentInternal(args, (result) => {
+      captured = result;
+    });
+    for await (const _ of iterable) {
+      // Drain the iterable to drive `onResult` to completion. The
+      // projection is already published on the bus.
+    }
+    if (captured === undefined) {
+      // Defensive: `runAgentInternal` always invokes the callback when the
+      // generator settles normally. Reaching this branch means the
+      // generator exited via an unhandled throw the for-await loop
+      // somehow swallowed — which is impossible per the spec, but we
+      // surface the impossibility as a domain error rather than `as`-ing.
+      throw new AgentRunnerError(
+        "Internal error: run completed without producing a result",
+        "runAndCollect",
+      );
+    }
+    return captured;
+  }
+
+  return { runAgent, runAndCollect };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Format the conventional-commits system-prompt addendum for `issueNumber`.
+ *
+ * The addendum is appended to the SDK's preset system prompt via the
+ * `append` field. It is short, deterministic, and unambiguous so the
+ * model can quote it back when it commits.
+ *
+ * The exact wording is asserted by snapshot in
+ * `tests/unit/agent_runner_test.ts` so any drift is caught before it
+ * reaches a PR description.
+ *
+ * @param issueNumber The GitHub issue this run is operating on.
+ * @returns The addendum text.
+ *
+ * @example
+ * ```ts
+ * const text = buildSystemPromptAddendum(makeIssueNumber(42));
+ * // "When you author commits ..."
+ * ```
+ */
+export function buildSystemPromptAddendum(issueNumber: IssueNumber): string {
+  return [
+    "When you author commits in this worktree, every commit message MUST follow",
+    "the Conventional Commits format with the issue scope:",
+    "",
+    `    <type>(#${issueNumber}): <subject>`,
+    "",
+    "where `<type>` is one of: feat, fix, docs, refactor, perf, test, build, ci,",
+    "chore, revert. The subject is imperative, lower-case, no trailing period,",
+    "and 72 characters or fewer. Body and footer are optional but follow the",
+    "same convention. Examples:",
+    "",
+    `    feat(#${issueNumber}): add task switcher overlay`,
+    `    fix(#${issueNumber}): handle SIGPIPE on TUI disconnect`,
+    "",
+    "Do not deviate from this format; the repository's commit-msg hook rejects",
+    "non-conforming subjects.",
+  ].join("\n");
+}
+
+/** Map an SDK message `type` to the supervisor's narrow role union. */
+function mapSdkTypeToRole(type: string): AgentRunnerMessage["role"] {
+  switch (type) {
+    case "assistant":
+      return "assistant";
+    case "user":
+      return "user";
+    case "tool_use":
+      return "tool-use";
+    case "tool_result":
+      return "tool-result";
+    default:
+      // `system`, `result`, `tool_progress`, `task_started`, … all
+      // funnel into the `system` bucket. The TUI renders them as a
+      // muted status line; the supervisor does not branch on them.
+      return "system";
+  }
+}
+
+/**
+ * Render the human-readable text for an SDK message.
+ *
+ * `assistant` messages carry a `BetaMessage` whose `content` is an array
+ * of blocks; we concatenate the `text` of every text block and surface
+ * `tool_use` blocks as a single `tool: <name>(<json input>)` line so the
+ * TUI can show the tool call without parsing the SDK shape itself.
+ *
+ * `result` messages carry the final `result` string. Other messages are
+ * rendered as `<type>: <session_id>` so the TUI has *something* to show
+ * without coupling to every SDK variant.
+ */
+function renderSdkMessageText(message: SdkMessageProjection): string {
+  if (message.type === "assistant" && message.message?.content !== undefined) {
+    const parts: string[] = [];
+    for (const block of message.message.content) {
+      if (block.type === "text" && typeof block.text === "string") {
+        parts.push(block.text);
+      } else if (block.type === "tool_use" && typeof block.name === "string") {
+        const inputText = renderToolInput(block.input);
+        parts.push(`[tool ${block.name}] ${inputText}`);
+      }
+    }
+    return parts.join("\n");
+  }
+  if (message.type === "user" && message.message?.content !== undefined) {
+    const parts: string[] = [];
+    for (const block of message.message.content) {
+      if (block.type === "text" && typeof block.text === "string") {
+        parts.push(block.text);
+      }
+    }
+    return parts.join("\n");
+  }
+  if (message.type === "result" && typeof message.result === "string") {
+    return message.result;
+  }
+  // Fallback for system/tool_progress/etc. — the type discriminant alone
+  // is more useful than nothing, and any caller that wants the full
+  // shape can hold the SDK message themselves (the runner exposes
+  // `runAgent` as an iterable and only adapts the bus events).
+  return `[${message.type}]`;
+}
+
+/**
+ * Render the input of a `tool_use` block as a single line.
+ *
+ * Strings pass through verbatim, JSON-serializable values are
+ * `JSON.stringify`'d, and unrepresentable values (cycles, BigInts) are
+ * stringified through `String()` so a malformed tool call never aborts
+ * the agent loop.
+ */
+function renderToolInput(input: unknown): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input === undefined || input === null) {
+    return "";
+  }
+  try {
+    return JSON.stringify(input);
+  } catch {
+    return String(input);
+  }
+}
+
+/**
+ * Slice `text` to the bus budget without exploding on a surrogate pair on
+ * the boundary; appends an ellipsis token when truncation occurs so the
+ * TUI can distinguish a hard cap from an empty model turn.
+ */
+function truncateForBus(text: string): string {
+  if (text.length <= AGENT_MESSAGE_TEXT_TRUNCATION_CODE_UNITS) {
+    return text;
+  }
+  return `${text.slice(0, AGENT_MESSAGE_TEXT_TRUNCATION_CODE_UNITS)}…`;
+}
+
+/**
+ * Default `which`-style executable resolver.
+ *
+ * Spawns `which <name>` and returns the trimmed first line of stdout. A
+ * non-zero exit (the canonical signal for "not found") is rethrown so
+ * the caller's catch maps it onto an {@link AgentRunnerError}. We do not
+ * branch on `Deno.build.os` here: `which` is on every supported macOS
+ * and Linux host we ship to, and Windows support is deferred per ADR-008.
+ */
+async function defaultResolveExecutable(name: string): Promise<string> {
+  const command = new Deno.Command("which", {
+    args: [name],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const result = await command.output();
+  if (!result.success) {
+    const stderr = new TextDecoder().decode(result.stderr).trim();
+    throw new Error(
+      `which ${name} failed (exit ${result.code})${stderr.length === 0 ? "" : `: ${stderr}`}`,
+    );
+  }
+  const stdout = new TextDecoder().decode(result.stdout);
+  const trimmed = stdout.split("\n")[0]?.trim() ?? "";
+  if (trimmed.length === 0) {
+    throw new Error(`which ${name} returned an empty path`);
+  }
+  return trimmed;
+}
+
+/** Default ISO-timestamp source. */
+function defaultNowIso(): string {
+  return new Date().toISOString();
+}
+
+/**
+ * Adapt the default-namespace `@std/log` logger to the narrow
+ * {@link AgentRunnerLogger} surface. `getLogger()` returns a `Logger`
+ * whose `warn` overload accepts a plain string, but TypeScript needs a
+ * thin adapter to project the SDK's shape onto our interface.
+ */
+function defaultLogger(): AgentRunnerLogger {
+  const inner = getLogger();
+  return {
+    warn(message: string): void {
+      inner.warn(message);
+    },
+  };
+}
+
+/** Render an unknown error for inclusion in log lines and error messages. */
+function stringifyError(caught: unknown): string {
+  if (caught instanceof Error) {
+    return `${caught.name}: ${caught.message}`;
+  }
+  return String(caught);
+}

--- a/src/daemon/agent-runner.ts
+++ b/src/daemon/agent-runner.ts
@@ -5,9 +5,9 @@
  *
  * The supervisor (Wave 3) drives every agent iteration through this module:
  *
- *  1. Mint or recover a {@link Task}'s `sessionId`.
+ *  1. Mint or recover the task's `sessionId` (see `Task` in `src/types.ts`).
  *  2. Call {@link AgentRunnerImpl.runAgent} with the per-task
- *     {@link Task.worktreePath} pinned as `cwd`.
+ *     `worktreePath` pinned as `cwd`.
  *  3. Iterate the returned async iterable. Each yielded
  *     {@link AgentRunnerMessage} is also published onto the injected
  *     {@link EventBus} as a `task-event` of kind `agent-message`,
@@ -49,6 +49,7 @@
  */
 
 import { getLogger } from "@std/log";
+import { isAbsolute } from "@std/path";
 
 import { AGENT_MESSAGE_TEXT_TRUNCATION_CODE_UNITS } from "../constants.ts";
 import type {
@@ -90,15 +91,18 @@ export interface SdkMessageProjection {
   /** SDK-assigned session id; populated on every message. */
   readonly session_id?: string;
   /**
-   * The model's response payload for `type === "assistant"` messages.
-   * Mirrors the SDK's `BetaMessage` shape; only `content` is consumed.
+   * The model's response payload for `type === "assistant"` messages
+   * **and** the tool-output payload for `type === "user"` messages.
+   * Mirrors the SDK's `BetaMessage` / `MessageParam` shape; only
+   * `content` is consumed.
    */
   readonly message?: {
     readonly content?: ReadonlyArray<SdkContentBlockProjection>;
   };
   /**
-   * The user's payload for `type === "user"` messages. Mirrors the SDK's
-   * `MessageParam` shape; only `content` is consumed.
+   * The SDK's final result payload for `type === "result"` messages.
+   * The runner surfaces this as the rendered text when the SDK signals
+   * the run has settled.
    */
   readonly result?: string;
   /** Free-form fields that may exist on richer SDK message variants. */
@@ -225,14 +229,28 @@ export interface AgentRunnerLogger {
  * Arguments accepted by {@link AgentRunnerImpl.runAgent}.
  *
  * Mirrors the {@link AgentRunner.runAgent} contract from `src/types.ts`
- * and adds `issueNumber`, which the runner uses to format the
- * conventional-commits system-prompt addendum.
+ * and adds an optional `issueNumber`, which the runner uses to format the
+ * conventional-commits system-prompt addendum. `issueNumber` is optional
+ * so the runner remains assignable to the W1 `AgentRunner` interface
+ * (which does not include it). When omitted, the addendum is rendered
+ * with the issue scope dropped — the format is `<type>: <subject>`
+ * instead of `<type>(#<n>): <subject>` — and the model is told to author
+ * commits in plain Conventional Commits without an issue scope. The
+ * supervisor (the only production caller) always passes `issueNumber`;
+ * the optional shape exists so consumers typed as `AgentRunner` cannot
+ * trip a `#undefined` rendering.
  */
 export interface RunAgentArgs {
   /** Task this run belongs to; events are published tagged with this id. */
   readonly taskId: TaskId;
-  /** GitHub issue number; embedded into the system-prompt addendum. */
-  readonly issueNumber: IssueNumber;
+  /**
+   * GitHub issue number; embedded into the system-prompt addendum. When
+   * omitted (e.g. a generic `AgentRunner` consumer that has not adopted
+   * the W3 extension) the runner builds an addendum without the
+   * `(#<n>)` issue scope; the commit format degrades to plain
+   * Conventional Commits.
+   */
+  readonly issueNumber?: IssueNumber;
   /** Absolute path of the per-task git worktree; pinned as `cwd`. */
   readonly worktreePath: string;
   /** Prompt to send to the model. */
@@ -251,7 +269,7 @@ export interface RunAgentArgs {
  * Settled result of a `runAgent` call.
  *
  * Returned by {@link AgentRunnerImpl.runAgent} once the async iterable is
- * exhausted. The supervisor stores `sessionId` on the {@link Task} so the
+ * exhausted. The supervisor stores `sessionId` on the task record so the
  * next iteration can resume.
  */
 export interface AgentRunResult {
@@ -458,6 +476,15 @@ export function createAgentRunner(opts: AgentRunnerOptions): AgentRunnerImpl {
         "worktreePath",
       );
     }
+    if (!isAbsolute(args.worktreePath)) {
+      throw new AgentRunnerError(
+        `RunAgentArgs.worktreePath must be an absolute path (got ${
+          JSON.stringify(args.worktreePath)
+        })`,
+        "validateArgs",
+        "worktreePath",
+      );
+    }
     if (args.prompt.length === 0) {
       throw new AgentRunnerError(
         "RunAgentArgs.prompt must be a non-empty string",
@@ -495,32 +522,50 @@ export function createAgentRunner(opts: AgentRunnerOptions): AgentRunnerImpl {
   }
 
   /**
-   * Adapt one SDK message into the runner's projection plus the bus event.
-   * Returns the projection (yielded to the iterable consumer) and the
-   * session id (if observed).
+   * Adapt one SDK message into the runner's projection (yielded to the
+   * iterable consumer at full length) plus the truncated payload for the
+   * event bus, plus the session id (if observed).
+   *
+   * The iterable carries the full rendered text so a consumer that wants
+   * the entire tool output (e.g. a future persistence sink) is not
+   * silently capped at the bus budget. Only the bus-side payload is
+   * truncated to the
+   * {@link AGENT_MESSAGE_TEXT_TRUNCATION_CODE_UNITS} ceiling so subscriber
+   * queues stay bounded.
    */
   function adaptMessage(
     sdkMessage: SdkMessageProjection,
-  ): { readonly projection: AgentRunnerMessage; readonly sessionId: string | undefined } {
+  ): {
+    readonly projection: AgentRunnerMessage;
+    readonly busPayload: AgentRunnerMessage;
+    readonly sessionId: string | undefined;
+  } {
     const role = mapSdkTypeToRole(sdkMessage.type);
     const text = renderSdkMessageText(sdkMessage);
     const truncated = truncateForBus(text);
+    const projection: AgentRunnerMessage = { role, text };
+    const busPayload: AgentRunnerMessage = truncated === text
+      ? projection
+      : { role, text: truncated };
     return {
-      projection: { role, text: truncated },
+      projection,
+      busPayload,
       sessionId: typeof sdkMessage.session_id === "string" ? sdkMessage.session_id : undefined,
     };
   }
 
   /**
    * Publish an `agent-message` event tagged with `taskId`. Caller is the
-   * runner; subscribers see the same projection consumers iterate.
+   * runner; subscribers see the bus-budget projection (truncated when the
+   * rendered text exceeded {@link AGENT_MESSAGE_TEXT_TRUNCATION_CODE_UNITS}).
+   * The yielded iterable carries the full text — see {@link adaptMessage}.
    */
-  function publishMessage(taskId: TaskId, projection: AgentRunnerMessage): void {
+  function publishMessage(taskId: TaskId, busPayload: AgentRunnerMessage): void {
     const event: TaskEvent = {
       taskId,
       atIso: nowIso(),
       kind: "agent-message",
-      data: projection,
+      data: busPayload,
     };
     try {
       eventBus.publish(event);
@@ -549,15 +594,21 @@ export function createAgentRunner(opts: AgentRunnerOptions): AgentRunnerImpl {
     let messageCount = 0;
     let observedSessionId: string | undefined = args.sessionId;
 
-    const stream = queryFn({ prompt: args.prompt, options });
     try {
+      // `queryFn(...)` lives inside the try so a synchronous SDK throw
+      // (e.g. test stub raising before yielding the iterable, or the
+      // production SDK validating its arguments eagerly) is wrapped in
+      // an `AgentRunnerError` consistent with the iteration-failure
+      // path. Without this, a sync throw would bypass the wrapping and
+      // surface a raw error type to the supervisor.
+      const stream = queryFn({ prompt: args.prompt, options });
       for await (const sdkMessage of stream) {
         messageCount += 1;
         const adapted = adaptMessage(sdkMessage);
         if (adapted.sessionId !== undefined) {
           observedSessionId = adapted.sessionId;
         }
-        publishMessage(args.taskId, adapted.projection);
+        publishMessage(args.taskId, adapted.busPayload);
         yield adapted.projection;
       }
     } catch (caught) {
@@ -614,39 +665,53 @@ export function createAgentRunner(opts: AgentRunnerOptions): AgentRunnerImpl {
 // ---------------------------------------------------------------------------
 
 /**
- * Format the conventional-commits system-prompt addendum for `issueNumber`.
+ * Format the conventional-commits system-prompt addendum.
  *
  * The addendum is appended to the SDK's preset system prompt via the
  * `append` field. It is short, deterministic, and unambiguous so the
  * model can quote it back when it commits.
  *
+ * When `issueNumber` is provided, the addendum embeds the
+ * `<type>(#<issueNumber>): <subject>` Conventional Commits format with
+ * the issue scope. When `issueNumber` is `undefined`, the format
+ * degrades to plain `<type>: <subject>` so a consumer typed as the W1
+ * `AgentRunner` (which does not pass `issueNumber`) never produces a
+ * `#undefined` literal in the prompt.
+ *
  * The exact wording is asserted by snapshot in
  * `tests/unit/agent_runner_test.ts` so any drift is caught before it
  * reaches a PR description.
  *
- * @param issueNumber The GitHub issue this run is operating on.
+ * @param issueNumber The GitHub issue this run is operating on. Omit to
+ *   render the addendum without an issue scope.
  * @returns The addendum text.
  *
  * @example
  * ```ts
  * const text = buildSystemPromptAddendum(makeIssueNumber(42));
  * // "When you author commits ..."
+ * const generic = buildSystemPromptAddendum();
+ * // Same body, scope-less examples.
  * ```
  */
-export function buildSystemPromptAddendum(issueNumber: IssueNumber): string {
+export function buildSystemPromptAddendum(issueNumber?: IssueNumber): string {
+  const scope = issueNumber === undefined ? "" : `(#${issueNumber})`;
+  const formatHeader = issueNumber === undefined
+    ? "the Conventional Commits format:"
+    : "the Conventional Commits format with the issue scope:";
   return [
     "When you author commits in this worktree, every commit message MUST follow",
-    "the Conventional Commits format with the issue scope:",
+    formatHeader,
     "",
-    `    <type>(#${issueNumber}): <subject>`,
+    `    <type>${scope}: <subject>`,
     "",
     "where `<type>` is one of: feat, fix, docs, refactor, perf, test, build, ci,",
     "chore, revert. The subject is imperative, lower-case, no trailing period,",
     "and 72 characters or fewer. Body and footer are optional but follow the",
     "same convention. Examples:",
     "",
-    `    feat(#${issueNumber}): add task switcher overlay`,
-    `    fix(#${issueNumber}): handle SIGPIPE on TUI disconnect`,
+    `    feat${scope}: add task switcher overlay`,
+    `    fix${scope}: handle SIGPIPE on TUI disconnect`,
     "",
     "Do not deviate from this format; the repository's commit-msg hook rejects",
     "non-conforming subjects.",
@@ -677,12 +742,20 @@ function mapSdkTypeToRole(type: string): AgentRunnerMessage["role"] {
  *
  * `assistant` messages carry a `BetaMessage` whose `content` is an array
  * of blocks; we concatenate the `text` of every text block and surface
- * `tool_use` blocks as a single `tool: <name>(<json input>)` line so the
+ * `tool_use` blocks as a single `[tool <name>] <input>` line so the
  * TUI can show the tool call without parsing the SDK shape itself.
  *
- * `result` messages carry the final `result` string. Other messages are
- * rendered as `<type>: <session_id>` so the TUI has *something* to show
- * without coupling to every SDK variant.
+ * `result` messages carry the final `result` string.
+ *
+ * Standalone `tool_use` / `tool_result` messages (which
+ * {@link mapSdkTypeToRole} surfaces as the `tool-use` / `tool-result`
+ * roles) render their `name`/`input` fields the same way embedded
+ * `tool_use` blocks do, so the transcript stays informative whichever
+ * shape the SDK chose.
+ *
+ * Other messages fall back to a bracketed type tag such as
+ * `[tool_progress]` so the TUI has *something* to show without coupling
+ * to every SDK variant.
  */
 function renderSdkMessageText(message: SdkMessageProjection): string {
   if (message.type === "assistant" && message.message?.content !== undefined) {
@@ -709,6 +782,28 @@ function renderSdkMessageText(message: SdkMessageProjection): string {
   if (message.type === "result" && typeof message.result === "string") {
     return message.result;
   }
+  if (message.type === "tool_use") {
+    // Standalone `tool_use` carries `name`/`input` at the message root
+    // (no embedded content blocks). Render the same way the embedded
+    // case does so the transcript line is uniform.
+    const name = typeof message.name === "string" ? message.name : "";
+    const inputText = renderToolInput(message.input);
+    return name.length === 0 ? `[tool_use] ${inputText}`.trimEnd() : `[tool ${name}] ${inputText}`;
+  }
+  if (message.type === "tool_result") {
+    // Standalone `tool_result` may carry the rendered output as
+    // `content` (string) or a nested `result.content` payload depending
+    // on SDK variant. Surface the string form when present; otherwise
+    // fall back to the bracketed type so the discriminant remains
+    // useful.
+    if (typeof message.content === "string") {
+      return `[tool_result] ${message.content}`;
+    }
+    if (typeof message.result === "string") {
+      return `[tool_result] ${message.result}`;
+    }
+    return `[tool_result]`;
+  }
   // Fallback for system/tool_progress/etc. — the type discriminant alone
   // is more useful than nothing, and any caller that wants the full
   // shape can hold the SDK message themselves (the runner exposes
@@ -720,9 +815,12 @@ function renderSdkMessageText(message: SdkMessageProjection): string {
  * Render the input of a `tool_use` block as a single line.
  *
  * Strings pass through verbatim, JSON-serializable values are
- * `JSON.stringify`'d, and unrepresentable values (cycles, BigInts) are
- * stringified through `String()` so a malformed tool call never aborts
- * the agent loop.
+ * `JSON.stringify`'d, and unrepresentable values (cycles, BigInts,
+ * functions, symbols) are stringified through `String()` so a malformed
+ * tool call never aborts the agent loop. `JSON.stringify` returns
+ * `undefined` for top-level functions and symbols; the explicit guard
+ * below converts those to `String(input)` rather than the literal
+ * `"undefined"` that string interpolation would otherwise produce.
  */
 function renderToolInput(input: unknown): string {
   if (typeof input === "string") {
@@ -732,7 +830,8 @@ function renderToolInput(input: unknown): string {
     return "";
   }
   try {
-    return JSON.stringify(input);
+    const stringified = JSON.stringify(input);
+    return stringified === undefined ? String(input) : stringified;
   } catch {
     return String(input);
   }

--- a/src/daemon/agent-runner.ts
+++ b/src/daemon/agent-runner.ts
@@ -639,9 +639,12 @@ export function createAgentRunner(opts: AgentRunnerOptions): AgentRunnerImpl {
     const iterable = runAgentInternal(args, (result) => {
       captured = result;
     });
-    for await (const _ of iterable) {
-      // Drain the iterable to drive `onResult` to completion. The
-      // projection is already published on the bus.
+    // Drain the iterable to drive `onResult` to completion. The projection
+    // is already published on the bus, so we discard the messages here and
+    // only need to advance the iterator.
+    const drain = iterable[Symbol.asyncIterator]();
+    while (!(await drain.next()).done) {
+      // intentionally empty — see comment above
     }
     if (captured === undefined) {
       // Defensive: `runAgentInternal` always invokes the callback when the

--- a/tests/integration/agent_runner_real_test.ts
+++ b/tests/integration/agent_runner_real_test.ts
@@ -7,9 +7,10 @@
  * `claude` CLI subprocess, talks to the Anthropic API, and depends on
  * network reachability. It runs only when `AGENT_RUNNER_REAL_TEST=1` is
  * set in the environment; the daemon CI workflow leaves it off by
- * default. The local developer running `deno task test` sees it
- * `t.step`-skipped with a one-line note explaining the gate so the
- * bypass is never silent.
+ * default. When the gate is off the test is `ignore:`-skipped at the
+ * outer `Deno.test` level — no `t.step` runs and no console note is
+ * printed. The console note (see below) is only emitted when the gate
+ * is on but `claude` cannot be located on PATH.
  *
  * **Skip when claude is missing.** Even with the gate enabled, the test
  * skips with a clear note when `which claude` returns nothing — that
@@ -27,12 +28,7 @@ import { assert, assertExists } from "@std/assert";
 
 import { createAgentRunner } from "../../src/daemon/agent-runner.ts";
 import { createEventBus } from "../../src/daemon/event-bus.ts";
-import {
-  type AgentRunnerMessage,
-  makeIssueNumber,
-  makeTaskId,
-  type TaskEvent,
-} from "../../src/types.ts";
+import { makeIssueNumber, makeTaskId, type TaskEvent } from "../../src/types.ts";
 
 const REAL_TEST_ENV_VAR = "AGENT_RUNNER_REAL_TEST";
 const REAL_TEST_ENABLED_VALUE = "1";
@@ -107,7 +103,6 @@ Deno.test({
             pathToClaudeCodeExecutable: claudePath,
           });
 
-          const messages: AgentRunnerMessage[] = [];
           try {
             // A short, deterministic prompt so the agent finishes quickly.
             // The model id is hard-coded to Sonnet 4.6 because the test
@@ -128,9 +123,6 @@ Deno.test({
             assert(events.every((event) => event.taskId === taskId));
           } finally {
             sub.unsubscribe();
-            // Drain anything still queued so the sanitizer does not
-            // flag a pending publish.
-            messages.length = 0;
           }
         } finally {
           await Deno.remove(tempDir, { recursive: true });

--- a/tests/integration/agent_runner_real_test.ts
+++ b/tests/integration/agent_runner_real_test.ts
@@ -81,7 +81,7 @@ Deno.test({
         if (claudePath === undefined) {
           // The harness ignores `t.step` failure-or-skip semantics, so we
           // explicitly bail with a console note rather than failing.
-          // eslint-disable-next-line no-console -- informational skip note
+          // deno-lint-ignore no-console -- informational skip note
           console.warn(
             `agent_runner_real: \`claude\` is not on PATH; skipping. ` +
               `Install Claude Code to exercise this path.`,

--- a/tests/integration/agent_runner_real_test.ts
+++ b/tests/integration/agent_runner_real_test.ts
@@ -1,0 +1,141 @@
+/**
+ * Integration test for `src/daemon/agent-runner.ts`. Exercises the
+ * production path (real SDK, real `claude` CLI, a temp git worktree)
+ * end-to-end so we have one test that *actually* spawns the agent.
+ *
+ * **Gating.** This test is intentionally expensive: it spawns the
+ * `claude` CLI subprocess, talks to the Anthropic API, and depends on
+ * network reachability. It runs only when `AGENT_RUNNER_REAL_TEST=1` is
+ * set in the environment; the daemon CI workflow leaves it off by
+ * default. The local developer running `deno task test` sees it
+ * `t.step`-skipped with a one-line note explaining the gate so the
+ * bypass is never silent.
+ *
+ * **Skip when claude is missing.** Even with the gate enabled, the test
+ * skips with a clear note when `which claude` returns nothing — that
+ * means the host doesn't have Claude Code installed and there is
+ * nothing to integrate against. The skip is logged so a misconfigured
+ * CI host produces an obvious signal.
+ *
+ * **Worktree boundary.** A `Deno.makeTempDir`-backed git repo is
+ * initialised in the test body (no shared state with other tests) and
+ * removed on settlement. The agent is asked a tiny prompt with a small
+ * `maxTurns`-equivalent budget so the run terminates quickly.
+ */
+
+import { assert, assertExists } from "@std/assert";
+
+import { createAgentRunner } from "../../src/daemon/agent-runner.ts";
+import { createEventBus } from "../../src/daemon/event-bus.ts";
+import {
+  type AgentRunnerMessage,
+  makeIssueNumber,
+  makeTaskId,
+  type TaskEvent,
+} from "../../src/types.ts";
+
+const REAL_TEST_ENV_VAR = "AGENT_RUNNER_REAL_TEST";
+const REAL_TEST_ENABLED_VALUE = "1";
+
+/**
+ * Resolve `claude` via `which`. Returns `undefined` when the binary is
+ * not installed so the test can skip with a clear note.
+ */
+async function claudePathOrUndefined(): Promise<string | undefined> {
+  try {
+    const command = new Deno.Command("which", {
+      args: ["claude"],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const result = await command.output();
+    if (!result.success) return undefined;
+    const path = new TextDecoder().decode(result.stdout).split("\n")[0]?.trim() ?? "";
+    return path.length === 0 ? undefined : path;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Initialise a tiny git worktree under `dir` so the agent has somewhere to operate. */
+async function initWorktree(dir: string): Promise<void> {
+  const init = await new Deno.Command("git", {
+    args: ["init", "--quiet", dir],
+    stdout: "null",
+    stderr: "piped",
+  }).output();
+  assert(init.success, new TextDecoder().decode(init.stderr));
+  await Deno.writeTextFile(`${dir}/README.md`, "# fixture\n");
+}
+
+Deno.test({
+  name: "agent_runner_real: end-to-end run against the real SDK",
+  // Resource-leak detection in Deno's test runner trips on the SDK's
+  // long-lived subprocess; the SDK manages it itself, but the harness
+  // would flag the open pipe as a sanitizer error.
+  sanitizeResources: false,
+  sanitizeOps: false,
+  ignore: Deno.env.get(REAL_TEST_ENV_VAR) !== REAL_TEST_ENABLED_VALUE,
+  async fn(t) {
+    await t.step({
+      name: "skip note when claude is not on PATH",
+      ignore: false,
+      async fn() {
+        const claudePath = await claudePathOrUndefined();
+        if (claudePath === undefined) {
+          // The harness ignores `t.step` failure-or-skip semantics, so we
+          // explicitly bail with a console note rather than failing.
+          // eslint-disable-next-line no-console -- informational skip note
+          console.warn(
+            `agent_runner_real: \`claude\` is not on PATH; skipping. ` +
+              `Install Claude Code to exercise this path.`,
+          );
+          return;
+        }
+
+        const tempDir = await Deno.makeTempDir({ prefix: "makina-agent-runner-it-" });
+        try {
+          await initWorktree(tempDir);
+
+          const bus = createEventBus();
+          const taskId = makeTaskId("task_real_integration");
+          const issueNumber = makeIssueNumber(1);
+          const events: TaskEvent[] = [];
+          const sub = bus.subscribe(taskId, (event) => events.push(event));
+          const runner = createAgentRunner({
+            eventBus: bus,
+            pathToClaudeCodeExecutable: claudePath,
+          });
+
+          const messages: AgentRunnerMessage[] = [];
+          try {
+            // A short, deterministic prompt so the agent finishes quickly.
+            // The model id is hard-coded to Sonnet 4.6 because the test
+            // environment is expected to have it available.
+            const result = await runner.runAndCollect({
+              taskId,
+              issueNumber,
+              worktreePath: tempDir,
+              prompt: "Reply with the single word ACK and nothing else.",
+              model: "claude-sonnet-4-6",
+            });
+            assertExists(result);
+            // We do not assert message contents — the model may add
+            // formatting — but at least one message must have arrived
+            // and the stream must publish to the bus.
+            assert(result.messageCount > 0);
+            assert(events.length > 0);
+            assert(events.every((event) => event.taskId === taskId));
+          } finally {
+            sub.unsubscribe();
+            // Drain anything still queued so the sanitizer does not
+            // flag a pending publish.
+            messages.length = 0;
+          }
+        } finally {
+          await Deno.remove(tempDir, { recursive: true });
+        }
+      },
+    });
+  },
+});

--- a/tests/unit/agent_runner_test.ts
+++ b/tests/unit/agent_runner_test.ts
@@ -1240,11 +1240,16 @@ Deno.test("tool_use blocks render an empty input string when input is null/undef
 
 Deno.test({
   name: "the default resolveExecutable invokes `which` against the real PATH",
-  // We rely on the host's `which sh` returning something useful. POSIX
-  // hosts (the only platforms makina ships to per ADR-008) all carry it.
-  // Branding `claude` would couple the test to whether the developer has
-  // Claude Code installed; a near-universal binary keeps the test green
-  // on a fresh dev box without skipping.
+  // The runner under test resolves `claude` via `which claude`, so this
+  // test exercises both branches of `defaultResolveExecutable`:
+  //  - success: `claude` is on PATH (developer has Claude Code installed),
+  //    in which case the resolver returns a non-empty path and the stub
+  //    query is invoked.
+  //  - failure: `claude` is not on PATH (typical fresh CI), in which case
+  //    the resolver throws an `AgentRunnerError` with
+  //    `operation: "resolveExecutable"`.
+  // Whichever branch the host happens to take, the assertions below cover
+  // it — neither outcome should leave a fresh dev box red.
   async fn() {
     const fake = fakeQuery({ messages: [assistantMessage("ok")] });
     const bus = createEventBus({ logger: recordingLogger() });

--- a/tests/unit/agent_runner_test.ts
+++ b/tests/unit/agent_runner_test.ts
@@ -434,6 +434,32 @@ Deno.test("buildSystemPromptAddendum embeds the issue number verbatim (snapshot)
   assertEquals(text, expected);
 });
 
+Deno.test("buildSystemPromptAddendum drops the issue scope when no issueNumber is given", () => {
+  // The W1 `AgentRunner` contract does not include `issueNumber`; a
+  // consumer typed as `AgentRunner` legally omits it. The runner
+  // degrades the format to plain Conventional Commits (no scope) so we
+  // never produce a `#undefined` literal in the prompt.
+  const text = buildSystemPromptAddendum();
+  const expected = [
+    "When you author commits in this worktree, every commit message MUST follow",
+    "the Conventional Commits format:",
+    "",
+    "    <type>: <subject>",
+    "",
+    "where `<type>` is one of: feat, fix, docs, refactor, perf, test, build, ci,",
+    "chore, revert. The subject is imperative, lower-case, no trailing period,",
+    "and 72 characters or fewer. Body and footer are optional but follow the",
+    "same convention. Examples:",
+    "",
+    "    feat: add task switcher overlay",
+    "    fix: handle SIGPIPE on TUI disconnect",
+    "",
+    "Do not deviate from this format; the repository's commit-msg hook rejects",
+    "non-conforming subjects.",
+  ].join("\n");
+  assertEquals(text, expected);
+});
+
 Deno.test("runAgent appends the addendum to the SDK's preset system prompt", async () => {
   const { runner, captures, stop } = buildRunner({
     pathOverride: FIXTURE_CLAUDE,
@@ -599,6 +625,33 @@ Deno.test("runAgent rejects when worktreePath is empty", async () => {
   }
 });
 
+Deno.test("runAgent rejects when worktreePath is not absolute", async () => {
+  // The error message claims an absolute path is required; the
+  // validator must enforce that, not just non-empty.
+  const { runner, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [],
+  });
+  try {
+    const error = await assertRejects(
+      () =>
+        drain(runner.runAgent({
+          taskId: FIXTURE_TASK_ID,
+          issueNumber: FIXTURE_ISSUE,
+          worktreePath: "relative/path",
+          prompt: FIXTURE_PROMPT,
+          model: FIXTURE_MODEL,
+        })),
+      AgentRunnerError,
+    );
+    assertEquals(error.operation, "validateArgs");
+    assertEquals(error.field, "worktreePath");
+    assertStringIncludes(error.message, "absolute");
+  } finally {
+    stop();
+  }
+});
+
 Deno.test("runAgent rejects when prompt is empty", async () => {
   const { runner, stop } = buildRunner({
     pathOverride: FIXTURE_CLAUDE,
@@ -673,6 +726,38 @@ Deno.test("runAgent wraps SDK rejections as AgentRunnerError carrying the cause"
   } finally {
     stop();
   }
+});
+
+Deno.test("runAgent wraps synchronous queryFn throws as AgentRunnerError", async () => {
+  // The SDK's `query` (or a misbehaving test stub) may throw before
+  // returning the iterable. The runner must wrap that synchronous throw
+  // the same way it wraps async iteration failures so the supervisor
+  // sees a single error type.
+  const cause = new Error("synchronous SDK boom");
+  const throwingQuery: SdkQueryFunction = () => {
+    throw cause;
+  };
+  const bus = createEventBus({ logger: recordingLogger() });
+  const runner = createAgentRunner({
+    eventBus: bus,
+    query: throwingQuery,
+    pathToClaudeCodeExecutable: FIXTURE_CLAUDE,
+    nowIso: () => "2026-04-26T00:00:00.000Z",
+  });
+  const error = await assertRejects(
+    () =>
+      drain(runner.runAgent({
+        taskId: FIXTURE_TASK_ID,
+        issueNumber: FIXTURE_ISSUE,
+        worktreePath: FIXTURE_WORKTREE,
+        prompt: FIXTURE_PROMPT,
+        model: FIXTURE_MODEL,
+      })),
+    AgentRunnerError,
+  );
+  assertEquals(error.operation, "sdkQuery");
+  assertEquals(error.cause, cause);
+  assertStringIncludes(error.message, "synchronous SDK boom");
 });
 
 Deno.test(
@@ -857,8 +942,56 @@ Deno.test("tool_use blocks render gracefully when input has unrepresentable valu
   }
 });
 
-Deno.test("very long assistant text is truncated to the bus budget", async () => {
-  const oversized = "x".repeat(AGENT_MESSAGE_TEXT_TRUNCATION_CODE_UNITS + 100);
+Deno.test("tool_use blocks fall back to String() when JSON.stringify returns undefined", async () => {
+  // `JSON.stringify(<function>)` and `JSON.stringify(<symbol>)` return
+  // `undefined`. Without an explicit guard, string interpolation
+  // converts that to the literal `"undefined"`. The renderer must fall
+  // back to `String(input)` so the line carries something more useful
+  // (the function/symbol's debug representation) than `undefined`.
+  const { runner, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [
+      {
+        type: "assistant",
+        session_id: "session-stub",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              name: "Weird",
+              input: function namedFn() {/* nothing */},
+            },
+          ],
+        },
+      },
+    ],
+  });
+  try {
+    const messages = await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    }));
+    const first = messages[0];
+    assertExists(first);
+    assertStringIncludes(first.text, "[tool Weird]");
+    // The fallback path is `String(input)`, which for a function yields
+    // its source. We just assert the literal `undefined` does not leak.
+    assertEquals(first.text.includes("undefined"), false);
+  } finally {
+    stop();
+  }
+});
+
+Deno.test("very long assistant text yields full length but truncates on the event bus", async () => {
+  // The iterable carries the full rendered text so a future consumer
+  // (e.g. a persistence sink) is not silently capped at the bus budget.
+  // Only the bus-side payload is truncated to keep subscriber queues
+  // bounded.
+  const oversizedLength = AGENT_MESSAGE_TEXT_TRUNCATION_CODE_UNITS + 100;
+  const oversized = "x".repeat(oversizedLength);
   const { runner, events, stop } = buildRunner({
     pathOverride: FIXTURE_CLAUDE,
     messages: [assistantMessage(oversized)],
@@ -872,17 +1005,17 @@ Deno.test("very long assistant text is truncated to the bus budget", async () =>
       model: FIXTURE_MODEL,
     }));
     await flush();
-    assertEquals(
-      messages[0]?.text.length,
-      AGENT_MESSAGE_TEXT_TRUNCATION_CODE_UNITS + 1, // ellipsis
-    );
-    assert(messages[0]?.text.endsWith("…"));
+    // Iterable: full length, no ellipsis.
+    assertEquals(messages[0]?.text.length, oversizedLength);
+    assertEquals(messages[0]?.text.endsWith("…"), false);
+    // Bus: capped at the budget plus one ellipsis code unit.
     assertEquals(events.length, 1);
     assert(events[0]?.kind === "agent-message");
     assertEquals(
       events[0]?.data.text.length,
       AGENT_MESSAGE_TEXT_TRUNCATION_CODE_UNITS + 1,
     );
+    assert(events[0]?.data.text.endsWith("…"));
   } finally {
     stop();
   }
@@ -951,7 +1084,9 @@ Deno.test("MockAgentRunner implements the supervisor's AgentRunner shape", async
 Deno.test("MockAgentRunner records a roundtripped sessionId", () => {
   const mock = new MockAgentRunner();
   mock.queueRun({ messages: [] });
-  const _ = mock.runAgent({
+  // `runAgent` records the invocation synchronously; the iterable does
+  // not need to be drained for the assertion below.
+  mock.runAgent({
     taskId: FIXTURE_TASK_ID,
     worktreePath: FIXTURE_WORKTREE,
     prompt: FIXTURE_PROMPT,
@@ -984,6 +1119,40 @@ Deno.test("standalone tool_use messages map to the tool-use role", async () => {
   }
 });
 
+Deno.test("standalone tool_use messages render their name and input", async () => {
+  // Standalone `tool_use` messages carry `name`/`input` at the message
+  // root (no embedded blocks). Render them the same way embedded
+  // tool_use blocks render so the transcript is uniform regardless of
+  // SDK variant.
+  const { runner, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [
+      {
+        type: "tool_use",
+        session_id: "s",
+        name: "Bash",
+        input: { command: "ls" },
+      },
+    ],
+  });
+  try {
+    const messages = await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    }));
+    const first = messages[0];
+    assertExists(first);
+    assertEquals(first.role, "tool-use");
+    assertStringIncludes(first.text, "[tool Bash]");
+    assertStringIncludes(first.text, "ls");
+  } finally {
+    stop();
+  }
+});
+
 Deno.test("standalone tool_result messages map to the tool-result role", async () => {
   const { runner, stop } = buildRunner({
     pathOverride: FIXTURE_CLAUDE,
@@ -998,6 +1167,35 @@ Deno.test("standalone tool_result messages map to the tool-result role", async (
       model: FIXTURE_MODEL,
     }));
     assertEquals(messages[0]?.role, "tool-result");
+  } finally {
+    stop();
+  }
+});
+
+Deno.test("standalone tool_result messages render their content payload", async () => {
+  const { runner, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [
+      {
+        type: "tool_result",
+        session_id: "s",
+        content: "command output line",
+      },
+    ],
+  });
+  try {
+    const messages = await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    }));
+    const first = messages[0];
+    assertExists(first);
+    assertEquals(first.role, "tool-result");
+    assertStringIncludes(first.text, "[tool_result]");
+    assertStringIncludes(first.text, "command output line");
   } finally {
     stop();
   }

--- a/tests/unit/agent_runner_test.ts
+++ b/tests/unit/agent_runner_test.ts
@@ -1,0 +1,1088 @@
+/**
+ * Unit tests for `src/daemon/agent-runner.ts`. Covers:
+ *
+ *  - Iterable shape: the runner streams `AgentRunnerMessage` projections
+ *    and exhausts cleanly.
+ *  - Event-bus integration: each yielded message is also published as an
+ *    `agent-message` tagged with the run's `taskId`.
+ *  - Session resumption: `sessionId` from the SDK is carried out via
+ *    `runAndCollect`, and a caller-supplied `sessionId` is forwarded to
+ *    the SDK as `options.resume`.
+ *  - System-prompt addendum: a snapshot of the addendum guards against
+ *    silent drift; the issue number flows through verbatim.
+ *  - SDK options: `cwd`, `executable: "deno"`, `permissionMode:
+ *    "acceptEdits"`, `model`, and `pathToClaudeCodeExecutable` are
+ *    forwarded as expected.
+ *  - Executable discovery: a custom `resolveExecutable` resolves; a
+ *    `claude` not on PATH yields an `AgentRunnerError` with a remediation
+ *    hint.
+ *  - Error paths: invalid args, SDK failures, and a publish-side bus
+ *    throw are wrapped/handled per the contract.
+ *  - `MockAgentRunner` shape compatibility — using the helper as the
+ *    supervisor would.
+ */
+
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertInstanceOf,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
+
+import {
+  AgentRunnerError,
+  type AgentRunnerImpl,
+  type AgentRunnerOptions,
+  buildSystemPromptAddendum,
+  createAgentRunner,
+  type ExecutableResolver,
+  type SdkMessageProjection,
+  type SdkQueryFunction,
+  type SdkQueryOptions,
+} from "../../src/daemon/agent-runner.ts";
+import { createEventBus } from "../../src/daemon/event-bus.ts";
+import { AGENT_MESSAGE_TEXT_TRUNCATION_CODE_UNITS } from "../../src/constants.ts";
+import {
+  type AgentRunnerMessage,
+  type EventBus,
+  makeIssueNumber,
+  makeTaskId,
+  type TaskEvent,
+  type TaskId,
+} from "../../src/types.ts";
+import { MockAgentRunner } from "../helpers/mock_agent_runner.ts";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+interface QueryCapture {
+  readonly prompt: string;
+  readonly options: SdkQueryOptions;
+}
+
+interface FakeQueryConfig {
+  readonly messages: ReadonlyArray<SdkMessageProjection>;
+  readonly throwAt?: number;
+  readonly throwError?: Error;
+}
+
+interface FakeQuery {
+  readonly fn: SdkQueryFunction;
+  readonly captures: QueryCapture[];
+}
+
+/**
+ * Build a structural stub of the SDK's `query` function. Captures every
+ * call in `captures` and yields the scripted messages. If `throwAt` is
+ * defined, the iterable rejects after yielding `throwAt` messages; the
+ * thrown error defaults to `Error("scripted SDK failure")`.
+ */
+function fakeQuery(config: FakeQueryConfig): FakeQuery {
+  const captures: QueryCapture[] = [];
+  const fn: SdkQueryFunction = (params) => {
+    captures.push({ prompt: params.prompt, options: params.options });
+    return iterate(config);
+  };
+  return { fn, captures };
+}
+
+async function* iterate(config: FakeQueryConfig): AsyncIterable<SdkMessageProjection> {
+  let i = 0;
+  for (const m of config.messages) {
+    if (config.throwAt !== undefined && i === config.throwAt) {
+      throw config.throwError ?? new Error("scripted SDK failure");
+    }
+    // `await` makes the iteration genuinely async so a consumer cannot
+    // accidentally rely on synchronous yields.
+    await Promise.resolve();
+    yield m;
+    i += 1;
+  }
+  if (config.throwAt !== undefined && i === config.throwAt) {
+    throw config.throwError ?? new Error("scripted SDK failure");
+  }
+}
+
+/** Recording logger that captures every `warn` call. */
+function recordingLogger(): { warn: (message: string) => void; messages: string[] } {
+  const messages: string[] = [];
+  return {
+    messages,
+    warn(message: string): void {
+      messages.push(message);
+    },
+  };
+}
+
+/**
+ * Drain `iterable` and return the materialized list. Keeps test bodies
+ * compact and lets us assert on the exact projection.
+ */
+async function drain<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of iterable) {
+    out.push(item);
+  }
+  return out;
+}
+
+/** Subscribe to `bus` for `target` and return the recorded events. */
+function recordBus(bus: EventBus, target: TaskId | "*"): {
+  readonly events: TaskEvent[];
+  readonly stop: () => void;
+} {
+  const events: TaskEvent[] = [];
+  const sub = bus.subscribe(target, (event) => {
+    events.push(event);
+  });
+  return {
+    events,
+    stop: () => sub.unsubscribe(),
+  };
+}
+
+/**
+ * Wait one macrotask so the event-bus pump has a chance to deliver any
+ * still-queued events to its subscribers.
+ */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/** Build a minimal `assistant` SDK message carrying a single text block. */
+function assistantMessage(text: string, sessionId = "session-stub"): SdkMessageProjection {
+  return {
+    type: "assistant",
+    session_id: sessionId,
+    message: {
+      content: [{ type: "text", text }],
+    },
+  };
+}
+
+/** Build a minimal `result` SDK message. */
+function resultMessage(result: string, sessionId = "session-stub"): SdkMessageProjection {
+  return {
+    type: "result",
+    session_id: sessionId,
+    result,
+  };
+}
+
+/**
+ * Boilerplate for the runner: returns a runner wired to a fresh event
+ * bus, the bus's recording subscription, and the captured queries.
+ */
+function buildRunner(
+  config: FakeQueryConfig & {
+    readonly resolveExecutable?: ExecutableResolver;
+    readonly pathOverride?: string;
+    readonly nowIso?: () => string;
+  },
+): {
+  readonly runner: AgentRunnerImpl;
+  readonly bus: EventBus;
+  readonly captures: QueryCapture[];
+  readonly events: TaskEvent[];
+  readonly stop: () => void;
+} {
+  const bus = createEventBus({ logger: recordingLogger() });
+  const recording = recordBus(bus, "*");
+  const fake = fakeQuery(config);
+  // `exactOptionalPropertyTypes: true` forbids passing `undefined` for
+  // an optional field, so we build the runner options conditionally.
+  const opts: AgentRunnerOptions = {
+    eventBus: bus,
+    query: fake.fn,
+    nowIso: config.nowIso ?? (() => "2026-04-26T00:00:00.000Z"),
+    ...(config.resolveExecutable === undefined
+      ? {}
+      : { resolveExecutable: config.resolveExecutable }),
+    ...(config.pathOverride === undefined
+      ? {}
+      : { pathToClaudeCodeExecutable: config.pathOverride }),
+  };
+  const runner = createAgentRunner(opts);
+  return {
+    runner,
+    bus,
+    captures: fake.captures,
+    events: recording.events,
+    stop: recording.stop,
+  };
+}
+
+const FIXTURE_TASK_ID = makeTaskId("task_unit_agent_runner");
+const FIXTURE_ISSUE = makeIssueNumber(42);
+const FIXTURE_WORKTREE = "/var/lib/makina/worktrees/owner__name/issue-42";
+const FIXTURE_PROMPT = "Implement the requested feature.";
+const FIXTURE_MODEL = "claude-sonnet-4-6";
+const FIXTURE_CLAUDE = "/usr/local/bin/claude";
+
+// ---------------------------------------------------------------------------
+// Iterable + event-bus integration
+// ---------------------------------------------------------------------------
+
+Deno.test("runAgent yields projected messages and exhausts", async () => {
+  const { runner, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [
+      assistantMessage("Reading the repository..."),
+      assistantMessage("Done."),
+      resultMessage("Done."),
+    ],
+  });
+  try {
+    const messages = await drain(
+      runner.runAgent({
+        taskId: FIXTURE_TASK_ID,
+        issueNumber: FIXTURE_ISSUE,
+        worktreePath: FIXTURE_WORKTREE,
+        prompt: FIXTURE_PROMPT,
+        model: FIXTURE_MODEL,
+      }),
+    );
+    assertEquals(messages.length, 3);
+    assertEquals(messages[0]?.role, "assistant");
+    assertEquals(messages[0]?.text, "Reading the repository...");
+    assertEquals(messages[2]?.role, "system"); // `result` falls into `system`
+    assertEquals(messages[2]?.text, "Done.");
+  } finally {
+    stop();
+  }
+});
+
+Deno.test("runAgent publishes each message as an event-bus event tagged with taskId", async () => {
+  const { runner, events, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [
+      assistantMessage("Hello"),
+      assistantMessage("World"),
+    ],
+  });
+  try {
+    await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    }));
+    await flush();
+    assertEquals(events.length, 2);
+    for (const event of events) {
+      assertEquals(event.taskId, FIXTURE_TASK_ID);
+      assertEquals(event.kind, "agent-message");
+      assertEquals(event.atIso, "2026-04-26T00:00:00.000Z");
+    }
+    assert(events[0]?.kind === "agent-message");
+    assertEquals(events[0]?.data.text, "Hello");
+    assert(events[1]?.kind === "agent-message");
+    assertEquals(events[1]?.data.text, "World");
+  } finally {
+    stop();
+  }
+});
+
+Deno.test("runAgent emits only to subscribers of the matching taskId", async () => {
+  const otherTaskId = makeTaskId("task_other");
+  const { runner, bus, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [assistantMessage("only me")],
+  });
+  const matching: TaskEvent[] = [];
+  const nonMatching: TaskEvent[] = [];
+  const subA = bus.subscribe(FIXTURE_TASK_ID, (e) => matching.push(e));
+  const subB = bus.subscribe(otherTaskId, (e) => nonMatching.push(e));
+  try {
+    await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    }));
+    await flush();
+    assertEquals(matching.length, 1);
+    assertEquals(nonMatching.length, 0);
+  } finally {
+    subA.unsubscribe();
+    subB.unsubscribe();
+    stop();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Session resumption
+// ---------------------------------------------------------------------------
+
+Deno.test("runAndCollect carries the SDK session id out", async () => {
+  const { runner, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [
+      assistantMessage("Step one", "session-from-sdk"),
+      assistantMessage("Step two", "session-from-sdk"),
+    ],
+  });
+  try {
+    const result = await runner.runAndCollect({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    });
+    assertEquals(result.sessionId, "session-from-sdk");
+    assertEquals(result.messageCount, 2);
+  } finally {
+    stop();
+  }
+});
+
+Deno.test("runAndCollect omits sessionId when the SDK never provides one", async () => {
+  const { runner, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [{ type: "system", subtype: "init" } as SdkMessageProjection],
+  });
+  try {
+    const result = await runner.runAndCollect({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    });
+    assertEquals(result.sessionId, undefined);
+    assertEquals(result.messageCount, 1);
+  } finally {
+    stop();
+  }
+});
+
+Deno.test("runAgent forwards a caller-supplied sessionId to the SDK as resume", async () => {
+  const { runner, captures, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [assistantMessage("ok", "session-roundtrip")],
+  });
+  try {
+    await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+      sessionId: "session-roundtrip",
+    }));
+    assertEquals(captures.length, 1);
+    assertEquals(captures[0]?.options.resume, "session-roundtrip");
+  } finally {
+    stop();
+  }
+});
+
+Deno.test("runAgent omits resume when no sessionId was passed", async () => {
+  const { runner, captures, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [assistantMessage("ok")],
+  });
+  try {
+    await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    }));
+    assertEquals(captures.length, 1);
+    const captured = captures[0];
+    assertExists(captured);
+    assertEquals(Object.prototype.hasOwnProperty.call(captured.options, "resume"), false);
+  } finally {
+    stop();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// System-prompt addendum
+// ---------------------------------------------------------------------------
+
+Deno.test("buildSystemPromptAddendum embeds the issue number verbatim (snapshot)", () => {
+  const text = buildSystemPromptAddendum(makeIssueNumber(99));
+  // Snapshot the exact wording so silent drift is caught in PR review.
+  // Re-baseline only when intentionally changing the agent's commit
+  // protocol; bump the assertion together with the change.
+  const expected = [
+    "When you author commits in this worktree, every commit message MUST follow",
+    "the Conventional Commits format with the issue scope:",
+    "",
+    "    <type>(#99): <subject>",
+    "",
+    "where `<type>` is one of: feat, fix, docs, refactor, perf, test, build, ci,",
+    "chore, revert. The subject is imperative, lower-case, no trailing period,",
+    "and 72 characters or fewer. Body and footer are optional but follow the",
+    "same convention. Examples:",
+    "",
+    "    feat(#99): add task switcher overlay",
+    "    fix(#99): handle SIGPIPE on TUI disconnect",
+    "",
+    "Do not deviate from this format; the repository's commit-msg hook rejects",
+    "non-conforming subjects.",
+  ].join("\n");
+  assertEquals(text, expected);
+});
+
+Deno.test("runAgent appends the addendum to the SDK's preset system prompt", async () => {
+  const { runner, captures, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [assistantMessage("ok")],
+  });
+  try {
+    await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    }));
+    const prompt = captures[0]?.options.systemPrompt;
+    assertExists(prompt);
+    assertEquals(prompt.type, "preset");
+    assertEquals(prompt.preset, "claude_code");
+    assertStringIncludes(prompt.append, "(#42)");
+    assertStringIncludes(prompt.append, "Conventional Commits");
+  } finally {
+    stop();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// SDK options forwarded
+// ---------------------------------------------------------------------------
+
+Deno.test("runAgent forwards cwd / executable / permissionMode / model / claude path", async () => {
+  const { runner, captures, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [assistantMessage("ok")],
+  });
+  try {
+    await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    }));
+    const captured = captures[0];
+    assertExists(captured);
+    assertEquals(captured.prompt, FIXTURE_PROMPT);
+    assertEquals(captured.options.cwd, FIXTURE_WORKTREE);
+    assertEquals(captured.options.executable, "deno");
+    assertEquals(captured.options.permissionMode, "acceptEdits");
+    assertEquals(captured.options.model, FIXTURE_MODEL);
+    assertEquals(captured.options.pathToClaudeCodeExecutable, FIXTURE_CLAUDE);
+  } finally {
+    stop();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Executable discovery
+// ---------------------------------------------------------------------------
+
+Deno.test("runAgent uses an injected resolveExecutable when no override is set", async () => {
+  const resolutions: string[] = [];
+  const resolveExecutable: ExecutableResolver = (name) => {
+    resolutions.push(name);
+    return Promise.resolve("/opt/homebrew/bin/claude");
+  };
+  const { runner, captures, stop } = buildRunner({
+    resolveExecutable,
+    messages: [assistantMessage("ok")],
+  });
+  try {
+    await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    }));
+    assertEquals(resolutions, ["claude"]);
+    assertEquals(captures[0]?.options.pathToClaudeCodeExecutable, "/opt/homebrew/bin/claude");
+  } finally {
+    stop();
+  }
+});
+
+Deno.test("resolveExecutable is memoized after the first successful call", async () => {
+  let count = 0;
+  const resolveExecutable: ExecutableResolver = () => {
+    count += 1;
+    return Promise.resolve("/usr/local/bin/claude");
+  };
+  const { runner, stop } = buildRunner({
+    resolveExecutable,
+    messages: [assistantMessage("ok")],
+  });
+  try {
+    for (let i = 0; i < 3; i += 1) {
+      await drain(runner.runAgent({
+        taskId: FIXTURE_TASK_ID,
+        issueNumber: FIXTURE_ISSUE,
+        worktreePath: FIXTURE_WORKTREE,
+        prompt: FIXTURE_PROMPT,
+        model: FIXTURE_MODEL,
+      }));
+    }
+    assertEquals(count, 1);
+  } finally {
+    stop();
+  }
+});
+
+Deno.test("runAgent rejects with AgentRunnerError when claude is not on PATH", async () => {
+  const resolveExecutable: ExecutableResolver = () =>
+    Promise.reject(new Error("which claude failed (exit 1)"));
+  const { runner, stop } = buildRunner({
+    resolveExecutable,
+    messages: [],
+  });
+  try {
+    const error = await assertRejects(
+      () =>
+        drain(runner.runAgent({
+          taskId: FIXTURE_TASK_ID,
+          issueNumber: FIXTURE_ISSUE,
+          worktreePath: FIXTURE_WORKTREE,
+          prompt: FIXTURE_PROMPT,
+          model: FIXTURE_MODEL,
+        })),
+      AgentRunnerError,
+    );
+    assertEquals(error.operation, "resolveExecutable");
+    assertEquals(error.field, "pathToClaudeCodeExecutable");
+    assertStringIncludes(error.message, "Could not locate the `claude` CLI");
+    assertExists(error.cause);
+  } finally {
+    stop();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Error paths
+// ---------------------------------------------------------------------------
+
+Deno.test("runAgent rejects when worktreePath is empty", async () => {
+  const { runner, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [],
+  });
+  try {
+    const error = await assertRejects(
+      () =>
+        drain(runner.runAgent({
+          taskId: FIXTURE_TASK_ID,
+          issueNumber: FIXTURE_ISSUE,
+          worktreePath: "",
+          prompt: FIXTURE_PROMPT,
+          model: FIXTURE_MODEL,
+        })),
+      AgentRunnerError,
+    );
+    assertEquals(error.operation, "validateArgs");
+    assertEquals(error.field, "worktreePath");
+  } finally {
+    stop();
+  }
+});
+
+Deno.test("runAgent rejects when prompt is empty", async () => {
+  const { runner, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [],
+  });
+  try {
+    const error = await assertRejects(
+      () =>
+        drain(runner.runAgent({
+          taskId: FIXTURE_TASK_ID,
+          issueNumber: FIXTURE_ISSUE,
+          worktreePath: FIXTURE_WORKTREE,
+          prompt: "",
+          model: FIXTURE_MODEL,
+        })),
+      AgentRunnerError,
+    );
+    assertEquals(error.operation, "validateArgs");
+    assertEquals(error.field, "prompt");
+  } finally {
+    stop();
+  }
+});
+
+Deno.test("runAgent rejects when model is empty", async () => {
+  const { runner, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [],
+  });
+  try {
+    const error = await assertRejects(
+      () =>
+        drain(runner.runAgent({
+          taskId: FIXTURE_TASK_ID,
+          issueNumber: FIXTURE_ISSUE,
+          worktreePath: FIXTURE_WORKTREE,
+          prompt: FIXTURE_PROMPT,
+          model: "",
+        })),
+      AgentRunnerError,
+    );
+    assertEquals(error.operation, "validateArgs");
+    assertEquals(error.field, "model");
+  } finally {
+    stop();
+  }
+});
+
+Deno.test("runAgent wraps SDK rejections as AgentRunnerError carrying the cause", async () => {
+  const cause = new Error("network unreachable");
+  const { runner, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [assistantMessage("first")],
+    throwAt: 1,
+    throwError: cause,
+  });
+  try {
+    const error = await assertRejects(
+      () =>
+        drain(runner.runAgent({
+          taskId: FIXTURE_TASK_ID,
+          issueNumber: FIXTURE_ISSUE,
+          worktreePath: FIXTURE_WORKTREE,
+          prompt: FIXTURE_PROMPT,
+          model: FIXTURE_MODEL,
+        })),
+      AgentRunnerError,
+    );
+    assertEquals(error.operation, "sdkQuery");
+    assertEquals(error.cause, cause);
+    assertStringIncludes(error.message, "network unreachable");
+  } finally {
+    stop();
+  }
+});
+
+Deno.test(
+  "runAgent logs and continues when the bus publish call throws synchronously",
+  async () => {
+    const logger = recordingLogger();
+    const throwingBus: EventBus = {
+      publish() {
+        throw new Error("bus publish exploded");
+      },
+      subscribe() {
+        return { unsubscribe() {} };
+      },
+    };
+    const fake = fakeQuery({
+      messages: [assistantMessage("Hello"), assistantMessage("World")],
+    });
+    const runner = createAgentRunner({
+      eventBus: throwingBus,
+      query: fake.fn,
+      pathToClaudeCodeExecutable: FIXTURE_CLAUDE,
+      logger,
+      nowIso: () => "2026-04-26T00:00:00.000Z",
+    });
+    const messages = await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    }));
+    assertEquals(messages.length, 2);
+    // Two messages, two warnings, one per failed publish.
+    assertEquals(logger.messages.length, 2);
+    const firstWarning = logger.messages[0];
+    assertExists(firstWarning);
+    assertStringIncludes(firstWarning, "event-bus publish threw");
+  },
+);
+
+Deno.test("createAgentRunner rejects a missing eventBus at construction", () => {
+  let caught: unknown;
+  try {
+    // Intentionally bypass the type to exercise the runtime guard. The
+    // runtime check is the contract-side defense for callers that ignore
+    // the compiler error.
+    createAgentRunner({ eventBus: undefined as unknown as EventBus });
+  } catch (error) {
+    caught = error;
+  }
+  assertInstanceOf(caught, RangeError);
+  assertStringIncludes((caught as RangeError).message, "eventBus is required");
+});
+
+// ---------------------------------------------------------------------------
+// Message rendering
+// ---------------------------------------------------------------------------
+
+Deno.test("assistant messages with tool_use blocks render a `[tool ...]` line", async () => {
+  const { runner, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [
+      {
+        type: "assistant",
+        session_id: "session-stub",
+        message: {
+          content: [
+            { type: "text", text: "Reading the file." },
+            {
+              type: "tool_use",
+              name: "Read",
+              input: { path: "/etc/hosts" },
+            },
+          ],
+        },
+      },
+    ],
+  });
+  try {
+    const messages = await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    }));
+    assertEquals(messages.length, 1);
+    const first = messages[0];
+    assertExists(first);
+    assertStringIncludes(first.text, "Reading the file.");
+    assertStringIncludes(first.text, "[tool Read]");
+    assertStringIncludes(first.text, "/etc/hosts");
+  } finally {
+    stop();
+  }
+});
+
+Deno.test("messages of unknown SDK type render as `[<type>]`", async () => {
+  const { runner, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [{ type: "tool_progress", session_id: "session-stub" }],
+  });
+  try {
+    const messages = await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    }));
+    assertEquals(messages[0]?.text, "[tool_progress]");
+    assertEquals(messages[0]?.role, "system");
+  } finally {
+    stop();
+  }
+});
+
+Deno.test("user messages with text content render the concatenated text", async () => {
+  const { runner, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [
+      {
+        type: "user",
+        session_id: "session-stub",
+        message: {
+          content: [
+            { type: "text", text: "Tool result A" },
+            { type: "text", text: "Tool result B" },
+          ],
+        },
+      },
+    ],
+  });
+  try {
+    const messages = await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    }));
+    assertEquals(messages[0]?.role, "user");
+    assertEquals(messages[0]?.text, "Tool result A\nTool result B");
+  } finally {
+    stop();
+  }
+});
+
+Deno.test("tool_use blocks render gracefully when input has unrepresentable values", async () => {
+  // BigInt is not JSON-serialisable and should not abort the agent loop.
+  const { runner, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [
+      {
+        type: "assistant",
+        session_id: "session-stub",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              name: "Bash",
+              input: { count: 10n },
+            },
+          ],
+        },
+      },
+    ],
+  });
+  try {
+    const messages = await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    }));
+    const first = messages[0];
+    assertExists(first);
+    assertStringIncludes(first.text, "[tool Bash]");
+  } finally {
+    stop();
+  }
+});
+
+Deno.test("very long assistant text is truncated to the bus budget", async () => {
+  const oversized = "x".repeat(AGENT_MESSAGE_TEXT_TRUNCATION_CODE_UNITS + 100);
+  const { runner, events, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [assistantMessage(oversized)],
+  });
+  try {
+    const messages = await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    }));
+    await flush();
+    assertEquals(
+      messages[0]?.text.length,
+      AGENT_MESSAGE_TEXT_TRUNCATION_CODE_UNITS + 1, // ellipsis
+    );
+    assert(messages[0]?.text.endsWith("…"));
+    assertEquals(events.length, 1);
+    assert(events[0]?.kind === "agent-message");
+    assertEquals(
+      events[0]?.data.text.length,
+      AGENT_MESSAGE_TEXT_TRUNCATION_CODE_UNITS + 1,
+    );
+  } finally {
+    stop();
+  }
+});
+
+Deno.test("string tool inputs pass through without JSON wrapping", async () => {
+  const { runner, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [
+      {
+        type: "assistant",
+        session_id: "session-stub",
+        message: {
+          content: [{ type: "tool_use", name: "Read", input: "raw-string" }],
+        },
+      },
+    ],
+  });
+  try {
+    const messages = await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    }));
+    const first = messages[0];
+    assertExists(first);
+    // Bare string, not JSON-wrapped.
+    assertStringIncludes(first.text, "[tool Read] raw-string");
+  } finally {
+    stop();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// MockAgentRunner shape compatibility (lessons learned: the contract
+// surface is the wire across waves; the mock is the supervisor's test
+// substitute).
+// ---------------------------------------------------------------------------
+
+Deno.test("MockAgentRunner implements the supervisor's AgentRunner shape", async () => {
+  const mock = new MockAgentRunner();
+  mock.queueRun({
+    messages: [
+      { role: "assistant", text: "Hello" },
+      { role: "tool-use", text: "git diff" },
+    ],
+  });
+  const got: AgentRunnerMessage[] = [];
+  for await (
+    const msg of mock.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    })
+  ) {
+    got.push(msg);
+  }
+  assertEquals(got.length, 2);
+  assertEquals(mock.recordedInvocations().length, 1);
+  assertEquals(mock.recordedInvocations()[0]?.taskId, FIXTURE_TASK_ID);
+});
+
+Deno.test("MockAgentRunner records a roundtripped sessionId", () => {
+  const mock = new MockAgentRunner();
+  mock.queueRun({ messages: [] });
+  const _ = mock.runAgent({
+    taskId: FIXTURE_TASK_ID,
+    worktreePath: FIXTURE_WORKTREE,
+    prompt: FIXTURE_PROMPT,
+    model: FIXTURE_MODEL,
+    sessionId: "previous-session",
+  });
+  assertEquals(mock.recordedInvocations()[0]?.sessionId, "previous-session");
+});
+
+// ---------------------------------------------------------------------------
+// Standalone tool_use / tool_result message variants
+// ---------------------------------------------------------------------------
+
+Deno.test("standalone tool_use messages map to the tool-use role", async () => {
+  const { runner, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [{ type: "tool_use", session_id: "s" }],
+  });
+  try {
+    const messages = await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    }));
+    assertEquals(messages[0]?.role, "tool-use");
+  } finally {
+    stop();
+  }
+});
+
+Deno.test("standalone tool_result messages map to the tool-result role", async () => {
+  const { runner, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [{ type: "tool_result", session_id: "s" }],
+  });
+  try {
+    const messages = await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    }));
+    assertEquals(messages[0]?.role, "tool-result");
+  } finally {
+    stop();
+  }
+});
+
+Deno.test("tool_use blocks render an empty input string when input is null/undefined", async () => {
+  const { runner, stop } = buildRunner({
+    pathOverride: FIXTURE_CLAUDE,
+    messages: [
+      {
+        type: "assistant",
+        session_id: "s",
+        message: {
+          content: [
+            { type: "tool_use", name: "Read", input: undefined },
+            { type: "tool_use", name: "Glob", input: null },
+          ],
+        },
+      },
+    ],
+  });
+  try {
+    const messages = await drain(runner.runAgent({
+      taskId: FIXTURE_TASK_ID,
+      issueNumber: FIXTURE_ISSUE,
+      worktreePath: FIXTURE_WORKTREE,
+      prompt: FIXTURE_PROMPT,
+      model: FIXTURE_MODEL,
+    }));
+    const first = messages[0];
+    assertExists(first);
+    assertStringIncludes(first.text, "[tool Read]");
+    assertStringIncludes(first.text, "[tool Glob]");
+  } finally {
+    stop();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Default executable resolver (real `which`)
+// ---------------------------------------------------------------------------
+
+Deno.test({
+  name: "the default resolveExecutable invokes `which` against the real PATH",
+  // We rely on the host's `which sh` returning something useful. POSIX
+  // hosts (the only platforms makina ships to per ADR-008) all carry it.
+  // Branding `claude` would couple the test to whether the developer has
+  // Claude Code installed; a near-universal binary keeps the test green
+  // on a fresh dev box without skipping.
+  async fn() {
+    const fake = fakeQuery({ messages: [assistantMessage("ok")] });
+    const bus = createEventBus({ logger: recordingLogger() });
+    // Construct the runner with NO `resolveExecutable` override and NO
+    // `pathToClaudeCodeExecutable`. This drives `defaultResolveExecutable`
+    // — the real production path. We then expect `which claude` to fail
+    // unless the developer has Claude Code installed; that's the
+    // exception-throwing branch we want to cover. The test asserts an
+    // `AgentRunnerError` with `operation: "resolveExecutable"` either
+    // because `claude` is not on PATH (typical CI), or — if it *is*
+    // installed — the resolver succeeds and the run reaches the
+    // (test-only) stub query which proves the default path executed.
+    const runner = createAgentRunner({
+      eventBus: bus,
+      query: fake.fn,
+      nowIso: () => "2026-04-26T00:00:00.000Z",
+    });
+    try {
+      await drain(runner.runAgent({
+        taskId: FIXTURE_TASK_ID,
+        issueNumber: FIXTURE_ISSUE,
+        worktreePath: FIXTURE_WORKTREE,
+        prompt: FIXTURE_PROMPT,
+        model: FIXTURE_MODEL,
+      }));
+      // Reached here: `which claude` resolved. Coverage hit the success
+      // branch and the runner forwarded a non-empty path.
+      assertEquals(fake.captures.length, 1);
+      const captured = fake.captures[0];
+      assertExists(captured);
+      assert(captured.options.pathToClaudeCodeExecutable.length > 0);
+    } catch (caught) {
+      // Reached here: `which claude` failed. Coverage hit the
+      // failure branch.
+      assertInstanceOf(caught, AgentRunnerError);
+      assertEquals(caught.operation, "resolveExecutable");
+    }
+  },
+});


### PR DESCRIPTION
## Summary

Implements [#11](https://github.com/koraytaylan/makina/issues/11) — `AgentRunner` wrapping the official Claude Agent SDK with session resumption, conventional-commits system-prompt addendum, and event-bus streaming.

## Linked issue

Closes #11

## References

- Plan §Architecture (AgentRunner).