### PR TITLE
feat(#14): TUI overlays — command palette, task switcher, slash-command parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ requests a Copilot review, watches CI, addresses review comments, re-requests re
 merges the PR per the configured policy. Run multiple `/issue` commands in parallel — each task gets
 its own git worktree on its own branch.
 
+The TUI ships a command palette (default `Ctrl+P`) and a task switcher (default `Ctrl+G`) for
+mid-session control. See the [slash command catalog](docs/architecture.md#slash-commands-w3) for the
+full vocabulary.
+
 A long-running daemon owns the agents and the polling. Quitting the TUI does not stop the daemon;
 reattach later and the scrollback is intact.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,11 +29,39 @@ Two cooperating processes communicate over a Unix domain socket using NDJSON:
 
 ## TUI
 
-| Component                           | File                  | Wave |
-| ----------------------------------- | --------------------- | ---- |
-| `App`                               | `src/tui/App.tsx`     | W2   |
-| `Header` / `MainPane` / `StatusBar` | `src/tui/components/` | W2   |
-| `CommandPalette` / `TaskSwitcher`   | `src/tui/components/` | W3   |
+| Component                           | File                              | Wave |
+| ----------------------------------- | --------------------------------- | ---- |
+| `App`                               | `src/tui/App.tsx`                 | W2   |
+| `Header` / `MainPane` / `StatusBar` | `src/tui/components/`             | W2   |
+| `CommandPalette` / `TaskSwitcher`   | `src/tui/components/`             | W3   |
+| `useFocusedTask`                    | `src/tui/hooks/useFocusedTask.ts` | W3   |
+| Slash-command parser                | `src/tui/slash-command-parser.ts` | W3   |
+| Keybindings parser                  | `src/tui/keybindings.ts`          | W3   |
+
+### Slash commands (W3)
+
+The command palette parses leading-`/` lines through `src/tui/slash-command-parser.ts` and
+dispatches the resulting `CommandPayload` over the daemon socket. Per-command lifecycle is handled
+by the wave that owns the feature; the parser only validates shape:
+
+| Command                                 | Behaviour                               | Wave  |
+| --------------------------------------- | --------------------------------------- | ----- |
+| `/issue <number> [--repo <owner/name>]` | Start a new task.                       | W3-W4 |
+| `/repo {add\|default\|list}`            | Manage registered repositories.         | W3    |
+| `/status`                               | Print every in-flight task's state.     | W3    |
+| `/switch <task-id>`                     | Focus the listed task.                  | W3    |
+| `/cancel <task-id>`                     | Cancel a non-terminal task.             | W3    |
+| `/retry <task-id>`                      | Re-enter a `NEEDS_HUMAN` task.          | W3    |
+| `/merge <task-id>`                      | Force the merge of `READY_TO_MERGE`.    | W4    |
+| `/logs <task-id>`                       | Open the task scrollback.               | W3    |
+| `/quit`                                 | Exit the TUI; the daemon keeps running. | W3    |
+| `/daemon stop`                          | Stop the daemon process.                | W3    |
+| `/help [command]`                       | List commands or describe one.          | W3    |
+
+Default overlay toggles: `Ctrl+P` (palette), `Ctrl+G` (switcher); both are configurable via
+`tui.keybindings` in `config.json`. The chord parser in `src/tui/keybindings.ts` accepts
+`<modifier>+<key>` strings (`ctrl+p`, `ctrl+shift+tab`) and matches Ink's `useInput` flag bag
+uniformly across macOS and Linux.
 
 ## IPC protocol
 

--- a/main.ts
+++ b/main.ts
@@ -17,6 +17,7 @@ import { dirname } from "@std/path";
 
 import { MAKINA_VERSION } from "./src/constants.ts";
 import { ConfigLoadError, expandHome, loadConfig } from "./src/config/load.ts";
+import { createEventBus } from "./src/daemon/event-bus.ts";
 import { startDaemon } from "./src/daemon/server.ts";
 import {
   createStdioWizardIo,
@@ -35,30 +36,21 @@ if (Deno.args.includes("--version")) {
 const subcommand = Deno.args[0];
 
 if (subcommand === "daemon") {
-  // Defensive wiring for the Wave 2 daemon subcommand.
+  // Wiring for the Wave 2 daemon subcommand.
   //
-  // The config loader is now a direct import (this PR lands it). The
-  // EventBus (#8) is still loaded via dynamic `import()` because we
-  // distinguish two outcomes for *that* sibling:
+  // The config loader and the EventBus (#8) are both direct imports —
+  // `src/daemon/event-bus.ts` is permanent on develop, so the earlier
+  // dynamic-import + module-not-found fallback bought no value and just
+  // added a complex error-narrowing branch (a parse failure, a thrown
+  // top-level statement, or a permission error in the bus module would
+  // have been silently demoted to "module missing" if the sniff guessed
+  // wrong). A missing module now surfaces as a normal load failure.
   //
-  //  1. **Module not found** (`ERR_MODULE_NOT_FOUND`): the sibling has
-  //     not landed yet. Log a single `note:` line and continue with no
-  //     event bus, which makes `subscribe` envelopes ack with
-  //     `{ ok: false, error: "unimplemented" }`.
-  //  2. **Anything else** (parse failure, permission error, throwing
-  //     constructor, …): a real misconfiguration. Print the diagnostic
-  //     to stderr and exit non-zero. Silently swallowing these would
-  //     mean a typo'd `config.json` boots a daemon on `/tmp/makina.sock`
-  //     and the operator has no signal that anything went wrong.
-  //
-  // For the loader, a missing user `config.json` is also a benign signal
+  // For the loader, a missing user `config.json` is a benign signal
   // ("user has not run `makina setup` yet") — we log a one-liner and
   // fall back to `${TMPDIR:-/tmp}/makina.sock` so the binary still boots
   // for smoke-testing. Any other config failure (permissions, malformed
   // JSON, schema-invalid) exits non-zero with the loader's diagnostic.
-  //
-  // TODO(#8): once #8 lands, the event-bus branch becomes a direct
-  // import and the module-missing fallback can be dropped.
   const tmpDir = Deno.env.get("TMPDIR") ?? "/tmp";
   const fallbackSocketPath = `${tmpDir.replace(/\/$/, "")}/makina.sock`;
 
@@ -89,40 +81,9 @@ if (subcommand === "daemon") {
     }
   }
 
-  let eventBus: import("./src/types.ts").EventBus | undefined;
-  try {
-    // The event-bus module exports a `createEventBus()` factory, not a
-    // class. The dynamic import keeps the "module-missing → unimplemented"
-    // fallback while the real factory binding is the load-bearing line: a
-    // stale lookup for a non-existent class export would silently leave
-    // the daemon without an event bus and bury subscribe behind
-    // `unimplemented`. Once the dynamic-import fallback is no longer
-    // needed (TODO below), this becomes a direct top-level import.
-    const busModule = await import("./src/daemon/event-bus.ts");
-    const factory = (busModule as {
-      createEventBus?: () => import("./src/types.ts").EventBus;
-    }).createEventBus;
-    if (typeof factory === "function") {
-      eventBus = factory();
-    } else {
-      console.error(
-        "[daemon] note: src/daemon/event-bus.ts does not export createEventBus; subscribe will reply unimplemented",
-      );
-    }
-  } catch (error) {
-    if (isModuleNotFoundError(error)) {
-      console.error(
-        "[daemon] note: src/daemon/event-bus.ts not found; subscribe will reply unimplemented",
-      );
-    } else {
-      console.error(`[daemon] failed to initialise event bus: ${formatError(error)}`);
-      Deno.exit(1);
-    }
-  }
+  const eventBus = createEventBus();
 
-  const handle = await startDaemon(
-    eventBus === undefined ? { socketPath } : { socketPath, eventBus },
-  );
+  const handle = await startDaemon({ socketPath, eventBus });
   console.error(`[daemon] listening on ${handle.socketPath}`);
 
   // Translate SIGINT/SIGTERM into a clean shutdown so a crashed daemon
@@ -169,27 +130,6 @@ if (subcommand === "daemon") {
 } else {
   // Default branch → launch the Ink-based TUI.
   await import("./src/tui/App.tsx").then((module) => module.launch());
-}
-
-/**
- * Whether `error` is the specific "module file does not exist" failure
- * that Deno's dynamic `import()` raises. We treat this as a benign
- * "sibling has not landed yet" signal; every other failure (a parse
- * error in the module, a thrown top-level statement, a permission
- * issue) is propagated by the caller so misconfiguration cannot silently
- * downgrade the daemon's behaviour.
- *
- * Deno surfaces this as a `TypeError` whose `code` is the Node-style
- * `ERR_MODULE_NOT_FOUND`. We sniff the `code` field defensively because
- * the constructor is `TypeError` (a base class shared with many other
- * runtime failures), and the message text is best-effort only.
- */
-function isModuleNotFoundError(error: unknown): boolean {
-  if (!(error instanceof TypeError)) {
-    return false;
-  }
-  const code = (error as TypeError & { code?: unknown }).code;
-  return code === "ERR_MODULE_NOT_FOUND";
 }
 
 /** Render an arbitrary error value to a single-line diagnostic. */

--- a/main.ts
+++ b/main.ts
@@ -87,10 +87,22 @@ if (subcommand === "daemon") {
   console.error(`[daemon] listening on ${handle.socketPath}`);
 
   // Translate SIGINT/SIGTERM into a clean shutdown so a crashed daemon
-  // does not leave a stale socket file behind.
+  // does not leave a stale socket file behind. We always exit at the end
+  // of the handler — the signal has already fired, the operator wants
+  // the process gone, and any further work would race the OS-level
+  // tear-down. A `handle.stop()` rejection (e.g. an in-flight tear-down
+  // that fails to release the socket) is logged with a non-zero exit
+  // code so it is visible to whatever supervisor restarted us; without
+  // the try/catch the rejection would surface as an unhandled-promise
+  // warning while the process kept running.
   const shutdown = async () => {
-    await handle.stop();
-    Deno.exit(0);
+    try {
+      await handle.stop();
+      Deno.exit(0);
+    } catch (error) {
+      console.error(`[daemon] error during shutdown: ${formatError(error)}`);
+      Deno.exit(1);
+    }
   };
   Deno.addSignalListener("SIGINT", shutdown);
   Deno.addSignalListener("SIGTERM", shutdown);

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -27,6 +27,8 @@
 import { z } from "zod";
 
 import {
+  DEFAULT_COMMAND_PALETTE_KEYBINDING,
+  DEFAULT_TASK_SWITCHER_KEYBINDING,
   MAX_MAX_TASK_ITERATIONS,
   MAX_POLL_INTERVAL_MILLISECONDS,
   MAX_SETTLING_WINDOW_MILLISECONDS,
@@ -263,15 +265,15 @@ const daemonConfigSchema: z.ZodType<DaemonConfig, z.ZodTypeDef, unknown> = z.obj
 
 const keybindingsConfigSchema: z.ZodType<KeybindingsConfig, z.ZodTypeDef, unknown> = z
   .object({
-    commandPalette: z.string().min(1).default("ctrl+p"),
-    taskSwitcher: z.string().min(1).default("ctrl+g"),
+    commandPalette: z.string().min(1).default(DEFAULT_COMMAND_PALETTE_KEYBINDING),
+    taskSwitcher: z.string().min(1).default(DEFAULT_TASK_SWITCHER_KEYBINDING),
   })
   .strict();
 
 const tuiConfigSchema: z.ZodType<TuiConfig, z.ZodTypeDef, unknown> = z.object({
   keybindings: keybindingsConfigSchema.default({
-    commandPalette: "ctrl+p",
-    taskSwitcher: "ctrl+g",
+    commandPalette: DEFAULT_COMMAND_PALETTE_KEYBINDING,
+    taskSwitcher: DEFAULT_TASK_SWITCHER_KEYBINDING,
   }),
 }).strict();
 
@@ -283,7 +285,10 @@ const configSchema: z.ZodType<Config, z.ZodTypeDef, unknown> = z
     workspace: z.string().min(1),
     daemon: daemonConfigSchema,
     tui: tuiConfigSchema.default({
-      keybindings: { commandPalette: "ctrl+p", taskSwitcher: "ctrl+g" },
+      keybindings: {
+        commandPalette: DEFAULT_COMMAND_PALETTE_KEYBINDING,
+        taskSwitcher: DEFAULT_TASK_SWITCHER_KEYBINDING,
+      },
     }),
   })
   .strict()

--- a/src/config/setup-wizard.ts
+++ b/src/config/setup-wizard.ts
@@ -33,6 +33,8 @@ import { exists } from "@std/fs";
 import { type Config, type GitHubConfig, parseConfig } from "./schema.ts";
 import { defaultEnvLookup, type EnvLookup, expandHome } from "./load.ts";
 import {
+  DEFAULT_COMMAND_PALETTE_KEYBINDING,
+  DEFAULT_TASK_SWITCHER_KEYBINDING,
   MAX_TASK_ITERATIONS,
   POLL_INTERVAL_MILLISECONDS,
   RADIX_DECIMAL,
@@ -540,7 +542,10 @@ function buildConfig(seeds: ConfigSeeds): unknown {
       autoStart: true,
     },
     tui: {
-      keybindings: { commandPalette: "ctrl+p", taskSwitcher: "ctrl+g" },
+      keybindings: {
+        commandPalette: DEFAULT_COMMAND_PALETTE_KEYBINDING,
+        taskSwitcher: DEFAULT_TASK_SWITCHER_KEYBINDING,
+      },
     },
   };
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -357,3 +357,64 @@ export const HEX_RADIX = 16;
  * {@link HEX_RADIX} for the supervisor's id-mint helper.
  */
 export const HEX_BYTE_WIDTH_CHARACTERS = 2;
+
+/**
+ * Maximum number of historical command-palette inputs the overlay
+ * remembers across opens.
+ *
+ * The history is round-robined (oldest entry drops on overflow) so a
+ * long-running session does not grow without bound. Sized to the same
+ * order as a shell scrollback's recall depth: enough to feel useful in
+ * a single session, small enough that scanning back is still cheap.
+ */
+export const COMMAND_PALETTE_HISTORY_LIMIT = 50;
+
+/**
+ * Default keybinding chord that toggles the command-palette overlay.
+ *
+ * Mirrors the schema default in `src/config/schema.ts` so the App can
+ * treat the constant as authoritative when no config has been loaded
+ * (e.g. snapshot tests).
+ */
+export const DEFAULT_COMMAND_PALETTE_KEYBINDING = "ctrl+p";
+
+/**
+ * Default keybinding chord that toggles the task-switcher overlay.
+ *
+ * Mirrors the schema default in `src/config/schema.ts`.
+ */
+export const DEFAULT_TASK_SWITCHER_KEYBINDING = "ctrl+g";
+
+/**
+ * Number of milliseconds in one second.
+ *
+ * Used by the task-switcher's age-formatter so the bare `1000` does not
+ * leak into the renderer.
+ */
+export const MILLISECONDS_PER_SECOND = 1_000;
+
+/**
+ * Number of seconds in one minute.
+ */
+export const SECONDS_PER_MINUTE = 60;
+
+/**
+ * Number of minutes in one hour.
+ */
+export const MINUTES_PER_HOUR = 60;
+
+/**
+ * Number of hours in one day.
+ */
+export const HOURS_PER_DAY = 24;
+
+/**
+ * Maximum width, in UTF-16 code units, used to truncate a command-palette
+ * suggestion when it is rendered in the dropdown.
+ *
+ * Suggestion lines longer than this are abbreviated with an ellipsis so
+ * a single long entry cannot break the overlay layout. The limit is
+ * generous (twice the status bar's) because suggestion rows are the
+ * dominant content of the open palette.
+ */
+export const COMMAND_PALETTE_SUGGESTION_WIDTH_CODE_UNITS = 160;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -91,8 +91,12 @@ export const MAX_IPC_LENGTH_PREFIX_DIGITS = 8;
  * Default capacity of the in-process event-bus per-subscriber queue.
  *
  * Subscribers consume events through a bounded `ReadableStream`; once the
- * buffer fills the publisher applies backpressure (Wave 2 picks the exact
- * policy). The cap keeps a slow TUI from holding the daemon hostage.
+ * buffer fills, the publisher drops newly published events for that
+ * subscriber rather than blocking, and a single warning is emitted per
+ * overflow episode (further warnings are suppressed until the queue drains
+ * again, to avoid log spam). The cap keeps a slow TUI from holding the
+ * daemon hostage. See `docs/adrs/012-event-bus-backpressure-and-sync-callbacks.md`
+ * and `src/daemon/event-bus.ts` for the full policy.
  */
 export const EVENT_BUS_DEFAULT_BUFFER_SIZE = 256;
 

--- a/src/ipc/codec.ts
+++ b/src/ipc/codec.ts
@@ -112,29 +112,52 @@ export function encode(envelope: MessageEnvelope): Uint8Array {
  * State machine for the streaming decoder. Holds the unconsumed tail of
  * the byte stream between calls so frames split across `chunk` boundaries
  * are stitched together correctly.
+ *
+ * **Storage strategy.** The decoder keeps an array of chunks plus a
+ * running total length, and only collapses the queue into one contiguous
+ * `Uint8Array` when the next frame is being inspected. Appending a chunk
+ * is therefore O(1) regardless of how the bytes are split — a stream
+ * that delivers a 64 KiB frame as 64 separate 1 KiB writes does 64 cheap
+ * pushes plus a single concat per frame, instead of the O(n²) repeated
+ * concat the prior implementation suffered from when frames arrive in
+ * many small chunks. After a frame is extracted, the consumed bytes are
+ * dropped and the remaining tail (if any) is copied into a fresh
+ * `Uint8Array` so the codec does not retain the original chunks'
+ * backing `ArrayBuffer`s, which can be much larger than the tail.
  */
 class DecoderState {
   /**
-   * Pending bytes that have not been fully consumed into a frame yet.
-   * Initially empty; grows when a chunk supplies less than a complete
-   * frame, shrinks when whole frames are extracted.
+   * Pending chunks that together form the unconsumed byte stream. Empty
+   * when the decoder has nothing buffered. Each element is a view into
+   * the bytes the transport handed us, in arrival order.
    */
-  private buffer: Uint8Array = new Uint8Array(0);
+  private chunks: Uint8Array[] = [];
+  /**
+   * Total byte length across {@link DecoderState.chunks}. Maintained
+   * incrementally so we can answer "do we have enough bytes for this
+   * frame yet?" without re-scanning the chunk list.
+   */
+  private totalLength = 0;
+  /**
+   * Cached collapsed view of {@link DecoderState.chunks}. Built lazily by
+   * {@link DecoderState.materialize} when a frame is being inspected and
+   * invalidated whenever {@link DecoderState.chunks} is mutated.
+   */
+  private collapsed: Uint8Array | undefined;
 
   /**
-   * Append `chunk` to the pending buffer.
+   * Append `chunk` to the pending byte stream. O(1) — no copy. Empty
+   * chunks are dropped to keep the chunk list short.
    *
    * @param chunk Bytes pulled from the underlying transport.
    */
   push(chunk: Uint8Array): void {
-    if (this.buffer.byteLength === 0) {
-      this.buffer = chunk;
+    if (chunk.byteLength === 0) {
       return;
     }
-    const merged = new Uint8Array(this.buffer.byteLength + chunk.byteLength);
-    merged.set(this.buffer, 0);
-    merged.set(chunk, this.buffer.byteLength);
-    this.buffer = merged;
+    this.chunks.push(chunk);
+    this.totalLength += chunk.byteLength;
+    this.collapsed = undefined;
   }
 
   /**
@@ -145,7 +168,10 @@ class DecoderState {
    * @throws {IpcCodecError} On any framing or schema problem.
    */
   next(): MessageEnvelope | undefined {
-    const view = this.buffer;
+    if (this.totalLength === 0) {
+      return undefined;
+    }
+    const view = this.materialize();
     const newlineIndex = indexOfNewline(view);
     if (newlineIndex === -1) {
       if (view.byteLength > MAX_IPC_LENGTH_PREFIX_DIGITS) {
@@ -211,8 +237,22 @@ class DecoderState {
       throw new IpcCodecError("frame payload failed schema validation", validation.issues);
     }
 
-    // Drop the consumed bytes (prefix + newline + payload + trailing newline).
-    this.buffer = view.subarray(trailerEnd);
+    // Drop the consumed bytes (prefix + newline + payload + trailing
+    // newline). Copy the remaining tail into a fresh `Uint8Array` so we
+    // do not retain the full backing `ArrayBuffer` of a large
+    // previously-decoded frame: `subarray` keeps a reference to the
+    // entire underlying buffer, which can be tens of MiB.
+    const tail = view.subarray(trailerEnd);
+    if (tail.byteLength === 0) {
+      this.chunks = [];
+      this.totalLength = 0;
+      this.collapsed = undefined;
+    } else {
+      const owned = new Uint8Array(tail);
+      this.chunks = [owned];
+      this.totalLength = owned.byteLength;
+      this.collapsed = owned;
+    }
     return validation.data;
   }
 
@@ -223,7 +263,45 @@ class DecoderState {
    * @returns `true` iff there is at least one buffered byte.
    */
   hasPendingBytes(): boolean {
-    return this.buffer.byteLength > 0;
+    return this.totalLength > 0;
+  }
+
+  /**
+   * Collapse {@link DecoderState.chunks} into a single contiguous
+   * `Uint8Array`. Cached so two `next()` calls in a row do not pay the
+   * concat cost twice; invalidated whenever a chunk is appended.
+   *
+   * Single-chunk fast path: when there is exactly one pending chunk,
+   * return it without copying — the typical case once a frame fits in
+   * one transport read.
+   */
+  private materialize(): Uint8Array {
+    if (this.collapsed !== undefined) {
+      return this.collapsed;
+    }
+    if (this.chunks.length === 1) {
+      const sole = this.chunks[0];
+      if (sole === undefined) {
+        // Defensive: chunks.length === 1 but chunks[0] is undefined is
+        // impossible under normal control flow, so fall through to the
+        // empty-array case rather than asserting non-null.
+        return new Uint8Array(0);
+      }
+      this.collapsed = sole;
+      return sole;
+    }
+    const combined = new Uint8Array(this.totalLength);
+    let offset = 0;
+    for (const chunk of this.chunks) {
+      combined.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    // Replace the chunk list with the combined view so subsequent
+    // `next()` calls can short-circuit on the single-chunk fast path,
+    // and so `push()` does not have to walk a long chunk list.
+    this.chunks = [combined];
+    this.collapsed = combined;
+    return combined;
   }
 }
 

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -13,17 +13,27 @@
  * @module
  */
 
-import { Box, render, Text, useApp } from "ink";
-import { type ReactElement, useEffect, useMemo, useState } from "react";
+import { Box, render, Text, useApp, useInput } from "ink";
+import { type ReactElement, useCallback, useEffect, useMemo, useState } from "react";
 
+import { CommandPalette } from "./components/CommandPalette.tsx";
 import { Header } from "./components/Header.tsx";
 import { MainPane } from "./components/MainPane.tsx";
 import { StatusBar } from "./components/StatusBar.tsx";
-import { type DaemonClient, SocketDaemonClient } from "./ipc-client.ts";
+import { TaskSwitcher } from "./components/TaskSwitcher.tsx";
+import { type DaemonClient, type DaemonReply, SocketDaemonClient } from "./ipc-client.ts";
 import { type ConnectionLifecycle, useDaemonConnection } from "./hooks/useDaemonConnection.ts";
-import type { EventPayload } from "../ipc/protocol.ts";
+import { useFocusedTask } from "./hooks/useFocusedTask.ts";
+import { matchesKeybinding } from "./keybindings.ts";
+import type { CommandPayload, EventPayload, MessageEnvelope } from "../ipc/protocol.ts";
 import { makeTaskId, type TaskId } from "../types.ts";
-import { MAKINA_VERSION, STATUS_BAR_TRUNCATION_WIDTH_CODE_UNITS } from "../constants.ts";
+import {
+  COMMAND_PALETTE_HISTORY_LIMIT,
+  DEFAULT_COMMAND_PALETTE_KEYBINDING,
+  DEFAULT_TASK_SWITCHER_KEYBINDING,
+  MAKINA_VERSION,
+  STATUS_BAR_TRUNCATION_WIDTH_CODE_UNITS,
+} from "../constants.ts";
 
 /**
  * Default Unix-socket path the daemon listens on.
@@ -32,6 +42,18 @@ import { MAKINA_VERSION, STATUS_BAR_TRUNCATION_WIDTH_CODE_UNITS } from "../const
  * config loader can supply a different one.
  */
 const DEFAULT_DAEMON_SOCKET_PATH = `${Deno.env.get("HOME") ?? "/tmp"}/.makina/daemon.sock`;
+
+/**
+ * Subset of TUI keybindings the App reads. Only the overlay toggles
+ * are needed here; future keybindings (focus next task, send prompt,
+ * …) extend this interface alongside their config schema entries.
+ */
+export interface AppKeybindings {
+  /** Chord that toggles the command-palette overlay. */
+  readonly commandPalette: string;
+  /** Chord that toggles the task-switcher overlay. */
+  readonly taskSwitcher: string;
+}
 
 /**
  * Props accepted by {@link App}.
@@ -43,8 +65,8 @@ export interface AppProps {
    */
   readonly client: DaemonClient & ConnectionLifecycle;
   /**
-   * Initial focused-task id. Wave 3 wires the task switcher; until
-   * then the value is provided externally for snapshot determinism.
+   * Initial focused-task id. Forwarded to {@link useFocusedTask} so the
+   * Header's focus pill renders deterministically from snapshot tests.
    */
   readonly initialFocusedTaskId?: TaskId | undefined;
   /**
@@ -59,6 +81,23 @@ export interface AppProps {
    * @default true
    */
   readonly autoConnect?: boolean | undefined;
+  /**
+   * Optional keybindings override. Defaults to the constants
+   * mirrored from `src/config/schema.ts`. Production callers should
+   * forward the loaded `Config.tui.keybindings`; snapshot tests pin
+   * the defaults.
+   *
+   * @default { commandPalette: "ctrl+p", taskSwitcher: "ctrl+g" }
+   */
+  readonly keybindings?: AppKeybindings | undefined;
+  /**
+   * If `true`, Ink's `useInput` hooks at the App level are wired up.
+   * Snapshot tests render with `inputEnabled={false}` so Ink does
+   * not race the Deno test sanitizer with stdin readers.
+   *
+   * @default true
+   */
+  readonly inputEnabled?: boolean | undefined;
 }
 
 /**
@@ -81,15 +120,26 @@ export function App(props: AppProps): ReactElement {
     initialFocusedTaskId,
     version = MAKINA_VERSION,
     autoConnect = true,
+    keybindings = {
+      commandPalette: DEFAULT_COMMAND_PALETTE_KEYBINDING,
+      taskSwitcher: DEFAULT_TASK_SWITCHER_KEYBINDING,
+    },
+    inputEnabled = true,
   } = props;
   const connection = useDaemonConnection({
     client,
     autoConnect,
   });
+  const focus = useFocusedTask({
+    source: client,
+    initialFocusedTaskId,
+  });
   const [knownTaskIds, setKnownTaskIds] = useState<ReadonlySet<TaskId>>(() => new Set());
   const [lastMessage, setLastMessage] = useState<string | undefined>(undefined);
   const [lastError, setLastError] = useState<string | undefined>(undefined);
-  const [focusedTaskId, setFocusedTaskId] = useState<TaskId | undefined>(initialFocusedTaskId);
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const [switcherOpen, setSwitcherOpen] = useState(false);
+  const [paletteHistory, setPaletteHistory] = useState<readonly string[]>([]);
 
   useEffect(() => {
     const subscription = connection.subscribe((event) => {
@@ -97,7 +147,6 @@ export function App(props: AppProps): ReactElement {
         setKnownTaskIds,
         setLastMessage,
         setLastError,
-        setFocusedTaskId,
       });
     });
     return () => {
@@ -119,23 +168,192 @@ export function App(props: AppProps): ReactElement {
     }
   }, [connection.status, connection.lastError]);
 
+  const overlayOpen = paletteOpen || switcherOpen;
+
+  // Top-level chord handler: toggles the overlays per the configured
+  // keybindings. Disabled while an overlay is already open so the
+  // overlay's own input handler owns the keystroke (Esc closes;
+  // typing into the palette is forwarded as text).
+  useInput(
+    (input, key) => {
+      if (!inputEnabled || overlayOpen) {
+        return;
+      }
+      if (matchesKeybinding(keybindings.commandPalette, input, key)) {
+        setPaletteOpen(true);
+        return;
+      }
+      if (matchesKeybinding(keybindings.taskSwitcher, input, key)) {
+        setSwitcherOpen(true);
+      }
+    },
+    { isActive: inputEnabled && !overlayOpen },
+  );
+
+  const handlePaletteSubmit = useCallback(
+    (payload: CommandPayload, raw: string) => {
+      setPaletteHistory((previous) => trimHistory([raw, ...previous]));
+      setPaletteOpen(false);
+      // Fire-and-forget: the App reflects the dispatch in the status
+      // bar; per-command lifecycle is owned by the relevant wave.
+      void dispatchCommand((envelope) => connection.send(envelope), payload).then(
+        (result) => {
+          if (result.kind === "error") {
+            setLastError(result.message);
+            return;
+          }
+          setLastMessage(result.message);
+        },
+        // The send is wrapped in a success/error result, so the
+        // promise itself only rejects on truly exceptional errors;
+        // surface those to the status bar.
+        (error) => {
+          setLastError(
+            error instanceof Error ? error.message : String(error),
+          );
+        },
+      );
+    },
+    [connection.send],
+  );
+
+  const handlePaletteClose = useCallback(() => {
+    setPaletteOpen(false);
+  }, []);
+
+  const handleSwitcherPick = useCallback(
+    (taskId: TaskId) => {
+      focus.focusTask(taskId);
+      setSwitcherOpen(false);
+    },
+    [focus],
+  );
+
+  const handleSwitcherClose = useCallback(() => {
+    setSwitcherOpen(false);
+  }, []);
+
+  const keybindingsHint =
+    `${keybindings.commandPalette} palette · ${keybindings.taskSwitcher} switcher · Ctrl+C exit`;
+
   return (
     <Box flexDirection="column">
       <Header
         version={version}
         status={connection.status}
-        focusedTaskId={focusedTaskId}
+        focusedTaskId={focus.focusedTaskId}
       />
       <MainPane
-        activeTaskCount={knownTaskIds.size}
+        activeTaskCount={Math.max(knownTaskIds.size, focus.tasks.length)}
         hint={hint}
       />
+      {paletteOpen
+        ? (
+          <CommandPalette
+            history={paletteHistory}
+            onSubmit={handlePaletteSubmit}
+            onClose={handlePaletteClose}
+            inputEnabled={inputEnabled}
+          />
+        )
+        : null}
+      {switcherOpen
+        ? (
+          <TaskSwitcher
+            tasks={focus.tasks}
+            focusedTaskId={focus.focusedTaskId}
+            onPick={handleSwitcherPick}
+            onClose={handleSwitcherClose}
+            inputEnabled={inputEnabled}
+          />
+        )
+        : null}
       <StatusBar
         message={lastMessage ?? "ready"}
         errorMessage={lastError ?? connection.lastError}
+        keybindingsHint={keybindingsHint}
       />
     </Box>
   );
+}
+
+/**
+ * Trim `entries` to {@link COMMAND_PALETTE_HISTORY_LIMIT}, keeping the
+ * head (most-recent) entries. Exported for unit-test reuse.
+ *
+ * @param entries Candidate history entries.
+ * @returns The trimmed array.
+ */
+export function trimHistory(entries: readonly string[]): readonly string[] {
+  if (entries.length <= COMMAND_PALETTE_HISTORY_LIMIT) {
+    return entries;
+  }
+  return entries.slice(0, COMMAND_PALETTE_HISTORY_LIMIT);
+}
+
+/**
+ * Outcome reported back to {@link App}'s status bar after a palette
+ * submission. Exported so the unit tests around
+ * {@link dispatchCommand} can pin the discriminant.
+ */
+export interface DispatchOutcome {
+  /** `"ok"` for an accepted command; `"error"` for a refusal. */
+  readonly kind: "ok" | "error";
+  /** Human-readable status-bar message. */
+  readonly message: string;
+}
+
+/**
+ * Send a parsed command envelope to the daemon and translate the
+ * reply into a status-bar message. Exported for unit-test reuse.
+ *
+ * @param send The {@link useDaemonConnection} `send` callback.
+ * @param payload The parsed command payload.
+ * @returns The status-bar outcome.
+ */
+export async function dispatchCommand(
+  send: (envelope: MessageEnvelope) => Promise<DaemonReply>,
+  payload: CommandPayload,
+): Promise<DispatchOutcome> {
+  const envelope: MessageEnvelope = {
+    id: makeCommandEnvelopeId(),
+    type: "command",
+    payload,
+  };
+  try {
+    const reply = await send(envelope);
+    if (reply.type !== "ack") {
+      return {
+        kind: "error",
+        message: `unexpected reply for /${payload.name}: ${reply.type}`,
+      };
+    }
+    if (reply.payload.ok === false) {
+      return {
+        kind: "error",
+        message: reply.payload.error ?? `/${payload.name} refused`,
+      };
+    }
+    return { kind: "ok", message: `/${payload.name} dispatched` };
+  } catch (error) {
+    return {
+      kind: "error",
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Mint a fresh envelope id for a command dispatch.
+ *
+ * Uses `crypto.randomUUID()` so collisions cannot happen in practice;
+ * isolated to a helper so tests that stub the random source have a
+ * single seam.
+ *
+ * @returns The envelope id.
+ */
+function makeCommandEnvelopeId(): string {
+  return `cmd-${crypto.randomUUID()}`;
 }
 
 /**
@@ -144,10 +362,9 @@ export function App(props: AppProps): ReactElement {
  * call site passes React `useState` setters, while tests pass plain
  * closures that capture into local variables.
  *
- * `setFocusedTaskId` accepts a functional updater so the handler can
- * apply "auto-focus only when nothing is focused yet" without reading
- * the current focused-task value out of band — the React setter and
- * the test stubs both honor the closure-style update.
+ * Wave 3 lifted the focused-task slot into {@link useFocusedTask}, so
+ * the handler no longer reaches in here. The remaining slots are owned
+ * by the App component: known-task tally, last log/error.
  */
 export interface EventSetters {
   /** Setter for the known-tasks set used by `MainPane`. */
@@ -158,15 +375,6 @@ export interface EventSetters {
   readonly setLastMessage: (next: string | undefined) => void;
   /** Setter for the most-recent error message rendered in the status bar. */
   readonly setLastError: (next: string | undefined) => void;
-  /**
-   * Setter for the focused task id rendered in the header.
-   *
-   * Receives a functional updater so {@link handleEvent} can preserve
-   * an existing focus instead of clobbering it on every event.
-   */
-  readonly setFocusedTaskId: (
-    update: (previous: TaskId | undefined) => TaskId | undefined,
-  ) => void;
 }
 
 /**
@@ -193,12 +401,6 @@ export function handleEvent(event: EventPayload, setters: EventSetters): void {
     next.add(taskId);
     return next;
   });
-  // Auto-focus the first task we hear about so the header's focus pill
-  // stops saying "no task focused" once events arrive. Subsequent
-  // events leave the focused task alone — Wave 3's task switcher will
-  // own focus changes — so the focus does not jump around as new
-  // tasks appear.
-  setters.setFocusedTaskId((previous) => previous ?? taskId);
   switch (event.kind) {
     case "log":
       setters.setLastMessage(`[${event.data.level}] ${event.data.message}`);

--- a/src/tui/components/CommandPalette.tsx
+++ b/src/tui/components/CommandPalette.tsx
@@ -119,10 +119,18 @@ export function CommandPalette(props: CommandPaletteProps): ReactElement {
     if (input.trim().length === 0) {
       return;
     }
+    // The overlay renders a leading `/` placeholder when `input` is
+    // empty, but `input` itself is the source of truth. If the user
+    // types the command name without an explicit `/` (relying on the
+    // visual hint) reconstruct the canonical `/<name>` form before
+    // parsing so the captured payload matches what the user saw on
+    // screen. A user who typed an explicit `/` keeps it verbatim.
+    const trimmed = input.trim();
+    const canonical = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
     try {
-      const payload = parseSlashCommand(input);
+      const payload = parseSlashCommand(canonical);
       setParseError(undefined);
-      onSubmit(payload, input.trim());
+      onSubmit(payload, canonical);
     } catch (error) {
       if (error instanceof SlashCommandParseError) {
         setParseError(error.message);

--- a/src/tui/components/CommandPalette.tsx
+++ b/src/tui/components/CommandPalette.tsx
@@ -1,0 +1,367 @@
+/**
+ * tui/components/CommandPalette.tsx — overlay that captures user
+ * input and dispatches it as a slash command.
+ *
+ * Default toggle: `Ctrl+P` (configurable via `tui.keybindings.commandPalette`
+ * in `config.json`). When open, the overlay renders a single-line
+ * input field plus an autocomplete dropdown filtered against
+ * {@link "../slash-command-parser.ts".SLASH_COMMAND_SPECS}; `Enter`
+ * parses the line and forwards the resulting
+ * {@link "../../ipc/protocol.ts".CommandPayload} to {@link CommandPaletteProps.onSubmit}.
+ *
+ * History is kept in-memory only — Wave 3 does not persist it across
+ * runs (#14 explicitly out-of-scope). Up/Down without a typed prefix
+ * walks the history; once the user types, Up/Down navigates the
+ * suggestion dropdown instead.
+ *
+ * @module
+ */
+
+import { Box, Text, useInput } from "ink";
+import { type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  parseSlashCommand,
+  SLASH_COMMAND_SPECS,
+  SlashCommandParseError,
+  type SlashCommandSpec,
+} from "../slash-command-parser.ts";
+import type { CommandPayload } from "../../ipc/protocol.ts";
+import {
+  COMMAND_PALETTE_HISTORY_LIMIT,
+  COMMAND_PALETTE_SUGGESTION_WIDTH_CODE_UNITS,
+} from "../../constants.ts";
+
+/**
+ * Props accepted by {@link CommandPalette}.
+ */
+export interface CommandPaletteProps {
+  /**
+   * Called when the user submits a parsed command. The App routes the
+   * payload through the daemon connection and closes the overlay.
+   *
+   * @param payload The parsed command payload.
+   * @param raw The raw user input that produced it (with surrounding
+   *   whitespace trimmed). Useful for the App-level history log.
+   */
+  readonly onSubmit: (payload: CommandPayload, raw: string) => void;
+  /** Called when the user dismisses the overlay (`Escape`). */
+  readonly onClose: () => void;
+  /**
+   * Optional history seed. The overlay defensively copies and trims
+   * to {@link COMMAND_PALETTE_HISTORY_LIMIT}. Most-recent first.
+   */
+  readonly history?: readonly string[] | undefined;
+  /**
+   * If `true`, Ink's `useInput` is wired up. The snapshot tests render
+   * the overlay with `inputEnabled={false}` so Ink's stdin reader
+   * does not race the Deno test sanitizer.
+   *
+   * @default true
+   */
+  readonly inputEnabled?: boolean | undefined;
+  /**
+   * Initial input value, useful for the snapshot tests' "filtered"
+   * variant. Defaults to `""`.
+   */
+  readonly initialInput?: string | undefined;
+}
+
+/**
+ * Render the command-palette overlay.
+ *
+ * @param props See {@link CommandPaletteProps}.
+ * @returns The overlay element.
+ *
+ * @example
+ * ```tsx
+ * <CommandPalette
+ *   onSubmit={(payload) => sendCommand(payload)}
+ *   onClose={() => setOpen(false)}
+ *   history={paletteHistory}
+ * />
+ * ```
+ */
+export function CommandPalette(props: CommandPaletteProps): ReactElement {
+  const {
+    onSubmit,
+    onClose,
+    history = [],
+    inputEnabled = true,
+    initialInput = "",
+  } = props;
+  const [input, setInput] = useState(initialInput);
+  const [suggestionIndex, setSuggestionIndex] = useState(0);
+  const [, setHistoryIndex] = useState<number | null>(null);
+  const [parseError, setParseError] = useState<string | undefined>(undefined);
+
+  // Trim and de-duplicate the seeded history so the up/down navigation
+  // never replays the same line twice in a row.
+  const trimmedHistory = useMemo(() => {
+    return dedupe(history).slice(0, COMMAND_PALETTE_HISTORY_LIMIT);
+  }, [history]);
+
+  // Filter the spec list to entries whose name shares a prefix with
+  // the current input (with the leading `/` stripped). When the input
+  // is empty, every spec is shown.
+  const suggestions = useMemo<readonly SlashCommandSpec[]>(() => {
+    return filterSuggestions(input);
+  }, [input]);
+
+  // Re-pin the suggestion cursor whenever the suggestion list shrinks.
+  useEffect(() => {
+    if (suggestionIndex >= suggestions.length) {
+      setSuggestionIndex(suggestions.length === 0 ? 0 : suggestions.length - 1);
+    }
+  }, [suggestionIndex, suggestions.length]);
+
+  const handleSubmit = useCallback(() => {
+    if (input.trim().length === 0) {
+      return;
+    }
+    try {
+      const payload = parseSlashCommand(input);
+      setParseError(undefined);
+      onSubmit(payload, input.trim());
+    } catch (error) {
+      if (error instanceof SlashCommandParseError) {
+        setParseError(error.message);
+        return;
+      }
+      throw error;
+    }
+  }, [input, onSubmit]);
+
+  // Stable input ref so the keyboard handler can read the current
+  // value without re-binding on every keystroke.
+  const inputRef = useRef(input);
+  useEffect(() => {
+    inputRef.current = input;
+  }, [input]);
+
+  const applyHistory = useCallback(
+    (delta: 1 | -1) => {
+      if (trimmedHistory.length === 0) {
+        return;
+      }
+      setHistoryIndex((previous) => {
+        const start = previous ?? -1;
+        const candidate = start + delta;
+        if (candidate < 0) {
+          // Walked above the freshest entry — restore the in-progress
+          // input the user had before they started navigating.
+          return null;
+        }
+        const clamped = Math.min(candidate, trimmedHistory.length - 1);
+        const replacement = trimmedHistory[clamped];
+        if (replacement !== undefined) {
+          setInput(replacement);
+        }
+        return clamped;
+      });
+    },
+    [trimmedHistory],
+  );
+
+  const handleInputChange = useCallback((next: string) => {
+    setInput(next);
+    setHistoryIndex(null);
+    setSuggestionIndex(0);
+    setParseError(undefined);
+  }, []);
+
+  // Decide whether arrow keys walk history or autocomplete: when the
+  // input field is empty (or whitespace), arrows walk history; once
+  // the user is typing, arrows navigate the suggestion dropdown.
+  const arrowsNavigateHistory = input.trim().length === 0;
+
+  useInput(
+    (rawInput, key) => {
+      if (!inputEnabled) {
+        return;
+      }
+      if (key.escape) {
+        onClose();
+        return;
+      }
+      if (key.return) {
+        handleSubmit();
+        return;
+      }
+      if (key.upArrow) {
+        if (arrowsNavigateHistory) {
+          applyHistory(1);
+          return;
+        }
+        if (suggestions.length > 0) {
+          setSuggestionIndex((previous) => previous <= 0 ? suggestions.length - 1 : previous - 1);
+        }
+        return;
+      }
+      if (key.downArrow) {
+        if (arrowsNavigateHistory) {
+          applyHistory(-1);
+          return;
+        }
+        if (suggestions.length > 0) {
+          setSuggestionIndex((previous) => (previous + 1) % suggestions.length);
+        }
+        return;
+      }
+      if (key.tab) {
+        // Tab inserts the highlighted suggestion's canonical
+        // `/<name>` form. The user can keep typing arguments after.
+        const chosen = suggestions[suggestionIndex];
+        if (chosen !== undefined) {
+          handleInputChange(`/${chosen.name} `);
+        }
+        return;
+      }
+      if (key.backspace || key.delete) {
+        if (inputRef.current.length === 0) {
+          return;
+        }
+        handleInputChange(inputRef.current.slice(0, -1));
+        return;
+      }
+      if (rawInput.length > 0 && !key.ctrl && !key.meta) {
+        handleInputChange(`${inputRef.current}${rawInput}`);
+      }
+    },
+    { isActive: inputEnabled },
+  );
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="cyan"
+      paddingX={1}
+      paddingY={0}
+    >
+      <Box justifyContent="space-between">
+        <Text bold color="cyan">Command Palette</Text>
+        <Text dimColor>Tab autocomplete · Enter run · Esc close</Text>
+      </Box>
+      <Box>
+        <Text color="cyan">{"> "}</Text>
+        <Text>{input.length === 0 ? "/" : input}</Text>
+      </Box>
+      {parseError !== undefined
+        ? <Text color="red">{parseError}</Text>
+        : suggestions.length === 0
+        ? <Text dimColor>No matching commands.</Text>
+        : (
+          <Box flexDirection="column">
+            {suggestions.map((spec, index) => (
+              <SuggestionRow
+                key={spec.name}
+                spec={spec}
+                highlighted={index === suggestionIndex}
+              />
+            ))}
+          </Box>
+        )}
+      <Box>
+        {trimmedHistory.length > 0
+          ? (
+            <Text dimColor>
+              History: {trimmedHistory.length} ↑/↓ recall
+            </Text>
+          )
+          : <Text dimColor>No history yet.</Text>}
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Filter {@link SLASH_COMMAND_SPECS} to entries whose name shares a
+ * prefix with the current input. The input may or may not start with
+ * `/`; both shapes filter identically.
+ *
+ * Public so the snapshot tests can drive deterministic dropdowns
+ * without going through `useState`.
+ *
+ * @param input Current palette input.
+ * @returns The filtered specs, in the source order
+ *   ({@link SLASH_COMMAND_SPECS} is alphabetical).
+ */
+export function filterSuggestions(input: string): readonly SlashCommandSpec[] {
+  const trimmed = input.trim();
+  const stem = trimmed.startsWith("/") ? trimmed.slice(1) : trimmed;
+  if (stem.length === 0) {
+    return SLASH_COMMAND_SPECS;
+  }
+  // Match the head token only — once the user has typed past the name
+  // (`/issue 4` etc.) the dropdown narrows to the matching spec.
+  const head = stem.split(/\s+/u, 1)[0] ?? "";
+  return SLASH_COMMAND_SPECS.filter((spec) => spec.name.startsWith(head));
+}
+
+/**
+ * Drop duplicates from `entries`, preserving order. Empty strings are
+ * dropped too — the history is round-robined by trimming the head;
+ * an empty entry would compare equal to nothing.
+ *
+ * @param entries The candidate entries.
+ * @returns The de-duplicated list.
+ */
+function dedupe(entries: readonly string[]): readonly string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const entry of entries) {
+    const trimmed = entry.trim();
+    if (trimmed.length === 0) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+/**
+ * Render one entry in the suggestion dropdown.
+ */
+interface SuggestionRowProps {
+  /** The spec to render. */
+  readonly spec: SlashCommandSpec;
+  /** Whether the cursor sits on this entry. */
+  readonly highlighted: boolean;
+}
+
+/**
+ * Render one suggestion row.
+ *
+ * @param props See {@link SuggestionRowProps}.
+ * @returns The row element.
+ */
+function SuggestionRow(props: SuggestionRowProps): ReactElement {
+  const { spec, highlighted } = props;
+  const cursor = highlighted ? ">" : " ";
+  const text = `${cursor} /${spec.name} — ${spec.summary}`;
+  if (highlighted) {
+    return (
+      <Text color="cyan">
+        {truncate(text, COMMAND_PALETTE_SUGGESTION_WIDTH_CODE_UNITS)}
+      </Text>
+    );
+  }
+  return <Text>{truncate(text, COMMAND_PALETTE_SUGGESTION_WIDTH_CODE_UNITS)}</Text>;
+}
+
+/**
+ * Truncate `text` to at most `limit` UTF-16 code units, appending an
+ * ellipsis when shortened. Centralised here so the dropdown rows do
+ * not need to import the App-level truncator.
+ *
+ * @param text The text to truncate.
+ * @param limit The maximum length, in UTF-16 code units.
+ * @returns The (possibly-truncated) string.
+ */
+function truncate(text: string, limit: number): string {
+  if (text.length <= limit) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(0, limit - 1))}…`;
+}

--- a/src/tui/components/CommandPalette.tsx
+++ b/src/tui/components/CommandPalette.tsx
@@ -92,7 +92,7 @@ export function CommandPalette(props: CommandPaletteProps): ReactElement {
   } = props;
   const [input, setInput] = useState(initialInput);
   const [suggestionIndex, setSuggestionIndex] = useState(0);
-  const [, setHistoryIndex] = useState<number | null>(null);
+  const [historyIndex, setHistoryIndex] = useState<number | null>(null);
   const [parseError, setParseError] = useState<string | undefined>(undefined);
 
   // Trim and de-duplicate the seeded history so the up/down navigation
@@ -139,6 +139,13 @@ export function CommandPalette(props: CommandPaletteProps): ReactElement {
     inputRef.current = input;
   }, [input]);
 
+  // Draft retained across history navigation. The first time the user
+  // walks into history we snapshot the in-progress input; when they
+  // walk back above the freshest entry we restore it. The ref is reset
+  // whenever the user types a fresh character (handleInputChange) so a
+  // brand-new input does not leak the previous draft.
+  const draftRef = useRef<string | null>(null);
+
   const applyHistory = useCallback(
     (delta: 1 | -1) => {
       if (trimmedHistory.length === 0) {
@@ -146,10 +153,19 @@ export function CommandPalette(props: CommandPaletteProps): ReactElement {
       }
       setHistoryIndex((previous) => {
         const start = previous ?? -1;
+        if (previous === null && delta === 1) {
+          // Entering history: capture the current input so we can
+          // restore it if the user walks back above the freshest entry.
+          draftRef.current = inputRef.current;
+        }
         const candidate = start + delta;
         if (candidate < 0) {
           // Walked above the freshest entry — restore the in-progress
           // input the user had before they started navigating.
+          if (draftRef.current !== null) {
+            setInput(draftRef.current);
+            draftRef.current = null;
+          }
           return null;
         }
         const clamped = Math.min(candidate, trimmedHistory.length - 1);
@@ -168,12 +184,19 @@ export function CommandPalette(props: CommandPaletteProps): ReactElement {
     setHistoryIndex(null);
     setSuggestionIndex(0);
     setParseError(undefined);
+    // The user is editing a fresh draft now; drop any cached pre-history
+    // snapshot so a future history walk captures the new value.
+    draftRef.current = null;
   }, []);
 
-  // Decide whether arrow keys walk history or autocomplete: when the
-  // input field is empty (or whitespace), arrows walk history; once
-  // the user is typing, arrows navigate the suggestion dropdown.
-  const arrowsNavigateHistory = input.trim().length === 0;
+  // Decide whether arrow keys walk history or autocomplete. Two
+  // conditions keep arrows on the history rail: the input field is
+  // empty (a fresh palette open), or the user is already in the middle
+  // of a history walk (so the recalled command does not flip arrows
+  // over to the suggestion dropdown). Once the user types a fresh
+  // character `handleInputChange` clears `historyIndex` and arrows
+  // switch back to navigating suggestions.
+  const arrowsNavigateHistory = historyIndex !== null || input.trim().length === 0;
 
   useInput(
     (rawInput, key) => {

--- a/src/tui/components/TaskSwitcher.tsx
+++ b/src/tui/components/TaskSwitcher.tsx
@@ -1,0 +1,291 @@
+/**
+ * tui/components/TaskSwitcher.tsx — overlay listing in-flight tasks.
+ *
+ * The user opens this overlay through the configured keybinding
+ * (default `Ctrl+G`); arrow keys move the highlight, `Enter` focuses
+ * the highlighted task, `Escape` closes the overlay without changing
+ * focus.
+ *
+ * The component is **stateless about the daemon**: every piece of
+ * task data flows in through props from the {@link useFocusedTask}
+ * hook above. That keeps the snapshot tests trivially deterministic
+ * and lets the App control its lifetime.
+ *
+ * @module
+ */
+
+import { Box, Text, useInput } from "ink";
+import { type ReactElement, useCallback, useEffect, useState } from "react";
+
+import { formatTaskAge, type TaskSummary } from "../hooks/useFocusedTask.ts";
+import type { TaskId, TaskState } from "../../types.ts";
+
+/**
+ * Props accepted by {@link TaskSwitcher}.
+ */
+export interface TaskSwitcherProps {
+  /** The tasks the daemon has reported, sorted most-recent-first. */
+  readonly tasks: readonly TaskSummary[];
+  /** The currently-focused task, when any. */
+  readonly focusedTaskId?: TaskId | undefined;
+  /**
+   * Called when the user picks a task with `Enter`. The App routes
+   * this to {@link FocusedTaskApi.focusTask} and closes the overlay.
+   *
+   * @param taskId The picked task's id.
+   */
+  readonly onPick: (taskId: TaskId) => void;
+  /** Called when the user dismisses the overlay (`Escape`). */
+  readonly onClose: () => void;
+  /**
+   * If `true`, Ink's `useInput` is wired up. Defaults to `true`. The
+   * snapshot tests render the overlay with `inputEnabled={false}` so
+   * Ink's stdin reader does not race the Deno test sanitizer.
+   *
+   * @default true
+   */
+  readonly inputEnabled?: boolean | undefined;
+  /**
+   * Reference timestamp passed to {@link formatTaskAge}. Defaults to
+   * `new Date()`; the snapshot tests pin a fixed clock to keep the
+   * rendered ages stable.
+   */
+  readonly now?: Date | undefined;
+}
+
+/**
+ * Render the task switcher overlay.
+ *
+ * Stateful only on the cursor index. Synchronises the cursor with the
+ * focused task on first render so the highlight starts on the
+ * currently-focused task.
+ *
+ * @param props See {@link TaskSwitcherProps}.
+ * @returns The overlay element.
+ *
+ * @example
+ * ```tsx
+ * <TaskSwitcher
+ *   tasks={tasks}
+ *   focusedTaskId={focused}
+ *   onPick={focusTask}
+ *   onClose={() => setOpen(false)}
+ * />
+ * ```
+ */
+export function TaskSwitcher(props: TaskSwitcherProps): ReactElement {
+  const {
+    tasks,
+    focusedTaskId,
+    onPick,
+    onClose,
+    inputEnabled = true,
+    now,
+  } = props;
+  const [cursor, setCursor] = useState(() => initialCursor(tasks, focusedTaskId));
+
+  // Re-pin the cursor when the task list shrinks below the cursor
+  // index. Without this guard, removing the last task would leave the
+  // cursor pointing at -1 (logical) and crash the keyboard handler.
+  useEffect(() => {
+    if (tasks.length === 0) {
+      setCursor(0);
+      return;
+    }
+    if (cursor >= tasks.length) {
+      setCursor(tasks.length - 1);
+    }
+  }, [tasks.length, cursor]);
+
+  const handleInput = useCallback(
+    (
+      input: string,
+      key: { upArrow: boolean; downArrow: boolean; return: boolean; escape: boolean },
+    ) => {
+      if (key.escape) {
+        onClose();
+        return;
+      }
+      if (tasks.length === 0) {
+        // Nothing to navigate; ignore arrow keys but let `Enter`
+        // close so the user is not stuck with an empty list.
+        if (key.return) {
+          onClose();
+        }
+        return;
+      }
+      if (key.upArrow) {
+        setCursor((previous) => (previous <= 0 ? tasks.length - 1 : previous - 1));
+        return;
+      }
+      if (key.downArrow) {
+        setCursor((previous) => (previous + 1) % tasks.length);
+        return;
+      }
+      if (key.return) {
+        const picked = tasks[cursor];
+        if (picked !== undefined) {
+          onPick(picked.id);
+        }
+        return;
+      }
+      // Vi-style fallback so the switcher still works in environments
+      // where the arrow keys do not propagate clean key codes.
+      if (input === "j") {
+        setCursor((previous) => (previous + 1) % tasks.length);
+      } else if (input === "k") {
+        setCursor((previous) => (previous <= 0 ? tasks.length - 1 : previous - 1));
+      }
+    },
+    [cursor, onClose, onPick, tasks],
+  );
+
+  // Wire the keyboard handler under Ink's `useInput` only when input
+  // is enabled. The hook must always be called for React's hook order
+  // contract; it falls through to `noop` when `inputEnabled` is false.
+  useInput(
+    (input, key) => {
+      if (!inputEnabled) {
+        return;
+      }
+      handleInput(input, key);
+    },
+    { isActive: inputEnabled },
+  );
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="magenta"
+      paddingX={1}
+      paddingY={0}
+    >
+      <Box justifyContent="space-between">
+        <Text bold color="magenta">Task Switcher</Text>
+        <Text dimColor>↑/↓ navigate · Enter focus · Esc close</Text>
+      </Box>
+      {tasks.length === 0
+        ? <Text dimColor>No tasks yet — invoke /issue to start one.</Text>
+        : tasks.map((task, index) => (
+          <TaskRow
+            key={task.id}
+            task={task}
+            highlighted={index === cursor}
+            focused={task.id === focusedTaskId}
+            now={now}
+          />
+        ))}
+    </Box>
+  );
+}
+
+/**
+ * Compute the cursor's initial position so it lands on the focused
+ * task when one exists, falling back to the first row otherwise.
+ *
+ * @param tasks Task list.
+ * @param focusedTaskId Currently-focused task, if any.
+ * @returns The initial cursor index (>= 0).
+ */
+function initialCursor(
+  tasks: readonly TaskSummary[],
+  focusedTaskId: TaskId | undefined,
+): number {
+  if (focusedTaskId === undefined) {
+    return 0;
+  }
+  const index = tasks.findIndex((task) => task.id === focusedTaskId);
+  return index < 0 ? 0 : index;
+}
+
+/**
+ * Single row in the switcher. Stateless; everything flows in via
+ * props so the snapshot tests can pin every variant deterministically.
+ */
+interface TaskRowProps {
+  /** The task summary to render. */
+  readonly task: TaskSummary;
+  /** Whether the cursor currently sits on this row. */
+  readonly highlighted: boolean;
+  /** Whether the task is the currently-focused one. */
+  readonly focused: boolean;
+  /** Reference clock, forwarded to {@link formatTaskAge}. */
+  readonly now: Date | undefined;
+}
+
+/**
+ * Render one row of the task switcher.
+ *
+ * @param props See {@link TaskRowProps}.
+ * @returns The row element.
+ */
+function TaskRow(props: TaskRowProps): ReactElement {
+  const { task, highlighted, focused, now } = props;
+  const cursorMark = highlighted ? ">" : " ";
+  const focusMark = focused ? "*" : " ";
+  const age = formatTaskAge(task, now);
+  const stateText = stateBadge(task.state);
+  const colour = stateColor(task.state);
+  return (
+    <Box flexDirection="row">
+      {highlighted
+        ? (
+          <Text color="magenta">
+            {cursorMark} {focusMark} {task.id}
+          </Text>
+        )
+        : (
+          <Text>
+            {cursorMark} {focusMark} {task.id}
+          </Text>
+        )}
+      <Box flexGrow={1} />
+      {colour === undefined ? <Text>{stateText}</Text> : <Text color={colour}>{stateText}</Text>}
+      <Text dimColor>{` ${age}`}</Text>
+    </Box>
+  );
+}
+
+/**
+ * Map a task state to a short uppercase badge.
+ *
+ * @param state Current task state, when known.
+ * @returns The badge text.
+ */
+function stateBadge(state: TaskState | undefined): string {
+  if (state === undefined) {
+    return "PENDING";
+  }
+  return state;
+}
+
+/**
+ * Map a task state to the colour applied to its badge.
+ *
+ * @param state Current task state, when known.
+ * @returns A colour name accepted by Ink's `<Text color>` prop.
+ */
+function stateColor(state: TaskState | undefined): string | undefined {
+  switch (state) {
+    case undefined:
+      return "gray";
+    case "INIT":
+    case "CLONING_WORKTREE":
+    case "DRAFTING":
+    case "COMMITTING":
+    case "PUSHING":
+      return "yellow";
+    case "PR_OPEN":
+    case "STABILIZING":
+      return "cyan";
+    case "READY_TO_MERGE":
+      return "green";
+    case "MERGED":
+      return "green";
+    case "NEEDS_HUMAN":
+      return "yellow";
+    case "FAILED":
+      return "red";
+  }
+}

--- a/src/tui/hooks/useDaemonConnection.ts
+++ b/src/tui/hooks/useDaemonConnection.ts
@@ -147,9 +147,13 @@ export interface UseDaemonConnectionOptions {
  * - Calling `send`/`subscribe` against the returned object is stable
  *   — the function references survive re-renders, so consumers can
  *   include them in dependency arrays without triggering effect loops.
- * - The hook never holds a reference to a stale client: pass a new
- *   client and the previous subscription is torn down on the cleanup
- *   pass.
+ * - The internal client reference always tracks the latest `options.client`
+ *   so subsequent `send`/`subscribe` calls hit the new instance. The
+ *   one-shot `autoConnect` effect only fires on mount, however, so swapping
+ *   the client at runtime does **not** trigger a fresh `connect()` — call
+ *   `disconnect()`/`connect()` from the consumer if a reactive re-wire is
+ *   needed. In practice no current call site passes a reactive client, so
+ *   the simpler mount-only contract is the one we ship.
  *
  * @param options Hook options. See {@link UseDaemonConnectionOptions}.
  * @returns The {@link DaemonConnectionApi} the component should render
@@ -238,9 +242,14 @@ export function useDaemonConnection(
     return () => {
       cancelled = true;
     };
-    // Intentionally empty: we want to fire connect exactly once on
-    // mount. Re-subscribing on every render would defeat the purpose
-    // of `autoConnect`.
+    // Mount-only by design: the dep array intentionally excludes
+    // `client` so a re-render with a swapped instance does not trigger
+    // a fresh `connect()`. `clientRef` is updated in the effect above
+    // so manual `connect()`/`disconnect()` calls and `send`/`subscribe`
+    // still hit the latest instance — but the auto-wire stays a
+    // one-shot. No current consumer passes a reactive client; if one
+    // ever needs that, drive the lifecycle from the consumer rather
+    // than re-subscribing here.
   }, [autoConnect]);
 
   return { status, lastError, send, subscribe, connect, disconnect };

--- a/src/tui/hooks/useFocusedTask.ts
+++ b/src/tui/hooks/useFocusedTask.ts
@@ -100,7 +100,13 @@ export interface FocusedTaskApi {
    * @param taskId The task to focus.
    */
   readonly focusTask: (taskId: TaskId) => void;
-  /** Drop the current focus (the header reverts to "no task focused"). */
+  /**
+   * Drop the current focus. The header reverts to "no task focused"
+   * and stays that way until the caller invokes
+   * {@link FocusedTaskApi.focusTask} again — the auto-focus path that
+   * promotes the first observed task is suppressed once `clearFocus`
+   * has fired, so subsequent events do not silently re-acquire focus.
+   */
   readonly clearFocus: () => void;
 }
 
@@ -193,28 +199,42 @@ export function useFocusedTask(options: UseFocusedTaskOptions): FocusedTaskApi {
     });
   }, [taskMap]);
 
-  // Stable callbacks — they read the focused-task id through the ref
-  // below so they do not need to re-bind on every render.
+  // `clearedRef` records that the user has explicitly dropped focus.
+  // Once set, the auto-focus path in `handleFocusedTaskEvent` no longer
+  // promotes the next task into focus; the user has to opt back in via
+  // `focusTask`. The Wave 2 first-event auto-focus survives intact for
+  // the initial-load case (where `clearedRef` is still false).
+  const clearedRef = useRef(false);
+
+  // Stable callbacks — they manipulate state through the setters and
+  // the cleared-focus ref so they survive re-renders.
   const focusTask = useCallback((taskId: TaskId) => {
+    clearedRef.current = false;
     setFocusedTaskId(taskId);
   }, []);
 
   const clearFocus = useCallback(() => {
+    clearedRef.current = true;
     setFocusedTaskId(undefined);
   }, []);
-
-  // `sourceRef` mirrors the source so the subscribe effect can pick up
-  // a fresh subscriber on remount without re-running on every render.
-  const sourceRef = useRef(source);
-  useEffect(() => {
-    sourceRef.current = source;
-  }, [source]);
 
   useEffect(() => {
     const subscription = source.subscribeEvents((event) => {
       handleFocusedTaskEvent(event, {
         setTaskMap,
-        setFocusedTaskId,
+        setFocusedTaskId: (update) => {
+          setFocusedTaskId((previous) => {
+            // Once the user has explicitly cleared focus we honour that
+            // until they invoke `focusTask` again. The auto-focus path
+            // would otherwise promote the next inbound event back into
+            // focus, contradicting `clearFocus`'s "drop the current
+            // focus" contract.
+            if (clearedRef.current) {
+              return previous;
+            }
+            return update(previous);
+          });
+        },
       });
     });
     return () => {

--- a/src/tui/hooks/useFocusedTask.ts
+++ b/src/tui/hooks/useFocusedTask.ts
@@ -1,0 +1,393 @@
+/**
+ * tui/hooks/useFocusedTask.ts — focused-task state plus event subscription
+ * helpers for the Wave 3 overlays.
+ *
+ * The Wave 2 shell tracked a single focused task id inline in
+ * `App.tsx`; Wave 3 spreads that responsibility across the command
+ * palette and the task switcher, so the state has been lifted into a
+ * dedicated hook. {@link useFocusedTask} centralises three concerns:
+ *
+ * 1. Maintaining a per-task index of the most recent
+ *    {@link TaskSummary} (state + last activity timestamp), built up
+ *    from {@link DaemonClient} events.
+ * 2. Tracking which task is "focused" right now — initially the first
+ *    task the daemon reports about, switchable through
+ *    {@link FocusedTaskApi.focusTask}.
+ * 3. Exposing a stable accessor surface so consumer components (the
+ *    task switcher, the header, the future per-task scrollback) can
+ *    re-render without flapping.
+ *
+ * The hook is transport-agnostic: it accepts the `subscribe` half of
+ * the {@link DaemonClient} surface (the same shape `useDaemonConnection`
+ * exposes) so the snapshot tests can drive it with the in-memory
+ * double.
+ *
+ * @module
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import type { EventPayload } from "../../ipc/protocol.ts";
+import { makeTaskId, type TaskEvent, type TaskId, type TaskState } from "../../types.ts";
+import {
+  HOURS_PER_DAY,
+  MILLISECONDS_PER_SECOND,
+  MINUTES_PER_HOUR,
+  SECONDS_PER_MINUTE,
+} from "../../constants.ts";
+
+/**
+ * Snapshot of one task as the TUI knows it. Built up from the events
+ * the daemon publishes.
+ *
+ * - `id` — the task identifier the daemon assigned.
+ * - `state` — the most recent {@link TaskState} reported. `undefined`
+ *   when the only events seen so far are `log`/`agent-message`/etc.
+ *   without a state-change.
+ * - `firstSeenAtIso` — wall-clock ISO timestamp of the *first* event
+ *   the TUI saw for this task. Used by the task switcher's age
+ *   formatter.
+ * - `lastSeenAtIso` — wall-clock ISO timestamp of the most recent
+ *   event. Used by the task switcher to sort by activity.
+ */
+export interface TaskSummary {
+  /** Task identifier. */
+  readonly id: TaskId;
+  /** Most-recent task state, when one has been observed. */
+  readonly state: TaskState | undefined;
+  /** ISO timestamp of the first observed event for this task. */
+  readonly firstSeenAtIso: string;
+  /** ISO timestamp of the most recent observed event for this task. */
+  readonly lastSeenAtIso: string;
+}
+
+/**
+ * The callback signature {@link FocusedTaskApi.subscribe} expects.
+ * Mirrors the {@link "../ipc-client.ts".DaemonEventSubscription} surface
+ * the in-memory double also exposes.
+ */
+export interface FocusedTaskEventSubscription {
+  /** Stop forwarding events to this handler. */
+  unsubscribe(): void;
+}
+
+/**
+ * Public surface exposed by {@link useFocusedTask}.
+ *
+ * Stable across re-renders: the function references survive every
+ * render commit so consumers can include them in dependency arrays
+ * without triggering effect loops.
+ */
+export interface FocusedTaskApi {
+  /**
+   * The currently-focused task id, when one exists. Set the first time
+   * the hook hears about a task (mirroring Wave 2's auto-focus
+   * behaviour) or whenever the user invokes
+   * {@link FocusedTaskApi.focusTask}.
+   */
+  readonly focusedTaskId: TaskId | undefined;
+  /**
+   * Snapshot of every task the hook has observed, in stable order
+   * (most-recent activity first).
+   */
+  readonly tasks: readonly TaskSummary[];
+  /**
+   * Switch focus to `taskId`. The id does not have to be present in
+   * {@link FocusedTaskApi.tasks} — focusing a task before the first
+   * event arrives is allowed (the switcher renders the focus pill
+   * either way).
+   *
+   * @param taskId The task to focus.
+   */
+  readonly focusTask: (taskId: TaskId) => void;
+  /** Drop the current focus (the header reverts to "no task focused"). */
+  readonly clearFocus: () => void;
+}
+
+/**
+ * The slice of {@link "../ipc-client.ts".DaemonClient} the hook needs.
+ *
+ * Either a real socket-backed client or the in-memory test double
+ * works here: both expose `subscribeEvents` with the same signature.
+ */
+export interface FocusedTaskEventSource {
+  /**
+   * Subscribe to event envelopes pushed by the daemon. The handler is
+   * invoked synchronously per event in arrival order.
+   *
+   * @param handler The callback invoked per event.
+   * @returns A subscription handle whose `unsubscribe()` stops further
+   *   deliveries.
+   */
+  subscribeEvents(
+    handler: (event: EventPayload) => void,
+  ): FocusedTaskEventSubscription;
+}
+
+/**
+ * Options accepted by {@link useFocusedTask}.
+ */
+export interface UseFocusedTaskOptions {
+  /**
+   * Source of pushed task events. Pass either the {@link DaemonClient}
+   * or any object that exposes the `subscribeEvents` surface (the
+   * `useDaemonConnection` hook's return value works directly).
+   */
+  readonly source: FocusedTaskEventSource;
+  /**
+   * Optional initial focus. Useful for tests that want a deterministic
+   * starting state without needing to inject an event first. Treated
+   * as a one-time seed: the auto-focus on first-event behaviour is
+   * skipped while this is set.
+   */
+  readonly initialFocusedTaskId?: TaskId | undefined;
+}
+
+/**
+ * React hook that tracks the focused task and the per-task summary
+ * index.
+ *
+ * Wave 3 components — the task switcher, the header's focus pill, the
+ * focused-task scrollback — all call this hook (or read its API
+ * through context) so the focus state is single-sourced. The hook
+ * deliberately does **not** drive any IPC of its own: focusing a task
+ * is a TUI-side concern; the supervisor on the daemon side is unaware
+ * of which task the user is staring at.
+ *
+ * @param options See {@link UseFocusedTaskOptions}.
+ * @returns The focused-task API; see {@link FocusedTaskApi}.
+ *
+ * @example
+ * ```tsx
+ * import { useFocusedTask } from "./useFocusedTask.ts";
+ *
+ * function Switcher({ client }: { client: DaemonClient }) {
+ *   const { tasks, focusedTaskId, focusTask } = useFocusedTask({ source: client });
+ *   return tasks.map((task) => (
+ *     <Text key={task.id}>{task.id === focusedTaskId ? "* " : "  "}{task.id}</Text>
+ *   ));
+ * }
+ * ```
+ */
+export function useFocusedTask(options: UseFocusedTaskOptions): FocusedTaskApi {
+  const { source, initialFocusedTaskId } = options;
+  const [focusedTaskId, setFocusedTaskId] = useState<TaskId | undefined>(
+    initialFocusedTaskId,
+  );
+  const [taskMap, setTaskMap] = useState<ReadonlyMap<TaskId, TaskSummary>>(
+    () => new Map(),
+  );
+
+  // Keep `taskMap`'s reference stable when no events have arrived; the
+  // memo on `tasks` below depends on it, and producing a fresh empty
+  // array per render would break consumer memoisation.
+  const tasks = useMemo<readonly TaskSummary[]>(() => {
+    return [...taskMap.values()].sort((left, right) => {
+      // Sort by lastSeenAtIso descending — most recent activity first.
+      // ISO strings compare lexicographically the same way they
+      // compare temporally for the same calendar epoch.
+      if (left.lastSeenAtIso === right.lastSeenAtIso) {
+        return left.id < right.id ? -1 : left.id > right.id ? 1 : 0;
+      }
+      return left.lastSeenAtIso < right.lastSeenAtIso ? 1 : -1;
+    });
+  }, [taskMap]);
+
+  // Stable callbacks — they read the focused-task id through the ref
+  // below so they do not need to re-bind on every render.
+  const focusTask = useCallback((taskId: TaskId) => {
+    setFocusedTaskId(taskId);
+  }, []);
+
+  const clearFocus = useCallback(() => {
+    setFocusedTaskId(undefined);
+  }, []);
+
+  // `sourceRef` mirrors the source so the subscribe effect can pick up
+  // a fresh subscriber on remount without re-running on every render.
+  const sourceRef = useRef(source);
+  useEffect(() => {
+    sourceRef.current = source;
+  }, [source]);
+
+  useEffect(() => {
+    const subscription = source.subscribeEvents((event) => {
+      handleFocusedTaskEvent(event, {
+        setTaskMap,
+        setFocusedTaskId,
+      });
+    });
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [source]);
+
+  return { focusedTaskId, tasks, focusTask, clearFocus };
+}
+
+/**
+ * Setters {@link handleFocusedTaskEvent} mutates when an event arrives.
+ *
+ * Extracted so the same code path is used by the production hook
+ * (passing React `useState` setters) and by direct unit tests (passing
+ * plain closures over local variables).
+ */
+export interface FocusedTaskEventSetters {
+  /** Setter for the per-task summary index. */
+  readonly setTaskMap: (
+    update: (
+      previous: ReadonlyMap<TaskId, TaskSummary>,
+    ) => ReadonlyMap<TaskId, TaskSummary>,
+  ) => void;
+  /** Setter for the focused task id. */
+  readonly setFocusedTaskId: (
+    update: (previous: TaskId | undefined) => TaskId | undefined,
+  ) => void;
+}
+
+/**
+ * Apply a single pushed event to the focused-task state.
+ *
+ * Public for unit-test reuse; production code drives this through
+ * {@link useFocusedTask}'s effect.
+ *
+ * @param event The event payload.
+ * @param setters The state setters captured by {@link useFocusedTask}.
+ */
+export function handleFocusedTaskEvent(
+  event: EventPayload,
+  setters: FocusedTaskEventSetters,
+): void {
+  let taskId: TaskId;
+  try {
+    taskId = makeTaskId(event.taskId);
+  } catch {
+    // Match `App.tsx`'s tolerant handling: a malformed task id is not
+    // worth crashing the renderer over. The focused-task hook simply
+    // skips the event; `App.handleEvent` is still in charge of
+    // surfacing the failure to the status bar.
+    return;
+  }
+  setters.setTaskMap((previous) => {
+    const existing = previous.get(taskId);
+    const nextState = nextStateFromEvent(event, existing?.state);
+    const summary: TaskSummary = {
+      id: taskId,
+      state: nextState,
+      firstSeenAtIso: existing?.firstSeenAtIso ?? event.atIso,
+      lastSeenAtIso: event.atIso,
+    };
+    if (existing !== undefined && summariesEqual(existing, summary)) {
+      return previous;
+    }
+    const next = new Map(previous);
+    next.set(taskId, summary);
+    return next;
+  });
+  setters.setFocusedTaskId((previous) => previous ?? taskId);
+}
+
+/**
+ * Extract the next {@link TaskState} from an event, falling back to
+ * the previous value when the event does not carry a state-change.
+ *
+ * @param event The event payload.
+ * @param previous The previously-known state for this task, when any.
+ * @returns The next state or `undefined` if no state has been observed.
+ */
+function nextStateFromEvent(
+  event: EventPayload,
+  previous: TaskState | undefined,
+): TaskState | undefined {
+  if (event.kind === "state-changed") {
+    return event.data.toState;
+  }
+  return previous;
+}
+
+/**
+ * Compare two task summaries field-by-field to avoid re-rendering when
+ * an event arrives that changes nothing observable (e.g. a duplicate
+ * timestamp from a fan-out).
+ *
+ * @param left First summary.
+ * @param right Second summary.
+ * @returns `true` when the summaries match.
+ */
+function summariesEqual(left: TaskSummary, right: TaskSummary): boolean {
+  return (
+    left.id === right.id &&
+    left.state === right.state &&
+    left.firstSeenAtIso === right.firstSeenAtIso &&
+    left.lastSeenAtIso === right.lastSeenAtIso
+  );
+}
+
+/**
+ * Compute the human-readable age of a {@link TaskSummary} relative to a
+ * reference timestamp.
+ *
+ * The output is the longest still-meaningful unit (`5s`, `12m`, `3h`,
+ * `2d`); both the command palette and the task switcher render this
+ * verbatim. Ages below one second display as `0s` rather than empty.
+ *
+ * Public so the snapshot tests can pin the age strings deterministically
+ * by passing an explicit `now` rather than relying on the wall clock.
+ *
+ * @param summary The task summary whose age to format.
+ * @param now Reference timestamp (defaults to `new Date()`).
+ * @returns The age string.
+ */
+export function formatTaskAge(summary: TaskSummary, now: Date = new Date()): string {
+  return formatAgeBetween(summary.firstSeenAtIso, now);
+}
+
+/**
+ * Compute the human-readable age between two timestamps.
+ *
+ * Used by both the {@link TaskSummary}-shaped helper above and any
+ * call site that wants to format an arbitrary first-seen timestamp.
+ *
+ * @param fromIso ISO timestamp of the past event.
+ * @param now Reference timestamp.
+ * @returns The age string (`5s`, `12m`, `3h`, `2d`).
+ */
+export function formatAgeBetween(fromIso: string, now: Date): string {
+  const fromDate = new Date(fromIso);
+  if (Number.isNaN(fromDate.getTime())) {
+    return "?";
+  }
+  const deltaMilliseconds = Math.max(0, now.getTime() - fromDate.getTime());
+  return formatAgeMilliseconds(deltaMilliseconds);
+}
+
+/**
+ * Convert a non-negative millisecond duration into the longest
+ * still-meaningful single-unit string.
+ *
+ * @param deltaMilliseconds Non-negative duration.
+ * @returns The age string (`5s`, `12m`, `3h`, `2d`).
+ */
+function formatAgeMilliseconds(deltaMilliseconds: number): string {
+  const seconds = Math.floor(deltaMilliseconds / MILLISECONDS_PER_SECOND);
+  if (seconds < SECONDS_PER_MINUTE) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / SECONDS_PER_MINUTE);
+  if (minutes < MINUTES_PER_HOUR) {
+    return `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / MINUTES_PER_HOUR);
+  if (hours < HOURS_PER_DAY) {
+    return `${hours}h`;
+  }
+  const days = Math.floor(hours / HOURS_PER_DAY);
+  return `${days}d`;
+}
+
+/**
+ * Re-export so the matching shape on the daemon side
+ * ({@link "../../types.ts".TaskEvent}) does not need to be imported
+ * separately when consumers wire up listeners against this hook.
+ */
+export type { TaskEvent };

--- a/src/tui/keybindings.ts
+++ b/src/tui/keybindings.ts
@@ -58,16 +58,28 @@ export interface KeystrokeFlags {
  * The `key` field carries the bare key name (e.g. `"p"`, `"tab"`,
  * `"escape"`). Modifier booleans report whether the chord requires
  * each modifier to be held.
+ *
+ * **No separate `alt`.** Ink's `useInput` only exposes a `meta` flag —
+ * its terminal layer collapses Alt and Cmd/Super/Win into the same
+ * boolean (xterm-style terminals deliver both as ESC-prefixed
+ * sequences, so the underlying signal is the same byte stream). A
+ * chord written as `alt+x` is treated as an alias for `meta+x`; the
+ * `alt` modifier name is accepted by the parser for ergonomics but
+ * does not produce a distinct field here. If a future Ink upgrade
+ * splits Alt off from Meta we can re-introduce `alt` without breaking
+ * existing config files.
  */
 export interface ParsedKeybinding {
   /** `ctrl` modifier required. */
   readonly ctrl: boolean;
   /** `shift` modifier required. */
   readonly shift: boolean;
-  /** `meta` modifier required. */
+  /**
+   * `meta` modifier required. Set when the chord uses either `meta+`
+   * or `alt+` (Ink does not distinguish the two — see the type-level
+   * comment).
+   */
   readonly meta: boolean;
-  /** `alt` modifier required (synonym for `meta` on most terminals). */
-  readonly alt: boolean;
   /** Bare key (lowercased; named keys preserved literally). */
   readonly key: string;
 }
@@ -108,7 +120,7 @@ const MODIFIER_NAMES = new Set(["ctrl", "shift", "meta", "alt"]);
  * @example
  * ```ts
  * const parsed = parseKeybinding("ctrl+p");
- * // → { ctrl: true, shift: false, meta: false, alt: false, key: "p" }
+ * // → { ctrl: true, shift: false, meta: false, key: "p" }
  * ```
  */
 export function parseKeybinding(chord: string): ParsedKeybinding {
@@ -141,11 +153,14 @@ export function parseKeybinding(chord: string): ParsedKeybinding {
       );
     }
   }
+  // Ink does not distinguish Alt and Meta (its terminal layer collapses
+  // both into `key.meta`); the chord syntax accepts `alt+` as a synonym
+  // and folds it into the `meta` flag here. See the JSDoc on
+  // `ParsedKeybinding` for the rationale.
   return {
     ctrl: modifiers.includes("ctrl"),
     shift: modifiers.includes("shift"),
-    meta: modifiers.includes("meta"),
-    alt: modifiers.includes("alt"),
+    meta: modifiers.includes("meta") || modifiers.includes("alt"),
     key,
   };
 }
@@ -214,11 +229,11 @@ export function matchesKeybinding(
     return false;
   }
   if (parsed.ctrl !== flags.ctrl) return false;
-  // `alt` is treated as the meta synonym Ink already exposes; the
-  // chord-side flag is folded into `meta` so the modifier check below
-  // matches the keystroke's flag bag uniformly.
-  const requiresMeta = parsed.meta || parsed.alt;
-  if (requiresMeta !== flags.meta) return false;
+  // `parsed.meta` is already true for both `meta+` and `alt+` chords
+  // (the parser folds Alt into Meta — see the JSDoc on
+  // `ParsedKeybinding`), so a single equality check matches the
+  // keystroke's flag bag uniformly.
+  if (parsed.meta !== flags.meta) return false;
   // Shift behaviour: enforce strict equality so the JSDoc contract
   // ("must match exactly") is the truth. A chord without `shift+` will
   // not fire while shift is held, and a `ctrl+shift+x` chord will not

--- a/src/tui/keybindings.ts
+++ b/src/tui/keybindings.ts
@@ -172,10 +172,21 @@ const NAMED_KEYS: Readonly<Record<string, keyof KeystrokeFlags>> = {
 /**
  * Test whether a keystroke matches a chord string.
  *
- * Modifier flags must match exactly — a chord without `shift+` does
- * not fire when the user is holding shift. The bare key compares
+ * **Modifier flags must match exactly.** A chord without `shift+` does
+ * not fire when the user is holding shift, and a `ctrl+shift+x` chord
+ * does not fire on a plain `ctrl+x` keystroke. The bare key compares
  * case-insensitively against the typed character (or against
  * {@link KeystrokeFlags}'s named-key flags for special keys).
+ *
+ * **Ctrl+letter terminal quirks.** Many terminals deliver `Ctrl+A`
+ * through `Ctrl+Z` as the corresponding ASCII control byte (`\x01`..
+ * `\x1A`) instead of the bare letter; some Ink configurations leave
+ * `input` empty altogether. The implementation accepts three shapes:
+ * the literal letter, the ASCII control byte, or empty input plus a
+ * single-character chord key. The empty-input branch is intentionally
+ * permissive — it cannot disambiguate between two `ctrl+<letter>`
+ * bindings — but the control-byte branch keeps a `ctrl+p` chord from
+ * matching a `ctrl+,` keystroke on standards-conforming terminals.
  *
  * @param chord The chord string from the config.
  * @param input The character Ink reports for the keystroke.
@@ -208,23 +219,48 @@ export function matchesKeybinding(
   // matches the keystroke's flag bag uniformly.
   const requiresMeta = parsed.meta || parsed.alt;
   if (requiresMeta !== flags.meta) return false;
-  // Shift behaviour: treat "ctrl+shift+x" strictly (require shift) but
-  // do not require shift when the chord did not name it. This mirrors
-  // typical terminal behaviour where a literal "p" might or might
-  // not arrive with shift depending on the key map.
-  if (parsed.shift && !flags.shift) return false;
+  // Shift behaviour: enforce strict equality so the JSDoc contract
+  // ("must match exactly") is the truth. A chord without `shift+` will
+  // not fire while shift is held, and a `ctrl+shift+x` chord will not
+  // fire on a plain `ctrl+x` keystroke. Named keys (`tab`, `escape`,
+  // arrows…) follow the same rule. Callers that genuinely want a
+  // shift-tolerant binding should declare both forms.
+  if (parsed.shift !== flags.shift) return false;
   const namedFlag = NAMED_KEYS[parsed.key];
   if (namedFlag !== undefined) {
     return flags[namedFlag];
   }
   // Plain character key. Ink hands us the raw character in `input`.
-  // For control combinations the input is often empty (Ctrl+P does
-  // not produce a printable character on most terminals), so when
-  // ctrl is required and input is empty we still match on the key
-  // string having the expected length and the chord asking for a
-  // single-character key.
-  if (parsed.ctrl && input.length === 0) {
-    return parsed.key.length === 1;
+  // For Ctrl+letter combinations many terminals deliver the ASCII
+  // control byte (`Ctrl+A` → `\x01`, …, `Ctrl+Z` → `\x1A`) while the
+  // `key.ctrl` flag is also true; some Ink configurations leave
+  // `input` empty instead. We accept three shapes for `ctrl+<letter>`:
+  //
+  //   1. `input` matches the chord key directly (e.g. `"p"` for
+  //      `ctrl+p`) — Ink's behaviour on most platforms.
+  //   2. `input` is the ASCII control byte for the chord key
+  //      (e.g. `"\x10"` for `ctrl+p`) — what xterm-style terminals
+  //      put on the wire. We compute the expected byte here so a
+  //      `ctrl+p` chord no longer matches a `ctrl+,` keystroke.
+  //   3. `input` is empty AND the chord key is a single character —
+  //      ambiguous, but unavoidable when Ink hides both the typed
+  //      character and the control byte. In that case any single-letter
+  //      `ctrl+<x>` chord will match; callers that need precision should
+  //      configure terminals that surface either the letter or the
+  //      control byte. This branch is documented in the test suite.
+  if (parsed.ctrl) {
+    if (input.length === 0) {
+      return parsed.key.length === 1;
+    }
+    if (parsed.key.length === 1) {
+      const expected = parsed.key.toLowerCase();
+      const code = expected.charCodeAt(0);
+      // Ctrl+a..z → 1..26; only meaningful for ASCII letters.
+      if (code >= 97 && code <= 122) {
+        const controlByte = String.fromCharCode(code - 96);
+        if (input === controlByte) return true;
+      }
+    }
   }
   return input.toLowerCase() === parsed.key.toLowerCase();
 }

--- a/src/tui/keybindings.ts
+++ b/src/tui/keybindings.ts
@@ -1,0 +1,230 @@
+/**
+ * tui/keybindings.ts — chord parser shared by every TUI component.
+ *
+ * Config files store keybindings as `<modifier>+<key>` strings
+ * (`ctrl+p`, `shift+tab`). Ink's `useInput` hands each keystroke to
+ * the consumer as a `(input, key)` pair where `key` already
+ * normalises modifier flags. This module bridges the two: turn a
+ * chord string into a predicate that reports whether a given Ink
+ * keystroke should fire it.
+ *
+ * The parser is intentionally cross-platform — modifiers are matched
+ * by name (`ctrl`, `shift`, `meta`, `alt`) so a config file written
+ * on macOS works on Linux without changes (Ink's `key.meta` flag
+ * normalises across platforms).
+ *
+ * @module
+ */
+
+/**
+ * Subset of Ink's `Key` shape this module reads. Pulled in as a
+ * structural type rather than imported from Ink so unit tests can
+ * call the helpers below with plain object literals.
+ */
+export interface KeystrokeFlags {
+  /** `Ctrl` modifier was held. */
+  readonly ctrl: boolean;
+  /** `Shift` modifier was held. */
+  readonly shift: boolean;
+  /** `Meta` (Cmd / Super / Win) modifier was held. */
+  readonly meta: boolean;
+  /** Tab key. */
+  readonly tab: boolean;
+  /** Return / Enter key. */
+  readonly return: boolean;
+  /** Escape key. */
+  readonly escape: boolean;
+  /** Backspace key. */
+  readonly backspace: boolean;
+  /** Delete key. */
+  readonly delete: boolean;
+  /** Up arrow. */
+  readonly upArrow: boolean;
+  /** Down arrow. */
+  readonly downArrow: boolean;
+  /** Left arrow. */
+  readonly leftArrow: boolean;
+  /** Right arrow. */
+  readonly rightArrow: boolean;
+  /** Page-up. */
+  readonly pageUp: boolean;
+  /** Page-down. */
+  readonly pageDown: boolean;
+}
+
+/**
+ * Parsed representation of a keybinding chord.
+ *
+ * The `key` field carries the bare key name (e.g. `"p"`, `"tab"`,
+ * `"escape"`). Modifier booleans report whether the chord requires
+ * each modifier to be held.
+ */
+export interface ParsedKeybinding {
+  /** `ctrl` modifier required. */
+  readonly ctrl: boolean;
+  /** `shift` modifier required. */
+  readonly shift: boolean;
+  /** `meta` modifier required. */
+  readonly meta: boolean;
+  /** `alt` modifier required (synonym for `meta` on most terminals). */
+  readonly alt: boolean;
+  /** Bare key (lowercased; named keys preserved literally). */
+  readonly key: string;
+}
+
+/**
+ * Error raised by {@link parseKeybinding} when the chord string
+ * cannot be parsed.
+ */
+export class KeybindingParseError extends Error {
+  /**
+   * Construct a parse error.
+   *
+   * @param message Human-readable description.
+   */
+  constructor(message: string) {
+    super(message);
+    this.name = "KeybindingParseError";
+  }
+}
+
+/**
+ * Recognised modifier names. Lowercased for compare-insensitive
+ * lookup.
+ */
+const MODIFIER_NAMES = new Set(["ctrl", "shift", "meta", "alt"]);
+
+/**
+ * Parse a chord string like `"ctrl+p"` into a {@link ParsedKeybinding}.
+ *
+ * Whitespace around the chord is trimmed; the components are split on
+ * `+` and lowercased. Empty components and unknown modifier names are
+ * rejected with {@link KeybindingParseError}.
+ *
+ * @param chord The chord string from `tui.keybindings`.
+ * @returns The parsed structure.
+ * @throws {KeybindingParseError} If the chord is malformed.
+ *
+ * @example
+ * ```ts
+ * const parsed = parseKeybinding("ctrl+p");
+ * // → { ctrl: true, shift: false, meta: false, alt: false, key: "p" }
+ * ```
+ */
+export function parseKeybinding(chord: string): ParsedKeybinding {
+  const trimmed = chord.trim();
+  if (trimmed.length === 0) {
+    throw new KeybindingParseError("keybinding cannot be empty");
+  }
+  const parts = trimmed.toLowerCase().split("+").map((part) => part.trim());
+  if (parts.some((part) => part.length === 0)) {
+    throw new KeybindingParseError(
+      `keybinding ${JSON.stringify(chord)} contains an empty component`,
+    );
+  }
+  const key = parts[parts.length - 1];
+  if (key === undefined) {
+    throw new KeybindingParseError(
+      `keybinding ${JSON.stringify(chord)} is missing a key`,
+    );
+  }
+  if (MODIFIER_NAMES.has(key)) {
+    throw new KeybindingParseError(
+      `keybinding ${JSON.stringify(chord)} ends in a modifier name`,
+    );
+  }
+  const modifiers = parts.slice(0, -1);
+  for (const modifier of modifiers) {
+    if (!MODIFIER_NAMES.has(modifier)) {
+      throw new KeybindingParseError(
+        `keybinding ${JSON.stringify(chord)} contains unknown modifier ${JSON.stringify(modifier)}`,
+      );
+    }
+  }
+  return {
+    ctrl: modifiers.includes("ctrl"),
+    shift: modifiers.includes("shift"),
+    meta: modifiers.includes("meta"),
+    alt: modifiers.includes("alt"),
+    key,
+  };
+}
+
+/**
+ * Map of named keys to the corresponding flag on {@link KeystrokeFlags}.
+ */
+const NAMED_KEYS: Readonly<Record<string, keyof KeystrokeFlags>> = {
+  tab: "tab",
+  return: "return",
+  enter: "return",
+  escape: "escape",
+  esc: "escape",
+  backspace: "backspace",
+  delete: "delete",
+  up: "upArrow",
+  down: "downArrow",
+  left: "leftArrow",
+  right: "rightArrow",
+  pageup: "pageUp",
+  pagedown: "pageDown",
+};
+
+/**
+ * Test whether a keystroke matches a chord string.
+ *
+ * Modifier flags must match exactly — a chord without `shift+` does
+ * not fire when the user is holding shift. The bare key compares
+ * case-insensitively against the typed character (or against
+ * {@link KeystrokeFlags}'s named-key flags for special keys).
+ *
+ * @param chord The chord string from the config.
+ * @param input The character Ink reports for the keystroke.
+ * @param flags The flag bag Ink hands the consumer.
+ * @returns `true` when the keystroke fires the chord.
+ *
+ * @example
+ * ```ts
+ * useInput((input, key) => {
+ *   if (matchesKeybinding("ctrl+p", input, key)) {
+ *     setPaletteOpen(true);
+ *   }
+ * });
+ * ```
+ */
+export function matchesKeybinding(
+  chord: string,
+  input: string,
+  flags: KeystrokeFlags,
+): boolean {
+  let parsed: ParsedKeybinding;
+  try {
+    parsed = parseKeybinding(chord);
+  } catch {
+    return false;
+  }
+  if (parsed.ctrl !== flags.ctrl) return false;
+  // `alt` is treated as the meta synonym Ink already exposes; the
+  // chord-side flag is folded into `meta` so the modifier check below
+  // matches the keystroke's flag bag uniformly.
+  const requiresMeta = parsed.meta || parsed.alt;
+  if (requiresMeta !== flags.meta) return false;
+  // Shift behaviour: treat "ctrl+shift+x" strictly (require shift) but
+  // do not require shift when the chord did not name it. This mirrors
+  // typical terminal behaviour where a literal "p" might or might
+  // not arrive with shift depending on the key map.
+  if (parsed.shift && !flags.shift) return false;
+  const namedFlag = NAMED_KEYS[parsed.key];
+  if (namedFlag !== undefined) {
+    return flags[namedFlag];
+  }
+  // Plain character key. Ink hands us the raw character in `input`.
+  // For control combinations the input is often empty (Ctrl+P does
+  // not produce a printable character on most terminals), so when
+  // ctrl is required and input is empty we still match on the key
+  // string having the expected length and the chord asking for a
+  // single-character key.
+  if (parsed.ctrl && input.length === 0) {
+    return parsed.key.length === 1;
+  }
+  return input.toLowerCase() === parsed.key.toLowerCase();
+}

--- a/src/tui/slash-command-parser.ts
+++ b/src/tui/slash-command-parser.ts
@@ -383,7 +383,17 @@ function parseRepo(tokens: readonly string[]): CommandPayload {
       const repo = parseRepoFullNameArg("/repo add", repoToken);
       // Validate the installation id parses as a positive integer up
       // front. The daemon will re-validate, but a fast local check
-      // gives the user a tight error loop.
+      // gives the user a tight error loop. Reject tokens with trailing
+      // junk before parsing — otherwise `"123oops"` parses as `123`
+      // and silently routes to a different installation.
+      if (!POSITIVE_DECIMAL_INTEGER_PATTERN.test(installationToken)) {
+        throw new SlashCommandParseError(
+          "bad-arguments",
+          `/repo add: installation id must be a positive integer; got ${
+            JSON.stringify(installationToken)
+          }.`,
+        );
+      }
       const installationId = Number.parseInt(installationToken, RADIX_DECIMAL);
       if (
         !Number.isFinite(installationId) ||
@@ -564,13 +574,33 @@ function tokenise(raw: string): string[] {
 }
 
 /**
+ * Decimal-integer regex used by the slash-command parser to reject tokens
+ * with leading/trailing junk (e.g. `"12abc"`) before they reach
+ * `Number.parseInt`. The regex matches one-or-more digits and nothing else.
+ *
+ * Centralised here so both the issue-number and installation-id call
+ * sites share the exact same validation contract.
+ */
+const POSITIVE_DECIMAL_INTEGER_PATTERN = /^[0-9]+$/u;
+
+/**
  * Parse a token expected to be a positive integer issue number.
+ *
+ * Rejects any token that is not entirely digits — `Number.parseInt`'s
+ * default behaviour of accepting trailing junk (e.g. parsing `"12abc"`
+ * as `12`) would silently misroute slash commands to the wrong issue.
  *
  * @param scope Caller name, prepended to the error message.
  * @param raw The candidate token.
  * @returns The branded {@link IssueNumber}.
  */
 function parseIssueNumberArg(scope: string, raw: string): IssueNumber {
+  if (!POSITIVE_DECIMAL_INTEGER_PATTERN.test(raw)) {
+    throw new SlashCommandParseError(
+      "bad-arguments",
+      `${scope}: issue number must be a positive integer; got ${JSON.stringify(raw)}.`,
+    );
+  }
   const numeric = Number.parseInt(raw, RADIX_DECIMAL);
   if (!Number.isFinite(numeric)) {
     throw new SlashCommandParseError(

--- a/src/tui/slash-command-parser.ts
+++ b/src/tui/slash-command-parser.ts
@@ -1,0 +1,643 @@
+/**
+ * tui/slash-command-parser.ts — pure parser for the TUI's slash-command
+ * vocabulary.
+ *
+ * The TUI's command palette lets the user type a leading-`/` line and
+ * dispatches it to the daemon as a `command` envelope. This module is
+ * the single source of truth for what a valid command looks like:
+ * tokenises the line, applies per-command argument grammar, returns a
+ * {@link CommandPayload} ready to drop into a {@link MessageEnvelope},
+ * and rejects malformed input through {@link SlashCommandParseError}.
+ *
+ * The parser is deliberately transport-agnostic — it does not call the
+ * daemon, does not touch React state, and has no side-effects. The
+ * command palette wires the result of {@link parseSlashCommand} into the
+ * IPC client; the unit tests exercise the parser in isolation.
+ *
+ * **Supported commands** (full grammar in {@link SLASH_COMMAND_SPECS}):
+ *
+ * - `/issue <number> [--repo <owner/name>]` — start a new task.
+ * - `/repo add <owner/name> <installation-id>` — register a repo.
+ * - `/repo default <owner/name>` — set the default repo.
+ * - `/repo list` — print the registered repositories.
+ * - `/status` — print every in-flight task's state.
+ * - `/switch <task-id>` — focus a task.
+ * - `/cancel <task-id>` — cancel a task; preserves the worktree.
+ * - `/retry <task-id>` — re-enter a `NEEDS_HUMAN` task.
+ * - `/merge <task-id>` — force the merge of a `READY_TO_MERGE` task.
+ * - `/logs <task-id>` — open the task's scrollback.
+ * - `/quit` — exit the TUI (the daemon keeps running).
+ * - `/daemon stop` — stop the daemon process.
+ * - `/help [command]` — list commands or describe one.
+ *
+ * @module
+ */
+
+import {
+  type IssueNumber,
+  makeIssueNumber,
+  makeRepoFullName,
+  type RepoFullName,
+} from "../types.ts";
+import type { CommandPayload } from "../ipc/protocol.ts";
+import { RADIX_DECIMAL } from "../constants.ts";
+
+// ---------------------------------------------------------------------------
+// Public type contracts
+// ---------------------------------------------------------------------------
+
+/**
+ * Names of every slash command the parser recognises.
+ *
+ * Exported as a `readonly` tuple so consumers (the command-palette
+ * autocomplete, the help command) can iterate it.
+ */
+export const SLASH_COMMAND_NAMES = [
+  "issue",
+  "repo",
+  "status",
+  "switch",
+  "cancel",
+  "retry",
+  "merge",
+  "logs",
+  "quit",
+  "daemon",
+  "help",
+] as const;
+
+/**
+ * Discriminant union of valid command names.
+ */
+export type SlashCommandName = typeof SLASH_COMMAND_NAMES[number];
+
+/**
+ * One row in the spec table the parser drives off. Entries describe the
+ * canonical command shape so the help text and the autocomplete
+ * dropdown stay in sync with the parser.
+ */
+export interface SlashCommandSpec {
+  /** The command name, without the leading `/`. */
+  readonly name: SlashCommandName;
+  /** One-line summary surfaced by `/help` and the autocomplete dropdown. */
+  readonly summary: string;
+  /** Canonical usage string surfaced by `/help <command>`. */
+  readonly usage: string;
+}
+
+/**
+ * Static specs for every command. Sorted alphabetically so the
+ * autocomplete dropdown's order is deterministic.
+ */
+export const SLASH_COMMAND_SPECS: readonly SlashCommandSpec[] = [
+  {
+    name: "cancel",
+    summary: "Cancel a non-terminal task; preserves the worktree.",
+    usage: "/cancel <task-id>",
+  },
+  {
+    name: "daemon",
+    summary: "Manage the long-running daemon (sub-commands: stop).",
+    usage: "/daemon stop",
+  },
+  {
+    name: "help",
+    summary: "List commands or describe one.",
+    usage: "/help [command]",
+  },
+  {
+    name: "issue",
+    summary: "Start a new task for an issue.",
+    usage: "/issue <number> [--repo <owner/name>]",
+  },
+  {
+    name: "logs",
+    summary: "Open the task scrollback.",
+    usage: "/logs <task-id>",
+  },
+  {
+    name: "merge",
+    summary: "Force the merge of a READY_TO_MERGE task.",
+    usage: "/merge <task-id>",
+  },
+  {
+    name: "quit",
+    summary: "Exit the TUI; the daemon keeps running.",
+    usage: "/quit",
+  },
+  {
+    name: "repo",
+    summary: "Manage registered repositories (add/default/list).",
+    usage: "/repo {add <owner/name> <installation-id> | default <owner/name> | list}",
+  },
+  {
+    name: "retry",
+    summary: "Re-enter a NEEDS_HUMAN task after a manual fix.",
+    usage: "/retry <task-id>",
+  },
+  {
+    name: "status",
+    summary: "Print every in-flight task's state.",
+    usage: "/status",
+  },
+  {
+    name: "switch",
+    summary: "Focus the listed task.",
+    usage: "/switch <task-id>",
+  },
+];
+
+/**
+ * Error raised by {@link parseSlashCommand} for any malformed input.
+ *
+ * The message is suitable for direct rendering in the command-palette
+ * status row; the {@link SlashCommandParseError.kind} tag distinguishes
+ * cases the renderer wants to highlight differently (an unknown command
+ * is autocompletable; a malformed argument is not).
+ */
+export class SlashCommandParseError extends Error {
+  /**
+   * Tag describing the failure category.
+   *
+   * - `not-a-command` — input did not start with `/`.
+   * - `empty` — input was just `/` or whitespace.
+   * - `unknown-command` — the command name is not in
+   *   {@link SLASH_COMMAND_NAMES}.
+   * - `bad-arguments` — the command was recognised but its arguments
+   *   failed validation.
+   */
+  readonly kind:
+    | "not-a-command"
+    | "empty"
+    | "unknown-command"
+    | "bad-arguments";
+
+  /**
+   * Construct a parse error.
+   *
+   * @param kind Category tag (see {@link SlashCommandParseError.kind}).
+   * @param message Human-readable description for the status row.
+   */
+  constructor(
+    kind:
+      | "not-a-command"
+      | "empty"
+      | "unknown-command"
+      | "bad-arguments",
+    message: string,
+  ) {
+    super(message);
+    this.kind = kind;
+    this.name = "SlashCommandParseError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public parse API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a single line of palette input into a {@link CommandPayload}.
+ *
+ * Whitespace surrounding the line is trimmed; tokens within the line
+ * are split on runs of ASCII whitespace (no shell-style quoting — the
+ * grammar does not need it). The returned payload is ready to drop
+ * into a `command` envelope.
+ *
+ * @param input The raw user input (with or without trailing newline).
+ * @returns The parsed command payload.
+ * @throws {SlashCommandParseError} If the input is not a slash command,
+ *   the command is unknown, or its arguments are malformed.
+ *
+ * @example
+ * ```ts
+ * const payload = parseSlashCommand("/issue 42 --repo owner/repo");
+ * // → { name: "issue", args: ["42"], issueNumber: 42, repo: "owner/repo" }
+ * ```
+ */
+export function parseSlashCommand(input: string): CommandPayload {
+  const trimmed = input.trim();
+  if (trimmed.length === 0 || trimmed === "/") {
+    throw new SlashCommandParseError("empty", "Type a command after the slash.");
+  }
+  if (!trimmed.startsWith("/")) {
+    throw new SlashCommandParseError(
+      "not-a-command",
+      `Commands must start with "/"; got ${JSON.stringify(input)}.`,
+    );
+  }
+  const tokens = tokenise(trimmed.slice(1));
+  const head = tokens.shift();
+  if (head === undefined || head.length === 0) {
+    throw new SlashCommandParseError("empty", "Type a command after the slash.");
+  }
+  if (!isKnownCommand(head)) {
+    throw new SlashCommandParseError(
+      "unknown-command",
+      `Unknown command "/${head}". Type /help for a list.`,
+    );
+  }
+  switch (head) {
+    case "issue":
+      return parseIssue(tokens);
+    case "repo":
+      return parseRepo(tokens);
+    case "status":
+      return parseNoArgs("status", tokens);
+    case "switch":
+      return parseSingleTaskId("switch", tokens);
+    case "cancel":
+      return parseSingleTaskId("cancel", tokens);
+    case "retry":
+      return parseSingleTaskId("retry", tokens);
+    case "merge":
+      return parseSingleTaskId("merge", tokens);
+    case "logs":
+      return parseSingleTaskId("logs", tokens);
+    case "quit":
+      return parseNoArgs("quit", tokens);
+    case "daemon":
+      return parseDaemon(tokens);
+    case "help":
+      return parseHelp(tokens);
+  }
+}
+
+/**
+ * Type guard backing the dispatch in {@link parseSlashCommand}.
+ *
+ * @param raw Candidate command name (without the leading `/`).
+ * @returns `true` when `raw` is one of {@link SLASH_COMMAND_NAMES}.
+ */
+function isKnownCommand(raw: string): raw is SlashCommandName {
+  return (SLASH_COMMAND_NAMES as readonly string[]).includes(raw);
+}
+
+// ---------------------------------------------------------------------------
+// Per-command grammar
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse `/issue <number> [--repo <owner/name>]`.
+ *
+ * The `--repo` flag is optional and may appear before or after the
+ * positional issue number; positional non-flag tokens beyond the issue
+ * number are rejected so the parser fails fast on typos.
+ *
+ * @param tokens Tokens after the command name.
+ * @returns The command payload.
+ */
+function parseIssue(tokens: readonly string[]): CommandPayload {
+  let issueArg: string | undefined;
+  let repoArg: string | undefined;
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === "--repo") {
+      const next = tokens[index + 1];
+      if (next === undefined) {
+        throw new SlashCommandParseError(
+          "bad-arguments",
+          "/issue: --repo requires an argument.",
+        );
+      }
+      if (repoArg !== undefined) {
+        throw new SlashCommandParseError(
+          "bad-arguments",
+          "/issue: --repo specified more than once.",
+        );
+      }
+      repoArg = next;
+      index += 1;
+      continue;
+    }
+    if (token !== undefined && token.startsWith("--")) {
+      throw new SlashCommandParseError(
+        "bad-arguments",
+        `/issue: unknown flag ${JSON.stringify(token)}.`,
+      );
+    }
+    if (issueArg !== undefined) {
+      throw new SlashCommandParseError(
+        "bad-arguments",
+        "/issue accepts a single issue number.",
+      );
+    }
+    issueArg = token;
+  }
+  if (issueArg === undefined) {
+    throw new SlashCommandParseError(
+      "bad-arguments",
+      "/issue requires an issue number.",
+    );
+  }
+  const issueNumber = parseIssueNumberArg("/issue", issueArg);
+  const repo = repoArg === undefined ? undefined : parseRepoFullNameArg("/issue", repoArg);
+  return makePayload({
+    name: "issue",
+    args: [issueArg],
+    issueNumber,
+    repo,
+  });
+}
+
+/**
+ * Parse `/repo {add <owner/name> <installation-id> | default <owner/name>
+ * | list}`.
+ *
+ * The sub-command is required; unknown sub-commands raise
+ * `bad-arguments`.
+ *
+ * @param tokens Tokens after the command name.
+ * @returns The command payload.
+ */
+function parseRepo(tokens: readonly string[]): CommandPayload {
+  const subcommand = tokens[0];
+  if (subcommand === undefined) {
+    throw new SlashCommandParseError(
+      "bad-arguments",
+      "/repo requires a sub-command (add | default | list).",
+    );
+  }
+  switch (subcommand) {
+    case "add": {
+      const repoToken = tokens[1];
+      const installationToken = tokens[2];
+      if (repoToken === undefined) {
+        throw new SlashCommandParseError(
+          "bad-arguments",
+          "/repo add requires <owner/name>.",
+        );
+      }
+      if (installationToken === undefined) {
+        throw new SlashCommandParseError(
+          "bad-arguments",
+          "/repo add requires <installation-id>.",
+        );
+      }
+      if (tokens.length > 3) {
+        throw new SlashCommandParseError(
+          "bad-arguments",
+          "/repo add accepts exactly two arguments.",
+        );
+      }
+      const repo = parseRepoFullNameArg("/repo add", repoToken);
+      // Validate the installation id parses as a positive integer up
+      // front. The daemon will re-validate, but a fast local check
+      // gives the user a tight error loop.
+      const installationId = Number.parseInt(installationToken, RADIX_DECIMAL);
+      if (
+        !Number.isFinite(installationId) ||
+        !Number.isInteger(installationId) ||
+        installationId <= 0
+      ) {
+        throw new SlashCommandParseError(
+          "bad-arguments",
+          `/repo add: installation id must be a positive integer; got ${
+            JSON.stringify(installationToken)
+          }.`,
+        );
+      }
+      return makePayload({
+        name: "repo",
+        args: ["add", repoToken, installationToken],
+        repo,
+      });
+    }
+    case "default": {
+      const repoToken = tokens[1];
+      if (repoToken === undefined) {
+        throw new SlashCommandParseError(
+          "bad-arguments",
+          "/repo default requires <owner/name>.",
+        );
+      }
+      if (tokens.length > 2) {
+        throw new SlashCommandParseError(
+          "bad-arguments",
+          "/repo default accepts exactly one argument.",
+        );
+      }
+      const repo = parseRepoFullNameArg("/repo default", repoToken);
+      return makePayload({
+        name: "repo",
+        args: ["default", repoToken],
+        repo,
+      });
+    }
+    case "list": {
+      if (tokens.length > 1) {
+        throw new SlashCommandParseError(
+          "bad-arguments",
+          "/repo list accepts no arguments.",
+        );
+      }
+      return makePayload({ name: "repo", args: ["list"] });
+    }
+    default:
+      throw new SlashCommandParseError(
+        "bad-arguments",
+        `/repo: unknown sub-command ${JSON.stringify(subcommand)}; expected add, default, or list.`,
+      );
+  }
+}
+
+/**
+ * Parse a command that takes no arguments (`/status`, `/quit`).
+ *
+ * @param name The command name.
+ * @param tokens Tokens after the command name.
+ * @returns The command payload.
+ */
+function parseNoArgs(
+  name: "status" | "quit",
+  tokens: readonly string[],
+): CommandPayload {
+  if (tokens.length > 0) {
+    throw new SlashCommandParseError(
+      "bad-arguments",
+      `/${name} accepts no arguments.`,
+    );
+  }
+  return makePayload({ name, args: [] });
+}
+
+/**
+ * Parse a command that takes a single task-id argument (`/switch`,
+ * `/cancel`, `/retry`, `/merge`, `/logs`).
+ *
+ * The task-id is forwarded as a string in `args[0]`; the daemon owns
+ * the shape validation against its in-memory task table.
+ *
+ * @param name The command name.
+ * @param tokens Tokens after the command name.
+ * @returns The command payload.
+ */
+function parseSingleTaskId(
+  name: "switch" | "cancel" | "retry" | "merge" | "logs",
+  tokens: readonly string[],
+): CommandPayload {
+  const taskIdToken = tokens[0];
+  if (taskIdToken === undefined || taskIdToken.length === 0) {
+    throw new SlashCommandParseError(
+      "bad-arguments",
+      `/${name} requires <task-id>.`,
+    );
+  }
+  if (tokens.length > 1) {
+    throw new SlashCommandParseError(
+      "bad-arguments",
+      `/${name} accepts exactly one argument.`,
+    );
+  }
+  return makePayload({ name, args: [taskIdToken] });
+}
+
+/**
+ * Parse `/daemon stop`. No other sub-commands exist yet; unknown
+ * sub-commands raise `bad-arguments`.
+ *
+ * @param tokens Tokens after the command name.
+ * @returns The command payload.
+ */
+function parseDaemon(tokens: readonly string[]): CommandPayload {
+  const subcommand = tokens[0];
+  if (subcommand === undefined) {
+    throw new SlashCommandParseError(
+      "bad-arguments",
+      "/daemon requires a sub-command (stop).",
+    );
+  }
+  if (subcommand !== "stop") {
+    throw new SlashCommandParseError(
+      "bad-arguments",
+      `/daemon: unknown sub-command ${JSON.stringify(subcommand)}; expected stop.`,
+    );
+  }
+  if (tokens.length > 1) {
+    throw new SlashCommandParseError(
+      "bad-arguments",
+      "/daemon stop accepts no arguments.",
+    );
+  }
+  return makePayload({ name: "daemon", args: ["stop"] });
+}
+
+/**
+ * Parse `/help [command]`. The optional argument constrains the help
+ * output to a single command.
+ *
+ * @param tokens Tokens after the command name.
+ * @returns The command payload.
+ */
+function parseHelp(tokens: readonly string[]): CommandPayload {
+  if (tokens.length === 0) {
+    return makePayload({ name: "help", args: [] });
+  }
+  if (tokens.length > 1) {
+    throw new SlashCommandParseError(
+      "bad-arguments",
+      "/help accepts at most one argument.",
+    );
+  }
+  const target = tokens[0];
+  if (target === undefined) {
+    return makePayload({ name: "help", args: [] });
+  }
+  return makePayload({ name: "help", args: [target] });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Split the post-slash text into whitespace-separated tokens.
+ *
+ * Empty tokens (runs of whitespace) are dropped so callers do not have
+ * to special-case them in their grammar checks.
+ *
+ * @param raw The post-slash text.
+ * @returns The token array.
+ */
+function tokenise(raw: string): string[] {
+  return raw.split(/\s+/u).filter((part) => part.length > 0);
+}
+
+/**
+ * Parse a token expected to be a positive integer issue number.
+ *
+ * @param scope Caller name, prepended to the error message.
+ * @param raw The candidate token.
+ * @returns The branded {@link IssueNumber}.
+ */
+function parseIssueNumberArg(scope: string, raw: string): IssueNumber {
+  const numeric = Number.parseInt(raw, RADIX_DECIMAL);
+  if (!Number.isFinite(numeric)) {
+    throw new SlashCommandParseError(
+      "bad-arguments",
+      `${scope}: issue number must be a positive integer; got ${JSON.stringify(raw)}.`,
+    );
+  }
+  try {
+    return makeIssueNumber(numeric);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new SlashCommandParseError(
+      "bad-arguments",
+      `${scope}: ${message}.`,
+    );
+  }
+}
+
+/**
+ * Parse a token expected to be `<owner>/<name>`.
+ *
+ * @param scope Caller name, prepended to the error message.
+ * @param raw The candidate token.
+ * @returns The branded {@link RepoFullName}.
+ */
+function parseRepoFullNameArg(scope: string, raw: string): RepoFullName {
+  try {
+    return makeRepoFullName(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new SlashCommandParseError(
+      "bad-arguments",
+      `${scope}: ${message}.`,
+    );
+  }
+}
+
+/**
+ * Build a {@link CommandPayload}, leaving optional fields undefined
+ * (vs. setting them to `undefined`) so callers downstream that read the
+ * value via `?.` or rest-spread see the expected `Object.keys` set.
+ *
+ * @param input Per-command pieces.
+ * @returns The constructed payload.
+ */
+function makePayload(
+  input: {
+    readonly name: SlashCommandName;
+    readonly args: readonly string[];
+    readonly repo?: RepoFullName | undefined;
+    readonly issueNumber?: IssueNumber | undefined;
+  },
+): CommandPayload {
+  const payload: {
+    name: SlashCommandName;
+    args: readonly string[];
+    repo?: RepoFullName;
+    issueNumber?: IssueNumber;
+  } = {
+    name: input.name,
+    args: input.args,
+  };
+  if (input.repo !== undefined) {
+    payload.repo = input.repo;
+  }
+  if (input.issueNumber !== undefined) {
+    payload.issueNumber = input.issueNumber;
+  }
+  return payload;
+}

--- a/tests/helpers/in_memory_daemon_client.ts
+++ b/tests/helpers/in_memory_daemon_client.ts
@@ -50,14 +50,61 @@ export interface DaemonEventSubscription {
 }
 
 /**
+ * The subset of {@link MessageEnvelope} variants that are
+ * client→daemon **requests** the in-memory client knows how to script
+ * replies for. Excludes `pong`, `ack`, and `event` (which are server→
+ * client envelopes the daemon emits, never receives).
+ */
+export type RequestEnvelope = Extract<
+  MessageEnvelope,
+  { type: "ping" | "subscribe" | "unsubscribe" | "command" | "prompt" }
+>;
+
+/**
+ * The {@link RequestEnvelope} variant that maps to a `pong` reply.
+ */
+export type PingEnvelope = Extract<RequestEnvelope, { type: "ping" }>;
+
+/**
+ * The {@link RequestEnvelope} variants that map to an `ack` reply
+ * (everything that is a request but not `ping`).
+ */
+export type AckEnvelope = Exclude<RequestEnvelope, { type: "ping" }>;
+
+/**
  * Per-request handler invoked when the SUT calls `send()`. Tests register
  * one with {@link InMemoryDaemonClient.setRequestHandler} to script
  * non-trivial daemon behavior; the default handler just produces an
  * `ack { ok: true }` (or a `pong` for `ping`).
+ *
+ * The signature is a callable interface with two overloads so the
+ * payload type tracks the envelope's `type` discriminant: a `ping`
+ * envelope must be answered with a {@link PongPayload}; every other
+ * request envelope must be answered with an {@link AckPayload}. This
+ * pushes the previous runtime casts inside {@link
+ * InMemoryDaemonClient.send} out to the handler boundary so the
+ * test-double's contract is self-checking.
+ *
+ * A test handler that returns the wrong shape for a given envelope
+ * type now fails to type-check, instead of silently shipping a stray
+ * runtime cast.
  */
-export type RequestHandler = (
-  envelope: MessageEnvelope,
-) => Promise<AckPayload | PongPayload>;
+export interface RequestHandler {
+  /**
+   * Reply to a `ping` envelope.
+   *
+   * @param envelope The `ping` envelope to reply to.
+   * @returns A promise resolving to the `pong` payload.
+   */
+  (envelope: PingEnvelope): Promise<PongPayload>;
+  /**
+   * Reply to any non-`ping` request envelope.
+   *
+   * @param envelope The request envelope to reply to.
+   * @returns A promise resolving to the `ack` payload.
+   */
+  (envelope: AckEnvelope): Promise<AckPayload>;
+}
 
 /**
  * In-memory daemon double for TUI shell tests.
@@ -99,11 +146,28 @@ export class InMemoryDaemonClient {
     }
     const parsed = validation.data;
     this.sentEnvelopes.push(parsed);
-    const reply = await this.requestHandler(parsed);
     if (parsed.type === "ping") {
-      return { id: parsed.id, type: "pong", payload: reply as PongPayload };
+      // The `RequestHandler` overload selected here returns
+      // `Promise<PongPayload>`; no runtime cast required.
+      const payload = await this.requestHandler(parsed);
+      return { id: parsed.id, type: "pong", payload };
     }
-    return { id: parsed.id, type: "ack", payload: reply as AckPayload };
+    if (
+      parsed.type === "subscribe" ||
+      parsed.type === "unsubscribe" ||
+      parsed.type === "command" ||
+      parsed.type === "prompt"
+    ) {
+      // The `AckEnvelope` overload returns `Promise<AckPayload>` for
+      // every non-`ping` request type. A `pong`/`ack`/`event` envelope
+      // would not be a valid client→daemon request and is rejected
+      // below.
+      const payload = await this.requestHandler(parsed);
+      return { id: parsed.id, type: "ack", payload };
+    }
+    throw new Error(
+      `InMemoryDaemonClient.send: ${parsed.type} envelopes flow daemon→client only`,
+    );
   }
 
   /**
@@ -154,9 +218,16 @@ export class InMemoryDaemonClient {
   }
 }
 
-const defaultRequestHandler: RequestHandler = (envelope) => {
+// The default handler must satisfy both overloads. Implementing both
+// signatures with one body and a runtime branch is the standard TS
+// pattern for overloaded callables.
+function defaultRequestHandler(envelope: PingEnvelope): Promise<PongPayload>;
+function defaultRequestHandler(envelope: AckEnvelope): Promise<AckPayload>;
+function defaultRequestHandler(
+  envelope: RequestEnvelope,
+): Promise<PongPayload | AckPayload> {
   if (envelope.type === "ping") {
     return Promise.resolve<PongPayload>({ daemonVersion: MAKINA_VERSION });
   }
   return Promise.resolve<AckPayload>({ ok: true });
-};
+}

--- a/tests/unit/__snapshots__/tui_overlays_test.tsx.snap
+++ b/tests/unit/__snapshots__/tui_overlays_test.tsx.snap
@@ -1,0 +1,73 @@
+export const snapshot = {};
+
+snapshot[`CommandPalette: empty input shows every spec 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────╮
+│ Command Palette                     Tab autocomplete · Enter run · Esc close │
+│ > /                                                                          │
+│ > /cancel — Cancel a non-terminal task; preserves the worktree.              │
+│   /daemon — Manage the long-running daemon (sub-commands: stop).             │
+│   /help — List commands or describe one.                                     │
+│   /issue — Start a new task for an issue.                                    │
+│   /logs — Open the task scrollback.                                          │
+│   /merge — Force the merge of a READY_TO_MERGE task.                         │
+│   /quit — Exit the TUI; the daemon keeps running.                            │
+│   /repo — Manage registered repositories (add/default/list).                 │
+│   /retry — Re-enter a NEEDS_HUMAN task after a manual fix.                   │
+│   /status — Print every in-flight task's state.                              │
+│   /switch — Focus the listed task.                                           │
+│ No history yet.                                                              │
+╰──────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+snapshot[`CommandPalette: filtered to a single command by typed prefix 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────╮
+│ Command Palette                     Tab autocomplete · Enter run · Esc close │
+│ > /iss                                                                       │
+│ > /issue — Start a new task for an issue.                                    │
+│ No history yet.                                                              │
+╰──────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+snapshot[`CommandPalette: closed = unmounted (no overlay markup rendered) 1`] = `""`;
+
+snapshot[`CommandPalette: history seed reports the count 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────╮
+│ Command Palette                     Tab autocomplete · Enter run · Esc close │
+│ > /                                                                          │
+│ > /cancel — Cancel a non-terminal task; preserves the worktree.              │
+│   /daemon — Manage the long-running daemon (sub-commands: stop).             │
+│   /help — List commands or describe one.                                     │
+│   /issue — Start a new task for an issue.                                    │
+│   /logs — Open the task scrollback.                                          │
+│   /merge — Force the merge of a READY_TO_MERGE task.                         │
+│   /quit — Exit the TUI; the daemon keeps running.                            │
+│   /repo — Manage registered repositories (add/default/list).                 │
+│   /retry — Re-enter a NEEDS_HUMAN task after a manual fix.                   │
+│   /status — Print every in-flight task's state.                              │
+│   /switch — Focus the listed task.                                           │
+│ History: 3 ↑/↓ recall                                                        │
+╰──────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+snapshot[`TaskSwitcher: zero tasks renders the empty-state hint 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────╮
+│ Task Switcher                         ↑/↓ navigate · Enter focus · Esc close │
+│ No tasks yet — invoke /issue to start one.                                   │
+╰──────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+snapshot[`TaskSwitcher: single task with focus pill 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────╮
+│ Task Switcher                         ↑/↓ navigate · Enter focus · Esc close │
+│ > * task_2026-04-26T12-00-00_abc123                              DRAFTING 5m │
+╰──────────────────────────────────────────────────────────────────────────────╯"
+`;
+
+snapshot[`TaskSwitcher: N tasks with assorted state badges 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────────╮
+│ Task Switcher                         ↑/↓ navigate · Enter focus · Esc close │
+│     task_alpha                                                STABILIZING 5m │
+│ > * task_beta                                             READY_TO_MERGE 15m │
+│     task_gamma                                                     FAILED 1h │
+╰──────────────────────────────────────────────────────────────────────────────╯"
+`;

--- a/tests/unit/__snapshots__/tui_shell_test.tsx.snap
+++ b/tests/unit/__snapshots__/tui_shell_test.tsx.snap
@@ -9,7 +9,7 @@ snapshot[`App: initial render against the in-memory double 1`] = `
 │ No tasks yet — invoke /issue <repo>#<n> to start one.                        │
 │                                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
- ready                                     Ctrl+C exit · / command palette (W3)"
+ ready                           ctrl+p palette · ctrl+g switcher · Ctrl+C exit"
 `;
 
 snapshot[`App: "1 task active" after a state-changed event 1`] = `
@@ -21,8 +21,8 @@ snapshot[`App: "1 task active" after a state-changed event 1`] = `
 │ 1 task active.                                                               │
 │                                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
- task_2026-04-26T12-00-00_abc123: INIT →        Ctrl+C exit · / command palette
- CLONING_WORKTREE                                (W3)"
+ task_2026-04-26T12-00-00_abc123: INIT →   ctrl+p palette · ctrl+g switcher ·
+ CLONING_WORKTREE                          Ctrl+C exit"
 `;
 
 snapshot[`App: "disconnected" status is reflected in the header 1`] = `

--- a/tests/unit/in_memory_doubles_test.ts
+++ b/tests/unit/in_memory_doubles_test.ts
@@ -21,7 +21,12 @@ import { INSTALLATION_TOKEN_REFRESH_LEAD_MILLISECONDS } from "../../src/constant
 
 import { InMemoryGitHubAuth } from "../helpers/in_memory_github_auth.ts";
 import { InMemoryGitHubClient } from "../helpers/in_memory_github_client.ts";
-import { InMemoryDaemonClient } from "../helpers/in_memory_daemon_client.ts";
+import {
+  type AckEnvelope,
+  InMemoryDaemonClient,
+  type PingEnvelope,
+  type RequestEnvelope,
+} from "../helpers/in_memory_daemon_client.ts";
 import { MockAgentRunner } from "../helpers/mock_agent_runner.ts";
 
 const ONE_HOUR_MILLISECONDS = 60 * 60 * 1_000;
@@ -265,12 +270,21 @@ Deno.test("InMemoryDaemonClient: non-ping requests get an ack", async () => {
 
 Deno.test("InMemoryDaemonClient: setRequestHandler customizes ack payloads", async () => {
   const client = new InMemoryDaemonClient();
-  client.setRequestHandler((envelope) => {
+  // Implement the overloaded `RequestHandler` contract: `ping` →
+  // `PongPayload`, every other request envelope → `AckPayload`. The
+  // implementation signature uses `RequestEnvelope` and a runtime
+  // discriminant, mirroring the helper's own default handler.
+  function handler(envelope: PingEnvelope): Promise<PongPayload>;
+  function handler(envelope: AckEnvelope): Promise<AckPayload>;
+  function handler(
+    envelope: RequestEnvelope,
+  ): Promise<PongPayload | AckPayload> {
     if (envelope.type === "ping") {
-      return Promise.resolve({ daemonVersion: "test" });
+      return Promise.resolve<PongPayload>({ daemonVersion: "test" });
     }
-    return Promise.resolve({ ok: false, error: "denied" });
-  });
+    return Promise.resolve<AckPayload>({ ok: false, error: "denied" });
+  }
+  client.setRequestHandler(handler);
   const ack = await client.send({
     id: "3",
     type: "command",

--- a/tests/unit/slash_command_parser_test.ts
+++ b/tests/unit/slash_command_parser_test.ts
@@ -1,0 +1,439 @@
+/**
+ * Unit tests for {@link parseSlashCommand}.
+ *
+ * The plan's §Slash commands lists every supported invocation; each
+ * canonical form has at least one assertion below, plus negative cases
+ * for malformed input. Errors surface as a typed
+ * {@link SlashCommandParseError} so the test suite can pin the failure
+ * category as well as the message.
+ */
+
+import { assertEquals, assertThrows } from "@std/assert";
+
+import {
+  parseSlashCommand,
+  SLASH_COMMAND_NAMES,
+  SLASH_COMMAND_SPECS,
+  SlashCommandParseError,
+} from "../../src/tui/slash-command-parser.ts";
+import { makeIssueNumber, makeRepoFullName } from "../../src/types.ts";
+
+// ---------------------------------------------------------------------------
+// Recognised commands — happy paths
+// ---------------------------------------------------------------------------
+
+Deno.test("parseSlashCommand: /issue with positional issue number", () => {
+  const payload = parseSlashCommand("/issue 42");
+  assertEquals(payload.name, "issue");
+  assertEquals(payload.args, ["42"]);
+  assertEquals(payload.issueNumber, makeIssueNumber(42));
+  assertEquals(payload.repo, undefined);
+});
+
+Deno.test("parseSlashCommand: /issue trims surrounding whitespace and trailing newline", () => {
+  const payload = parseSlashCommand("  /issue 7  \n");
+  assertEquals(payload.name, "issue");
+  assertEquals(payload.args, ["7"]);
+  assertEquals(payload.issueNumber, makeIssueNumber(7));
+});
+
+Deno.test("parseSlashCommand: /issue with --repo flag after the number", () => {
+  const payload = parseSlashCommand("/issue 99 --repo owner/repo");
+  assertEquals(payload.name, "issue");
+  assertEquals(payload.args, ["99"]);
+  assertEquals(payload.issueNumber, makeIssueNumber(99));
+  assertEquals(payload.repo, makeRepoFullName("owner/repo"));
+});
+
+Deno.test("parseSlashCommand: /issue with --repo flag before the number", () => {
+  const payload = parseSlashCommand("/issue --repo owner/repo 12");
+  assertEquals(payload.name, "issue");
+  assertEquals(payload.args, ["12"]);
+  assertEquals(payload.issueNumber, makeIssueNumber(12));
+  assertEquals(payload.repo, makeRepoFullName("owner/repo"));
+});
+
+Deno.test("parseSlashCommand: /repo add returns the repo + installation id tokens", () => {
+  const payload = parseSlashCommand("/repo add owner/repo 9876543");
+  assertEquals(payload.name, "repo");
+  assertEquals(payload.args, ["add", "owner/repo", "9876543"]);
+  assertEquals(payload.repo, makeRepoFullName("owner/repo"));
+});
+
+Deno.test("parseSlashCommand: /repo default forwards the repo token", () => {
+  const payload = parseSlashCommand("/repo default owner/repo");
+  assertEquals(payload.name, "repo");
+  assertEquals(payload.args, ["default", "owner/repo"]);
+  assertEquals(payload.repo, makeRepoFullName("owner/repo"));
+});
+
+Deno.test("parseSlashCommand: /repo list takes no arguments", () => {
+  const payload = parseSlashCommand("/repo list");
+  assertEquals(payload.name, "repo");
+  assertEquals(payload.args, ["list"]);
+  assertEquals(payload.repo, undefined);
+});
+
+Deno.test("parseSlashCommand: /status returns name with empty args", () => {
+  const payload = parseSlashCommand("/status");
+  assertEquals(payload.name, "status");
+  assertEquals(payload.args, []);
+});
+
+Deno.test("parseSlashCommand: /switch forwards the task-id token", () => {
+  const payload = parseSlashCommand("/switch task_2026-04-26T12-00-00_abc123");
+  assertEquals(payload.name, "switch");
+  assertEquals(payload.args, ["task_2026-04-26T12-00-00_abc123"]);
+});
+
+Deno.test("parseSlashCommand: /cancel forwards the task-id token", () => {
+  const payload = parseSlashCommand("/cancel task_x");
+  assertEquals(payload.name, "cancel");
+  assertEquals(payload.args, ["task_x"]);
+});
+
+Deno.test("parseSlashCommand: /retry forwards the task-id token", () => {
+  const payload = parseSlashCommand("/retry task_y");
+  assertEquals(payload.name, "retry");
+  assertEquals(payload.args, ["task_y"]);
+});
+
+Deno.test("parseSlashCommand: /merge forwards the task-id token", () => {
+  const payload = parseSlashCommand("/merge task_z");
+  assertEquals(payload.name, "merge");
+  assertEquals(payload.args, ["task_z"]);
+});
+
+Deno.test("parseSlashCommand: /logs forwards the task-id token", () => {
+  const payload = parseSlashCommand("/logs task_q");
+  assertEquals(payload.name, "logs");
+  assertEquals(payload.args, ["task_q"]);
+});
+
+Deno.test("parseSlashCommand: /quit takes no arguments", () => {
+  const payload = parseSlashCommand("/quit");
+  assertEquals(payload.name, "quit");
+  assertEquals(payload.args, []);
+});
+
+Deno.test("parseSlashCommand: /daemon stop is the only daemon sub-command", () => {
+  const payload = parseSlashCommand("/daemon stop");
+  assertEquals(payload.name, "daemon");
+  assertEquals(payload.args, ["stop"]);
+});
+
+Deno.test("parseSlashCommand: /help with no argument lists every command", () => {
+  const payload = parseSlashCommand("/help");
+  assertEquals(payload.name, "help");
+  assertEquals(payload.args, []);
+});
+
+Deno.test("parseSlashCommand: /help with a target forwards the argument", () => {
+  const payload = parseSlashCommand("/help issue");
+  assertEquals(payload.name, "help");
+  assertEquals(payload.args, ["issue"]);
+});
+
+// ---------------------------------------------------------------------------
+// Whitespace and tokenisation edge cases
+// ---------------------------------------------------------------------------
+
+Deno.test("parseSlashCommand: collapses runs of whitespace between tokens", () => {
+  const payload = parseSlashCommand("/issue   42    --repo   owner/repo");
+  assertEquals(payload.args, ["42"]);
+  assertEquals(payload.repo, makeRepoFullName("owner/repo"));
+});
+
+Deno.test("parseSlashCommand: tabs separate tokens like spaces", () => {
+  const payload = parseSlashCommand("/issue\t42\t--repo\towner/repo");
+  assertEquals(payload.args, ["42"]);
+  assertEquals(payload.repo, makeRepoFullName("owner/repo"));
+});
+
+// ---------------------------------------------------------------------------
+// Negative cases — every error category exercised
+// ---------------------------------------------------------------------------
+
+Deno.test('parseSlashCommand: empty input throws "empty"', () => {
+  const error = assertThrows(
+    () => parseSlashCommand(""),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "empty");
+});
+
+Deno.test('parseSlashCommand: lone slash throws "empty"', () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "empty");
+});
+
+Deno.test('parseSlashCommand: input without a leading slash throws "not-a-command"', () => {
+  const error = assertThrows(
+    () => parseSlashCommand("issue 42"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "not-a-command");
+});
+
+Deno.test('parseSlashCommand: unrecognised command throws "unknown-command"', () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/sneeze"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "unknown-command");
+});
+
+Deno.test('parseSlashCommand: /issue without a number throws "bad-arguments"', () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/issue"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test('parseSlashCommand: /issue with a non-numeric arg throws "bad-arguments"', () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/issue notanumber"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test('parseSlashCommand: /issue with --repo missing its value throws "bad-arguments"', () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/issue 1 --repo"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /issue rejects duplicate --repo flags", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/issue 1 --repo a/b --repo c/d"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /issue rejects unknown flags", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/issue 1 --boom"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /issue rejects extra positional arguments", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/issue 1 2"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /issue rejects malformed --repo value", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/issue 1 --repo nope"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test('parseSlashCommand: /repo without sub-command throws "bad-arguments"', () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/repo"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test('parseSlashCommand: /repo with unknown sub-command throws "bad-arguments"', () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/repo install"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test('parseSlashCommand: /repo add without all args throws "bad-arguments"', () => {
+  const e1 = assertThrows(
+    () => parseSlashCommand("/repo add"),
+    SlashCommandParseError,
+  );
+  assertEquals(e1.kind, "bad-arguments");
+  const e2 = assertThrows(
+    () => parseSlashCommand("/repo add owner/repo"),
+    SlashCommandParseError,
+  );
+  assertEquals(e2.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /repo add with non-numeric installation id throws", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/repo add owner/repo abc"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /repo add with extra args throws", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/repo add owner/repo 1 2"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /repo default rejects malformed repo arg", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/repo default not-a-slash"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /repo default rejects extra args", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/repo default owner/repo extra"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /repo list rejects extra args", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/repo list now"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /status rejects extra args", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/status all"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /quit rejects extra args", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/quit now"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /switch without task id throws", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/switch"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /switch with extra args throws", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/switch t1 t2"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /cancel without task id throws", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/cancel"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /retry without task id throws", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/retry"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /merge without task id throws", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/merge"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /logs without task id throws", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/logs"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /daemon without sub-command throws", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/daemon"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /daemon with unknown sub-command throws", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/daemon restart"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /daemon stop rejects extra args", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/daemon stop now"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+Deno.test("parseSlashCommand: /help rejects more than one argument", () => {
+  const error = assertThrows(
+    () => parseSlashCommand("/help issue repo"),
+    SlashCommandParseError,
+  );
+  assertEquals(error.kind, "bad-arguments");
+});
+
+// ---------------------------------------------------------------------------
+// Spec metadata invariants
+// ---------------------------------------------------------------------------
+
+Deno.test("SLASH_COMMAND_SPECS: every name from SLASH_COMMAND_NAMES has a spec", () => {
+  for (const name of SLASH_COMMAND_NAMES) {
+    const spec = SLASH_COMMAND_SPECS.find((entry) => entry.name === name);
+    if (spec === undefined) {
+      throw new Error(`spec missing for "${name}"`);
+    }
+    assertEquals(spec.name, name);
+  }
+  assertEquals(SLASH_COMMAND_SPECS.length, SLASH_COMMAND_NAMES.length);
+});
+
+Deno.test("SLASH_COMMAND_SPECS: usage strings begin with /<name>", () => {
+  for (const spec of SLASH_COMMAND_SPECS) {
+    if (!spec.usage.startsWith(`/${spec.name}`)) {
+      throw new Error(
+        `usage for "${spec.name}" does not start with the expected prefix: ${spec.usage}`,
+      );
+    }
+  }
+});
+
+Deno.test("SLASH_COMMAND_SPECS: alphabetical order", () => {
+  const names = SLASH_COMMAND_SPECS.map((entry) => entry.name);
+  const sorted = [...names].sort();
+  assertEquals(names, sorted);
+});

--- a/tests/unit/tui_overlays_test.tsx
+++ b/tests/unit/tui_overlays_test.tsx
@@ -1,0 +1,846 @@
+/**
+ * Snapshot + unit tests for the Wave 3 overlays.
+ *
+ * Two overlays land here:
+ *   - {@link CommandPalette} — autocomplete + history + parse error.
+ *   - {@link TaskSwitcher} — 0 / 1 / N tasks with state badges + ages.
+ *
+ * The test fixtures are pure props-driven renders (Ink's `useInput`
+ * hooks are wired but disabled, so the snapshot output is stable
+ * across the Deno sanitizer's strict op accounting). Each overlay's
+ * `inputEnabled={false}` path is exercised by the snapshot tests, and
+ * a small set of in-memory direct-keystroke tests drives the
+ * stateful behaviour of `TaskSwitcher` without touching Ink's stdin.
+ */
+
+import { assertEquals } from "@std/assert";
+import { assertSnapshot } from "@std/testing/snapshot";
+import { Box, render as inkRender } from "ink";
+
+import { dispatchCommand, trimHistory } from "../../src/tui/App.tsx";
+import { CommandPalette, filterSuggestions } from "../../src/tui/components/CommandPalette.tsx";
+import { TaskSwitcher } from "../../src/tui/components/TaskSwitcher.tsx";
+import type { MessageEnvelope } from "../../src/ipc/protocol.ts";
+import type { DaemonReply } from "../../src/tui/ipc-client.ts";
+import { COMMAND_PALETTE_HISTORY_LIMIT } from "../../src/constants.ts";
+import {
+  formatAgeBetween,
+  formatTaskAge,
+  handleFocusedTaskEvent,
+  type TaskSummary,
+} from "../../src/tui/hooks/useFocusedTask.ts";
+import {
+  KeybindingParseError,
+  matchesKeybinding,
+  parseKeybinding,
+} from "../../src/tui/keybindings.ts";
+import { makeTaskId, type TaskId } from "../../src/types.ts";
+import { SLASH_COMMAND_NAMES } from "../../src/tui/slash-command-parser.ts";
+
+// ---------------------------------------------------------------------------
+// Fake stdout — mirrors the harness used in `tui_shell_test.tsx`.
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal `NodeJS.WriteStream`-shaped object that captures every
+ * `write()` call. Identical to the shell-test harness; copied here
+ * rather than exported so the two test files can evolve independently.
+ */
+class FakeStream {
+  /** Width of the simulated terminal. */
+  columns = 80;
+  /** Height of the simulated terminal. */
+  rows = 24;
+  /** Tells Ink to render with terminal escapes. */
+  isTTY = true;
+  /** Recorded frame buffer. */
+  readonly frames: string[] = [];
+  // deno-lint-ignore no-explicit-any
+  private readonly listeners = new Map<string, Array<(...args: any[]) => void>>();
+
+  /**
+   * Capture a frame. Mimics Node's `WriteStream.write` contract.
+   *
+   * @param chunk The frame text.
+   * @returns Always `true`.
+   */
+  write(chunk: string): boolean {
+    this.frames.push(String(chunk));
+    return true;
+  }
+  /** No-op; Ink occasionally batches writes via cork/uncork. */
+  cork(): void {}
+  /** No-op; pair of {@link FakeStream.cork}. */
+  uncork(): void {}
+  /** No-op; some terminals close the stream when done. */
+  end(): void {}
+  /**
+   * Register a Node-style event listener.
+   *
+   * @param event The event name.
+   * @param handler The callback to register.
+   * @returns This stream, for chaining.
+   */
+  // deno-lint-ignore no-explicit-any
+  on(event: string, handler: (...args: any[]) => void): this {
+    const list = this.listeners.get(event) ?? [];
+    list.push(handler);
+    this.listeners.set(event, list);
+    return this;
+  }
+  /**
+   * Remove a Node-style event listener.
+   *
+   * @param event The event name.
+   * @param handler The callback to remove.
+   * @returns This stream, for chaining.
+   */
+  // deno-lint-ignore no-explicit-any
+  off(event: string, handler: (...args: any[]) => void): this {
+    const list = this.listeners.get(event);
+    if (list === undefined) return this;
+    const index = list.indexOf(handler);
+    if (index >= 0) list.splice(index, 1);
+    return this;
+  }
+  /**
+   * The most recent frame containing visible content.
+   *
+   * @returns The newest frame.
+   */
+  lastVisibleFrame(): string {
+    const escape = String.fromCharCode(0x1B);
+    const csiRegex = new RegExp(`${escape}\\[[0-9?;]*[a-zA-Z]`, "g");
+    for (let index = this.frames.length - 1; index >= 0; index -= 1) {
+      const frame = this.frames[index];
+      if (frame === undefined) continue;
+      const stripped = frame.replace(csiRegex, "");
+      if (stripped.trim().length > 0) {
+        return frame;
+      }
+    }
+    return "";
+  }
+}
+
+/**
+ * Render an Ink element to a fake stdout.
+ *
+ * @param node The element to render.
+ * @returns The frame recorder.
+ */
+async function renderToBuffer(
+  node: Parameters<typeof inkRender>[0],
+): Promise<FakeStream> {
+  const stdout = new FakeStream();
+  const stderr = new FakeStream();
+  const instance = inkRender(node, {
+    // deno-lint-ignore no-explicit-any
+    stdout: stdout as any,
+    // deno-lint-ignore no-explicit-any
+    stderr: stderr as any,
+    debug: true,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  });
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  instance.unmount();
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  return stdout;
+}
+
+// ---------------------------------------------------------------------------
+// CommandPalette snapshots
+// ---------------------------------------------------------------------------
+
+Deno.test({
+  name: "CommandPalette: empty input shows every spec",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async (t) => {
+    const stdout = await renderToBuffer(
+      <CommandPalette
+        onSubmit={() => {}}
+        onClose={() => {}}
+        inputEnabled={false}
+      />,
+    );
+    await assertSnapshot(t, stdout.lastVisibleFrame());
+  },
+});
+
+Deno.test({
+  name: "CommandPalette: filtered to a single command by typed prefix",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async (t) => {
+    const stdout = await renderToBuffer(
+      <CommandPalette
+        onSubmit={() => {}}
+        onClose={() => {}}
+        inputEnabled={false}
+        initialInput="/iss"
+      />,
+    );
+    await assertSnapshot(t, stdout.lastVisibleFrame());
+  },
+});
+
+Deno.test({
+  name: "CommandPalette: closed = unmounted (no overlay markup rendered)",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async (t) => {
+    // Rendering no palette results in only a wrapper, but the snapshot
+    // pins the absence of any palette markup so a regression that
+    // accidentally renders the palette unconditionally trips this.
+    const stdout = await renderToBuffer(<Box flexDirection="column" />);
+    await assertSnapshot(t, stdout.lastVisibleFrame());
+  },
+});
+
+Deno.test({
+  name: "CommandPalette: history seed reports the count",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async (t) => {
+    const stdout = await renderToBuffer(
+      <CommandPalette
+        onSubmit={() => {}}
+        onClose={() => {}}
+        inputEnabled={false}
+        history={["/issue 42", "/status", "/help"]}
+      />,
+    );
+    await assertSnapshot(t, stdout.lastVisibleFrame());
+  },
+});
+
+Deno.test("CommandPalette: filterSuggestions returns every spec for an empty input", () => {
+  assertEquals(filterSuggestions("").length, SLASH_COMMAND_NAMES.length);
+  assertEquals(filterSuggestions("  ").length, SLASH_COMMAND_NAMES.length);
+  assertEquals(filterSuggestions("/").length, SLASH_COMMAND_NAMES.length);
+});
+
+Deno.test("CommandPalette: filterSuggestions narrows by prefix", () => {
+  const suggestions = filterSuggestions("/iss");
+  assertEquals(suggestions.length, 1);
+  assertEquals(suggestions[0]?.name, "issue");
+});
+
+Deno.test("CommandPalette: filterSuggestions keeps every match for a shared prefix", () => {
+  // "re" is shared by /repo and /retry, so both should be returned.
+  const suggestions = filterSuggestions("/re");
+  const names = suggestions.map((spec) => spec.name);
+  assertEquals(names.includes("repo"), true);
+  assertEquals(names.includes("retry"), true);
+});
+
+Deno.test("CommandPalette: filterSuggestions returns empty for an unknown stem", () => {
+  assertEquals(filterSuggestions("/sneeze").length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// TaskSwitcher snapshots
+// ---------------------------------------------------------------------------
+
+const FIXED_NOW = new Date("2026-04-26T12:05:00.000Z");
+
+Deno.test({
+  name: "TaskSwitcher: zero tasks renders the empty-state hint",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async (t) => {
+    const stdout = await renderToBuffer(
+      <TaskSwitcher
+        tasks={[]}
+        onPick={() => {}}
+        onClose={() => {}}
+        inputEnabled={false}
+        now={FIXED_NOW}
+      />,
+    );
+    await assertSnapshot(t, stdout.lastVisibleFrame());
+  },
+});
+
+Deno.test({
+  name: "TaskSwitcher: single task with focus pill",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async (t) => {
+    const taskId = makeTaskId("task_2026-04-26T12-00-00_abc123");
+    const tasks: readonly TaskSummary[] = [
+      {
+        id: taskId,
+        state: "DRAFTING",
+        firstSeenAtIso: "2026-04-26T12:00:00.000Z",
+        lastSeenAtIso: "2026-04-26T12:04:30.000Z",
+      },
+    ];
+    const stdout = await renderToBuffer(
+      <TaskSwitcher
+        tasks={tasks}
+        focusedTaskId={taskId}
+        onPick={() => {}}
+        onClose={() => {}}
+        inputEnabled={false}
+        now={FIXED_NOW}
+      />,
+    );
+    await assertSnapshot(t, stdout.lastVisibleFrame());
+  },
+});
+
+Deno.test({
+  name: "TaskSwitcher: N tasks with assorted state badges",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async (t) => {
+    const tasks: readonly TaskSummary[] = [
+      {
+        id: makeTaskId("task_alpha"),
+        state: "STABILIZING",
+        firstSeenAtIso: "2026-04-26T12:00:00.000Z",
+        lastSeenAtIso: "2026-04-26T12:04:00.000Z",
+      },
+      {
+        id: makeTaskId("task_beta"),
+        state: "READY_TO_MERGE",
+        firstSeenAtIso: "2026-04-26T11:50:00.000Z",
+        lastSeenAtIso: "2026-04-26T12:01:00.000Z",
+      },
+      {
+        id: makeTaskId("task_gamma"),
+        state: "FAILED",
+        firstSeenAtIso: "2026-04-26T11:00:00.000Z",
+        lastSeenAtIso: "2026-04-26T11:30:00.000Z",
+      },
+    ];
+    const stdout = await renderToBuffer(
+      <TaskSwitcher
+        tasks={tasks}
+        focusedTaskId={makeTaskId("task_beta")}
+        onPick={() => {}}
+        onClose={() => {}}
+        inputEnabled={false}
+        now={FIXED_NOW}
+      />,
+    );
+    await assertSnapshot(t, stdout.lastVisibleFrame());
+  },
+});
+
+// ---------------------------------------------------------------------------
+// useFocusedTask — direct unit tests against handleFocusedTaskEvent
+// ---------------------------------------------------------------------------
+
+Deno.test("handleFocusedTaskEvent: state-changed updates the per-task summary", () => {
+  let map: ReadonlyMap<TaskId, TaskSummary> = new Map();
+  let focused: TaskId | undefined;
+  handleFocusedTaskEvent(
+    {
+      taskId: "t1",
+      atIso: "2026-04-26T12:00:00.000Z",
+      kind: "state-changed",
+      data: { fromState: "INIT", toState: "DRAFTING" },
+    },
+    {
+      setTaskMap: (update) => {
+        map = update(map);
+      },
+      setFocusedTaskId: (update) => {
+        focused = update(focused);
+      },
+    },
+  );
+  const summary = map.get(makeTaskId("t1"));
+  assertEquals(summary?.state, "DRAFTING");
+  assertEquals(summary?.firstSeenAtIso, "2026-04-26T12:00:00.000Z");
+  assertEquals(summary?.lastSeenAtIso, "2026-04-26T12:00:00.000Z");
+  assertEquals(focused, makeTaskId("t1"));
+});
+
+Deno.test("handleFocusedTaskEvent: log event preserves the state and bumps lastSeen", () => {
+  let map: ReadonlyMap<TaskId, TaskSummary> = new Map([[
+    makeTaskId("t1"),
+    {
+      id: makeTaskId("t1"),
+      state: "DRAFTING",
+      firstSeenAtIso: "2026-04-26T12:00:00.000Z",
+      lastSeenAtIso: "2026-04-26T12:00:00.000Z",
+    },
+  ]]);
+  handleFocusedTaskEvent(
+    {
+      taskId: "t1",
+      atIso: "2026-04-26T12:01:00.000Z",
+      kind: "log",
+      data: { level: "info", message: "tick" },
+    },
+    {
+      setTaskMap: (update) => {
+        map = update(map);
+      },
+      setFocusedTaskId: () => {},
+    },
+  );
+  const summary = map.get(makeTaskId("t1"));
+  assertEquals(summary?.state, "DRAFTING");
+  assertEquals(summary?.firstSeenAtIso, "2026-04-26T12:00:00.000Z");
+  assertEquals(summary?.lastSeenAtIso, "2026-04-26T12:01:00.000Z");
+});
+
+Deno.test("handleFocusedTaskEvent: focused task does not jump on subsequent events", () => {
+  let map: ReadonlyMap<TaskId, TaskSummary> = new Map();
+  let focused: TaskId | undefined;
+  handleFocusedTaskEvent(
+    {
+      taskId: "t1",
+      atIso: "2026-04-26T12:00:00.000Z",
+      kind: "log",
+      data: { level: "info", message: "first" },
+    },
+    {
+      setTaskMap: (update) => {
+        map = update(map);
+      },
+      setFocusedTaskId: (update) => {
+        focused = update(focused);
+      },
+    },
+  );
+  handleFocusedTaskEvent(
+    {
+      taskId: "t2",
+      atIso: "2026-04-26T12:00:30.000Z",
+      kind: "log",
+      data: { level: "info", message: "second" },
+    },
+    {
+      setTaskMap: (update) => {
+        map = update(map);
+      },
+      setFocusedTaskId: (update) => {
+        focused = update(focused);
+      },
+    },
+  );
+  assertEquals(focused, makeTaskId("t1"));
+  assertEquals(map.size, 2);
+});
+
+Deno.test("handleFocusedTaskEvent: malformed task id is ignored without crashing", () => {
+  let map: ReadonlyMap<TaskId, TaskSummary> = new Map();
+  let focused: TaskId | undefined;
+  handleFocusedTaskEvent(
+    {
+      taskId: "  ",
+      atIso: "2026-04-26T12:00:00.000Z",
+      kind: "log",
+      data: { level: "info", message: "skip" },
+    },
+    {
+      setTaskMap: (update) => {
+        map = update(map);
+      },
+      setFocusedTaskId: (update) => {
+        focused = update(focused);
+      },
+    },
+  );
+  assertEquals(map.size, 0);
+  assertEquals(focused, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// formatTaskAge / formatAgeBetween
+// ---------------------------------------------------------------------------
+
+Deno.test("formatTaskAge: seconds-granular near the present", () => {
+  const summary: TaskSummary = {
+    id: makeTaskId("t1"),
+    state: undefined,
+    firstSeenAtIso: "2026-04-26T12:00:00.000Z",
+    lastSeenAtIso: "2026-04-26T12:00:00.000Z",
+  };
+  assertEquals(formatTaskAge(summary, new Date("2026-04-26T12:00:05.000Z")), "5s");
+});
+
+Deno.test("formatAgeBetween: minutes / hours / days", () => {
+  assertEquals(
+    formatAgeBetween("2026-04-26T12:00:00.000Z", new Date("2026-04-26T12:30:00.000Z")),
+    "30m",
+  );
+  assertEquals(
+    formatAgeBetween("2026-04-26T08:00:00.000Z", new Date("2026-04-26T12:00:00.000Z")),
+    "4h",
+  );
+  assertEquals(
+    formatAgeBetween("2026-04-22T12:00:00.000Z", new Date("2026-04-26T12:00:00.000Z")),
+    "4d",
+  );
+});
+
+Deno.test("formatAgeBetween: malformed iso returns ?", () => {
+  assertEquals(formatAgeBetween("not-a-date", new Date()), "?");
+});
+
+Deno.test("formatAgeBetween: clamps negative deltas to 0s", () => {
+  // The reference clock is before the event — should not go negative.
+  assertEquals(
+    formatAgeBetween("2026-04-26T12:30:00.000Z", new Date("2026-04-26T12:00:00.000Z")),
+    "0s",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Keybindings
+// ---------------------------------------------------------------------------
+
+Deno.test("parseKeybinding: accepts ctrl+p", () => {
+  const parsed = parseKeybinding("ctrl+p");
+  assertEquals(parsed, { ctrl: true, shift: false, meta: false, alt: false, key: "p" });
+});
+
+Deno.test("parseKeybinding: accepts ctrl+shift+tab", () => {
+  const parsed = parseKeybinding("ctrl+shift+tab");
+  assertEquals(parsed, { ctrl: true, shift: true, meta: false, alt: false, key: "tab" });
+});
+
+Deno.test("parseKeybinding: trims surrounding whitespace and lowercases components", () => {
+  const parsed = parseKeybinding("  Ctrl+P  ");
+  assertEquals(parsed.ctrl, true);
+  assertEquals(parsed.key, "p");
+});
+
+Deno.test("parseKeybinding: rejects empty input", () => {
+  let threw = false;
+  try {
+    parseKeybinding("");
+  } catch (error) {
+    threw = error instanceof KeybindingParseError;
+  }
+  assertEquals(threw, true);
+});
+
+Deno.test("parseKeybinding: rejects unknown modifier", () => {
+  let threw = false;
+  try {
+    parseKeybinding("super+p");
+  } catch (error) {
+    threw = error instanceof KeybindingParseError;
+  }
+  assertEquals(threw, true);
+});
+
+Deno.test("parseKeybinding: rejects modifier-only chord", () => {
+  let threw = false;
+  try {
+    parseKeybinding("ctrl");
+  } catch (error) {
+    threw = error instanceof KeybindingParseError;
+  }
+  assertEquals(threw, true);
+});
+
+Deno.test("matchesKeybinding: ctrl+p fires on Ctrl+P keystroke", () => {
+  const fired = matchesKeybinding("ctrl+p", "p", {
+    ctrl: true,
+    shift: false,
+    meta: false,
+    tab: false,
+    return: false,
+    escape: false,
+    backspace: false,
+    delete: false,
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    pageUp: false,
+    pageDown: false,
+  });
+  assertEquals(fired, true);
+});
+
+Deno.test("matchesKeybinding: ctrl+p does not fire without ctrl", () => {
+  const fired = matchesKeybinding("ctrl+p", "p", {
+    ctrl: false,
+    shift: false,
+    meta: false,
+    tab: false,
+    return: false,
+    escape: false,
+    backspace: false,
+    delete: false,
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    pageUp: false,
+    pageDown: false,
+  });
+  assertEquals(fired, false);
+});
+
+Deno.test("matchesKeybinding: named keys (escape, tab) match by flag", () => {
+  const flags = {
+    ctrl: false,
+    shift: false,
+    meta: false,
+    tab: true,
+    return: false,
+    escape: false,
+    backspace: false,
+    delete: false,
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    pageUp: false,
+    pageDown: false,
+  };
+  assertEquals(matchesKeybinding("tab", "", flags), true);
+  assertEquals(matchesKeybinding("escape", "", flags), false);
+});
+
+Deno.test("matchesKeybinding: unparseable chord never fires", () => {
+  const fired = matchesKeybinding("this is not a chord", "p", {
+    ctrl: true,
+    shift: false,
+    meta: false,
+    tab: false,
+    return: false,
+    escape: false,
+    backspace: false,
+    delete: false,
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    pageUp: false,
+    pageDown: false,
+  });
+  assertEquals(fired, false);
+});
+
+Deno.test("parseKeybinding: rejects empty component (`ctrl++p`)", () => {
+  let threw = false;
+  try {
+    parseKeybinding("ctrl++p");
+  } catch (error) {
+    threw = error instanceof KeybindingParseError;
+  }
+  assertEquals(threw, true);
+});
+
+Deno.test("matchesKeybinding: meta-required chord does not fire without meta", () => {
+  const fired = matchesKeybinding("meta+x", "x", {
+    ctrl: false,
+    shift: false,
+    meta: false,
+    tab: false,
+    return: false,
+    escape: false,
+    backspace: false,
+    delete: false,
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    pageUp: false,
+    pageDown: false,
+  });
+  assertEquals(fired, false);
+});
+
+Deno.test("matchesKeybinding: alt+x requires meta flag", () => {
+  const without = matchesKeybinding("alt+x", "x", {
+    ctrl: false,
+    shift: false,
+    meta: false,
+    tab: false,
+    return: false,
+    escape: false,
+    backspace: false,
+    delete: false,
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    pageUp: false,
+    pageDown: false,
+  });
+  assertEquals(without, false);
+  const withMeta = matchesKeybinding("alt+x", "x", {
+    ctrl: false,
+    shift: false,
+    meta: true,
+    tab: false,
+    return: false,
+    escape: false,
+    backspace: false,
+    delete: false,
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    pageUp: false,
+    pageDown: false,
+  });
+  assertEquals(withMeta, true);
+});
+
+Deno.test("matchesKeybinding: shift-required chord does not fire without shift", () => {
+  const fired = matchesKeybinding("ctrl+shift+p", "p", {
+    ctrl: true,
+    shift: false,
+    meta: false,
+    tab: false,
+    return: false,
+    escape: false,
+    backspace: false,
+    delete: false,
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    pageUp: false,
+    pageDown: false,
+  });
+  assertEquals(fired, false);
+});
+
+// ---------------------------------------------------------------------------
+// App helpers — dispatchCommand and trimHistory
+// ---------------------------------------------------------------------------
+
+Deno.test("trimHistory: passes through arrays at or under the limit", () => {
+  const tiny: readonly string[] = ["/issue 1", "/status"];
+  assertEquals(trimHistory(tiny), tiny);
+});
+
+Deno.test("trimHistory: truncates oversized arrays from the tail", () => {
+  const oversized = Array.from(
+    { length: COMMAND_PALETTE_HISTORY_LIMIT + 5 },
+    (_value, index) => `/cmd-${index}`,
+  );
+  const trimmed = trimHistory(oversized);
+  assertEquals(trimmed.length, COMMAND_PALETTE_HISTORY_LIMIT);
+  // Newest entries are preserved (head); the oldest 5 are dropped.
+  assertEquals(trimmed[0], "/cmd-0");
+});
+
+Deno.test("dispatchCommand: ack with ok=true reports success", async () => {
+  const recorded: MessageEnvelope[] = [];
+  const send = (envelope: MessageEnvelope): Promise<DaemonReply> => {
+    recorded.push(envelope);
+    return Promise.resolve({
+      id: envelope.id,
+      type: "ack",
+      payload: { ok: true },
+    });
+  };
+  const outcome = await dispatchCommand(send, {
+    name: "status",
+    args: [],
+  });
+  assertEquals(outcome.kind, "ok");
+  assertEquals(outcome.message, "/status dispatched");
+  assertEquals(recorded.length, 1);
+  assertEquals(recorded[0]?.type, "command");
+});
+
+Deno.test("dispatchCommand: ack with ok=false reports an error message", async () => {
+  const send = (envelope: MessageEnvelope): Promise<DaemonReply> => {
+    return Promise.resolve({
+      id: envelope.id,
+      type: "ack",
+      payload: { ok: false, error: "no such task" },
+    });
+  };
+  const outcome = await dispatchCommand(send, {
+    name: "cancel",
+    args: ["task_x"],
+  });
+  assertEquals(outcome.kind, "error");
+  assertEquals(outcome.message, "no such task");
+});
+
+Deno.test("dispatchCommand: ack with ok=false but no error uses a fallback message", async () => {
+  const send = (envelope: MessageEnvelope): Promise<DaemonReply> => {
+    return Promise.resolve({
+      id: envelope.id,
+      type: "ack",
+      payload: { ok: false },
+    });
+  };
+  const outcome = await dispatchCommand(send, {
+    name: "cancel",
+    args: ["task_x"],
+  });
+  assertEquals(outcome.kind, "error");
+  assertEquals(outcome.message, "/cancel refused");
+});
+
+Deno.test("dispatchCommand: pong reply is treated as a protocol violation", async () => {
+  const send = (envelope: MessageEnvelope): Promise<DaemonReply> => {
+    return Promise.resolve({
+      id: envelope.id,
+      type: "pong",
+      payload: { daemonVersion: "x" },
+    });
+  };
+  const outcome = await dispatchCommand(send, {
+    name: "status",
+    args: [],
+  });
+  assertEquals(outcome.kind, "error");
+  assertEquals(outcome.message.startsWith("unexpected reply"), true);
+});
+
+Deno.test("dispatchCommand: a rejected send surfaces as an error outcome", async () => {
+  const send = (_envelope: MessageEnvelope): Promise<DaemonReply> => {
+    return Promise.reject(new Error("transport down"));
+  };
+  const outcome = await dispatchCommand(send, {
+    name: "status",
+    args: [],
+  });
+  assertEquals(outcome.kind, "error");
+  assertEquals(outcome.message, "transport down");
+});
+
+Deno.test("dispatchCommand: a non-Error rejection is stringified", async () => {
+  const send = (_envelope: MessageEnvelope): Promise<DaemonReply> => {
+    return Promise.reject("oh no");
+  };
+  const outcome = await dispatchCommand(send, {
+    name: "status",
+    args: [],
+  });
+  assertEquals(outcome.kind, "error");
+  assertEquals(outcome.message, "oh no");
+});
+
+Deno.test("matchesKeybinding: ctrl+p with empty input still matches via key length", () => {
+  // Some terminals deliver Ctrl+P as key.ctrl=true with input="".
+  const fired = matchesKeybinding("ctrl+p", "", {
+    ctrl: true,
+    shift: false,
+    meta: false,
+    tab: false,
+    return: false,
+    escape: false,
+    backspace: false,
+    delete: false,
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    pageUp: false,
+    pageDown: false,
+  });
+  assertEquals(fired, true);
+});

--- a/tests/unit/tui_overlays_test.tsx
+++ b/tests/unit/tui_overlays_test.tsx
@@ -500,12 +500,17 @@ Deno.test("formatAgeBetween: clamps negative deltas to 0s", () => {
 
 Deno.test("parseKeybinding: accepts ctrl+p", () => {
   const parsed = parseKeybinding("ctrl+p");
-  assertEquals(parsed, { ctrl: true, shift: false, meta: false, alt: false, key: "p" });
+  assertEquals(parsed, { ctrl: true, shift: false, meta: false, key: "p" });
 });
 
 Deno.test("parseKeybinding: accepts ctrl+shift+tab", () => {
   const parsed = parseKeybinding("ctrl+shift+tab");
-  assertEquals(parsed, { ctrl: true, shift: true, meta: false, alt: false, key: "tab" });
+  assertEquals(parsed, { ctrl: true, shift: true, meta: false, key: "tab" });
+});
+
+Deno.test("parseKeybinding: alt+ folds into the meta flag (no separate alt field)", () => {
+  const parsed = parseKeybinding("alt+x");
+  assertEquals(parsed, { ctrl: false, shift: false, meta: true, key: "x" });
 });
 
 Deno.test("parseKeybinding: trims surrounding whitespace and lowercases components", () => {

--- a/tests/unit/tui_overlays_test.tsx
+++ b/tests/unit/tui_overlays_test.tsx
@@ -844,3 +844,52 @@ Deno.test("matchesKeybinding: ctrl+p with empty input still matches via key leng
   });
   assertEquals(fired, true);
 });
+
+Deno.test("matchesKeybinding: ctrl+p matches the ASCII control byte \\x10", () => {
+  // xterm-style terminals deliver Ctrl+P as key.ctrl=true with input="\x10".
+  // The chord must match the right control byte; a chord asking for ctrl+p
+  // must NOT fire on a ctrl+, keystroke that delivers a different byte.
+  const flags = {
+    ctrl: true,
+    shift: false,
+    meta: false,
+    tab: false,
+    return: false,
+    escape: false,
+    backspace: false,
+    delete: false,
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    pageUp: false,
+    pageDown: false,
+  };
+  assertEquals(matchesKeybinding("ctrl+p", "\x10", flags), true);
+  assertEquals(matchesKeybinding("ctrl+a", "\x01", flags), true);
+  assertEquals(matchesKeybinding("ctrl+z", "\x1a", flags), true);
+  // ctrl+p (\x10) keystroke must not fire a ctrl+a (\x01) chord.
+  assertEquals(matchesKeybinding("ctrl+a", "\x10", flags), false);
+});
+
+Deno.test("matchesKeybinding: shift-tolerant — chord without shift does not fire while shift is held", () => {
+  // Doc/impl drift fix: the JSDoc claims modifiers must match exactly,
+  // and the implementation now enforces that for shift too.
+  const fired = matchesKeybinding("ctrl+p", "p", {
+    ctrl: true,
+    shift: true,
+    meta: false,
+    tab: false,
+    return: false,
+    escape: false,
+    backspace: false,
+    delete: false,
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    pageUp: false,
+    pageDown: false,
+  });
+  assertEquals(fired, false);
+});

--- a/tests/unit/tui_shell_test.tsx
+++ b/tests/unit/tui_shell_test.tsx
@@ -203,7 +203,7 @@ Deno.test({
   fn: async (t) => {
     const client = new InMemoryDaemonClient();
     const stdout = await renderToBuffer(
-      <App client={client} version="0.0.0-test" autoConnect={false} />,
+      <App client={client} version="0.0.0-test" autoConnect={false} inputEnabled={false} />,
     );
     await assertSnapshot(t, stdout.lastVisibleFrame());
   },
@@ -222,7 +222,7 @@ Deno.test({
     const stdout = new FakeStream();
     const stderr = new FakeStream();
     const instance = inkRender(
-      <App client={client} version="0.0.0-test" autoConnect={false} />,
+      <App client={client} version="0.0.0-test" autoConnect={false} inputEnabled={false} />,
       {
         // deno-lint-ignore no-explicit-any
         stdout: stdout as any,
@@ -271,7 +271,7 @@ Deno.test({
     // Sanity: the App with the in-memory double also renders cleanly.
     const client = new InMemoryDaemonClient();
     const stdoutApp = await renderToBuffer(
-      <App client={client} version="0.0.0-test" autoConnect={false} />,
+      <App client={client} version="0.0.0-test" autoConnect={false} inputEnabled={false} />,
     );
     assertEquals(stdoutApp.frames.length > 0, true);
   },
@@ -309,7 +309,6 @@ Deno.test("handleEvent: log event sets the last message with level prefix", () =
   let lastMessage: string | undefined;
   let lastError: string | undefined;
   let known = new Set<ReturnType<typeof makeTaskId>>();
-  let focused: ReturnType<typeof makeTaskId> | undefined;
   const event: EventPayload = {
     taskId: "t1",
     atIso: "2026-04-26T12:00:00.000Z",
@@ -326,14 +325,10 @@ Deno.test("handleEvent: log event sets the last message with level prefix", () =
     setLastError: (next) => {
       lastError = next;
     },
-    setFocusedTaskId: (update) => {
-      focused = update(focused);
-    },
   });
   assertEquals(lastMessage, "[info] hello");
   assertEquals(lastError, undefined);
   assertEquals(known.size, 1);
-  assertEquals(focused, makeTaskId("t1"));
 });
 
 Deno.test("handleEvent: state-changed event renders fromState → toState", () => {
@@ -354,51 +349,10 @@ Deno.test("handleEvent: state-changed event renders fromState → toState", () =
         lastMessage = next;
       },
       setLastError: () => {},
-      setFocusedTaskId: () => {},
     },
   );
   assertEquals(lastMessage, "task_x: INIT → CLONING_WORKTREE");
   assertEquals(known.has(makeTaskId("task_x")), true);
-});
-
-Deno.test("handleEvent: focused-task is auto-set on the first event only", () => {
-  let focused: ReturnType<typeof makeTaskId> | undefined;
-  // First event with t1 → focus snaps to t1.
-  handleEvent(
-    {
-      taskId: "t1",
-      atIso: "2026-04-26T12:00:00.000Z",
-      kind: "log",
-      data: { level: "info", message: "first" },
-    },
-    {
-      setKnownTaskIds: () => {},
-      setLastMessage: () => {},
-      setLastError: () => {},
-      setFocusedTaskId: (update) => {
-        focused = update(focused);
-      },
-    },
-  );
-  assertEquals(focused, makeTaskId("t1"));
-  // Second event from a different task — focus must NOT jump.
-  handleEvent(
-    {
-      taskId: "t2",
-      atIso: "2026-04-26T12:00:01.000Z",
-      kind: "log",
-      data: { level: "info", message: "second" },
-    },
-    {
-      setKnownTaskIds: () => {},
-      setLastMessage: () => {},
-      setLastError: () => {},
-      setFocusedTaskId: (update) => {
-        focused = update(focused);
-      },
-    },
-  );
-  assertEquals(focused, makeTaskId("t1"));
 });
 
 Deno.test("handleEvent: agent-message event truncates long text", () => {
@@ -417,7 +371,6 @@ Deno.test("handleEvent: agent-message event truncates long text", () => {
         lastMessage = next;
       },
       setLastError: () => {},
-      setFocusedTaskId: () => {},
     },
   );
   assertEquals(lastMessage?.endsWith("…"), true);
@@ -442,7 +395,6 @@ Deno.test("handleEvent: github-call event renders method + endpoint", () => {
         lastMessage = next;
       },
       setLastError: () => {},
-      setFocusedTaskId: () => {},
     },
   );
   assertEquals(lastMessage, "github GET /repos/o/r/issues/1");
@@ -463,7 +415,6 @@ Deno.test("handleEvent: error event sets lastError", () => {
       setLastError: (next) => {
         lastError = next;
       },
-      setFocusedTaskId: () => {},
     },
   );
   assertEquals(lastError, "boom");
@@ -490,7 +441,6 @@ Deno.test("handleEvent: invalid task id surfaces as an error and bails", () => {
       setLastError: (next) => {
         lastError = next;
       },
-      setFocusedTaskId: () => {},
     },
   );
   assertEquals(lastError?.startsWith("event with invalid task id"), true);
@@ -514,7 +464,6 @@ Deno.test("handleEvent: duplicate task id leaves the known set unchanged", () =>
       },
       setLastMessage: () => {},
       setLastError: () => {},
-      setFocusedTaskId: () => {},
     },
   );
   assertEquals(known.size, 1);


### PR DESCRIPTION
## Summary

- New `src/tui/slash-command-parser.ts`: single source of truth for the slash command vocabulary; every command from the plan's §Slash commands is covered (`/issue`, `/repo {add|default|list}`, `/status`, `/switch`, `/cancel`, `/retry`, `/merge`, `/logs`, `/quit`, `/daemon stop`, `/help`). Failures surface as a typed `SlashCommandParseError`.
- New `src/tui/components/CommandPalette.tsx` (default `Ctrl+P`) with autocomplete + in-memory history; `src/tui/components/TaskSwitcher.tsx` (default `Ctrl+G`) with arrow-key navigation, state badges, ages.
- New `src/tui/hooks/useFocusedTask.ts` consolidates focused-task state and per-task summaries from the daemon's event stream; lifted out of `App.tsx`.
- New `src/tui/keybindings.ts` parses `<modifier>+<key>` chord strings and matches Ink's `useInput` flag bag uniformly across macOS and Linux.
- `App.tsx` wires both overlays through `tui.keybindings.commandPalette` / `tui.keybindings.taskSwitcher` from config; palette submissions dispatch as `command` envelopes through `useDaemonConnection.send`.

## Test plan

- [x] `deno task ci` green locally (404 tests, coverage gate ≥80%; aggregate 90.3% lines / 94.7% branches).
- [x] `tests/unit/slash_command_parser_test.ts` exercises every command in §Slash commands plus negative cases for each `SlashCommandParseError.kind`.
- [x] `tests/unit/tui_overlays_test.tsx` snapshots palette open/closed/filtered, switcher with 0/1/N tasks; direct unit tests for `handleFocusedTaskEvent`, `formatAgeBetween`, keybindings parser, and `dispatchCommand`.
- [x] `deno doc --lint` green; JSDoc on every exported symbol.
- [x] Wave 2 lessons addressed up front: no bare numeric literals (added `COMMAND_PALETTE_HISTORY_LIMIT`, `MILLISECONDS_PER_SECOND`, etc.), no global mutation in tests, cross-platform keybindings (alt→meta fold), domain errors (`SlashCommandParseError`, `KeybindingParseError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)