### PR TITLE
feat(#18): merge modes + cleanup + /merge command

### DIFF
--- a/docs/adrs/018-merge-modes-failure-classification.md
+++ b/docs/adrs/018-merge-modes-failure-classification.md
@@ -1,0 +1,108 @@
+# ADR-018 — Merge-mode failure classification and `/merge` re-entry surface
+
+## Status
+
+Accepted (Wave 4, issue #18).
+
+## Context
+
+Wave 3 (#12) shipped the supervisor skeleton, including a stub at the `READY_TO_MERGE` step that
+performed an unconditional auto-merge or parked the task for `manual` mode. Wave 4 needs to fill in
+the real merge step:
+
+1. **Three merge modes.** `squash` and `rebase` auto-merge through `GitHubClient.mergePullRequest`;
+   `manual` waits for an operator-issued `/merge <task-id>` slash command.
+2. **Cleanup.** Configuration `lifecycle.preserveWorktreeOnMerge` controls whether the per-task
+   worktree is removed after a successful merge.
+3. **Failure handling.** `mergePullRequest` can fail for two structurally different reasons:
+   - The PR is genuinely **not mergeable** (conflicts, base-branch protection, stale head SHA). The
+     code is fine; an operator must unblock the merge by hand. Escalating the task to `FAILED` would
+     lose the work.
+   - The API call faulted for **transient** reasons (network glitch, 5xx). A follow-up retry is
+     reasonable; for now the task lands in `FAILED` so the operator decides whether to re-issue
+     `/merge` or restart the supervisor for that pair.
+
+The `/merge` slash command parser already exists on `develop` (W3 #14); this ADR records the
+daemon-side wiring choice the merge-modes branch is making.
+
+## Decision
+
+### 1. Merge runs through one shared step, regardless of entry point.
+
+`runMergeStep(task, mode)` is the single function that:
+
+- Validates `task.prNumber` is present.
+- Refuses to call the GitHub API with `mode === "manual"` (defensive — only `squash` / `rebase` are
+  valid `merge_method` values).
+- Calls `GitHubClient.mergePullRequest(repo, prNumber, mode)`.
+- Classifies any thrown error via `classifyMergeError()`.
+- Performs cleanup per `preserveWorktreeOnMerge`.
+
+Both the auto-merge path (the FSM's `READY_TO_MERGE` driver) and the manual-merge path
+(`mergeReadyTask`, wired to `/merge`) call into `runMergeStep`. This guarantees identical behaviour
+for cleanup, event-bus emission, and failure classification regardless of which trigger started the
+merge.
+
+### 2. Failure classification is keyed on HTTP status, not error message text.
+
+`classifyMergeError(error)` extracts the `status` field from the thrown error (matching
+`@octokit/request-error`'s shape) and:
+
+- Treats `405` and `409` as **`not-mergeable`** → escalates to `NEEDS_HUMAN`. The constant
+  `MERGE_NOT_MERGEABLE_HTTP_STATUSES = [405, 409]` is exported so unit tests assert against the same
+  source of truth as production.
+- Treats every other error (no status, 4xx other than the above, 5xx) as **`transient`** → escalates
+  to `FAILED`.
+
+We chose status-based classification rather than parsing GitHub's free- text response messages
+because:
+
+- GitHub localises and rephrases error messages without notice; a string match is fragile.
+- The `405` response for "Pull Request is not mergeable" is a long-standing API contract documented
+  under the [merge a PR endpoint](https://docs.github.com/en/rest/pulls/pulls#merge-a-pull-request).
+- The classifier is open for extension: future statuses (e.g. a future `412 Precondition Failed` for
+  stricter base-branch checks) flip a single constant rather than a regex.
+
+### 3. `mergeReadyTask` is the synchronous-failure entry point for `/merge`.
+
+The slash-command dispatcher needs to reject misuse with a precise
+`ack { ok: false, error: "..." }`. Two cases must be distinguished before any state transition is
+attempted:
+
+- **Unknown task id** — `kind: "unknown-task"`.
+- **Task is not at `READY_TO_MERGE`** — `kind: "not-ready-to-merge"`.
+
+Both cases throw a `SupervisorError` carrying a `kind` discriminator the daemon's command handler
+reads. FSM-internal failures (the merge itself faulting after the task ID and state are valid) do
+**not** throw — they land the task in `MERGED`, `NEEDS_HUMAN`, or `FAILED` and the handler reports
+the resulting state in the `ack`.
+
+### 4. `manual` substitutes `squash` when reaching the GitHub API.
+
+GitHub's `merge_method` accepts `merge`, `squash`, `rebase` only — `manual` is a makina-side concept
+meaning "wait for /merge". When `mergeReadyTask` fires for a task whose own `mergeMode` is `manual`,
+the supervisor substitutes `"squash"` as the API strategy unless the caller passes `overrideMode`.
+Operators can request a specific strategy by extending `/merge <task-id>` with a future flag (out of
+scope for this ADR); the supervisor surface already accepts the override.
+
+### 5. Cleanup failures never unwind the merge.
+
+`MERGED` is the durable success transition. If `removeWorktree` rejects after a successful API merge
+(e.g. the workspace is read-only), the supervisor logs a warning and leaves the task at `MERGED`.
+The worktree path is recoverable via `task.worktreePath` for manual cleanup; reverting the FSM to a
+non-terminal state would lie about what happened on GitHub's side.
+
+## Consequences
+
+- The merge step has a single error budget: every observable failure becomes a deterministic FSM
+  transition with a specific `terminalReason` prefix (`"merged"` / `"merge (not-mergeable): …"` /
+  `"merge: …"`). Operators can grep on those.
+- `mergeReadyTask` is exported on `TaskSupervisorImpl` but **not** on the W1 `TaskSupervisor`
+  contract — the daemon command dispatcher imports the wider implementation interface, while
+  consumers that only need the cross-wave surface (TUI, persistence) stay decoupled.
+- Adding a new "non-mergeable" HTTP status is a one-line change in
+  `MERGE_NOT_MERGEABLE_HTTP_STATUSES`. No FSM logic moves.
+- The `/merge` command's daemon wiring lives in the test fixture for this branch only; a follow-up
+  wave that constructs the supervisor inside `main.ts daemon` is responsible for promoting the
+  wiring to production. The classifier and the supervisor surface are the load-bearing contracts
+  that survive that wiring change.

--- a/docs/adrs/021-merge-modes-failure-classification.md
+++ b/docs/adrs/021-merge-modes-failure-classification.md
@@ -1,4 +1,4 @@
-# ADR-018 — Merge-mode failure classification and `/merge` re-entry surface
+# ADR-021 — Merge-mode failure classification and `/merge` re-entry surface
 
 ## Status
 

--- a/docs/adrs/021-merge-modes-failure-classification.md
+++ b/docs/adrs/021-merge-modes-failure-classification.md
@@ -66,24 +66,33 @@ because:
 ### 3. `mergeReadyTask` is the synchronous-failure entry point for `/merge`.
 
 The slash-command dispatcher needs to reject misuse with a precise
-`ack { ok: false, error: "..." }`. Two cases must be distinguished before any state transition is
+`ack { ok: false, error: "..." }`. Four cases must be distinguished before any state transition is
 attempted:
 
 - **Unknown task id** — `kind: "unknown-task"`.
 - **Task is not at `READY_TO_MERGE`** — `kind: "not-ready-to-merge"`.
+- **Concurrent `/merge` for the same task** — `kind: "merge-in-flight"`.
+- **Caller passed `overrideMode === "manual"`** — `kind: "merge-precondition"`. `manual` is not a
+  GitHub merge strategy; rejecting it at the entry point keeps a caller bug from landing the task in
+  `FAILED` via `runMergeStep`'s defensive check.
 
-Both cases throw a `SupervisorError` carrying a `kind` discriminator the daemon's command handler
-reads. FSM-internal failures (the merge itself faulting after the task ID and state are valid) do
-**not** throw — they land the task in `MERGED`, `NEEDS_HUMAN`, or `FAILED` and the handler reports
-the resulting state in the `ack`.
+All four cases throw a `SupervisorError` carrying a `kind` discriminator the daemon's command
+handler reads. FSM-internal failures (the merge itself faulting after the preconditions pass) do
+**not** throw — they land the task in `MERGED`, `NEEDS_HUMAN`, or `FAILED`. The handler inspects the
+returned task: `MERGED` becomes `ack { ok: true }`; `NEEDS_HUMAN` and `FAILED` become
+`ack { ok: false, error: "...final state: <STATE>: <terminalReason>" }` so clients can distinguish
+"merged" from "escalate-to-human" via the ack alone (in addition to the `state-changed` event
+stream).
 
 ### 4. `manual` substitutes `squash` when reaching the GitHub API.
 
 GitHub's `merge_method` accepts `merge`, `squash`, `rebase` only — `manual` is a makina-side concept
 meaning "wait for /merge". When `mergeReadyTask` fires for a task whose own `mergeMode` is `manual`,
 the supervisor substitutes `"squash"` as the API strategy unless the caller passes `overrideMode`.
-Operators can request a specific strategy by extending `/merge <task-id>` with a future flag (out of
-scope for this ADR); the supervisor surface already accepts the override.
+The override itself is constrained: passing `overrideMode === "manual"` is rejected synchronously
+(see §3) since substituting `manual` for `manual` would be a no-op tautology. Operators can request
+a specific strategy by extending `/merge <task-id>` with a future flag (out of scope for this ADR);
+the supervisor surface already accepts the override.
 
 ### 5. Cleanup failures never unwind the merge.
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -38,5 +38,19 @@ only when none of the phases needs to do work AND a configurable settling window
 
 ## Merge
 
-When `mergeMode` is `squash` or `rebase`, the supervisor performs the merge via the GitHub API once
-stable. `manual` stops at `READY_TO_MERGE` and waits for `/merge`.
+Once a task reaches `READY_TO_MERGE`, the supervisor branches on `mergeMode`:
+
+- `squash` and `rebase` auto-merge through `GitHubClient.mergePullRequest`. On success the task
+  lands in `MERGED`. On failure, [ADR-018](adrs/018-merge-modes-failure-classification.md)
+  classifies the error: HTTP `405` / `409` from the merge endpoint mean the PR is genuinely not
+  mergeable (conflicts, base-branch protection, stale head SHA) and escalate the task to
+  `NEEDS_HUMAN`; every other failure is transient and lands the task in `FAILED`.
+- `manual` parks at `READY_TO_MERGE` without calling the GitHub API. An operator unblocks the task
+  by issuing `/merge <task-id>` from the TUI; the daemon dispatches into the supervisor's
+  `mergeReadyTask` entry point, which re-uses the same merge step (so failure classification and
+  cleanup behave identically). `/merge` rejects with a precise `ack { ok: false, error }` if the
+  target task is unknown or not currently at `READY_TO_MERGE`.
+
+After a successful merge, the worktree is removed via `WorktreeManager.removeWorktree` unless
+`lifecycle.preserveWorktreeOnMerge` is true. Cleanup failures are logged but never unwind the
+`MERGED` transition — `MERGED` is the durable success state.

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -41,7 +41,7 @@ only when none of the phases needs to do work AND a configurable settling window
 Once a task reaches `READY_TO_MERGE`, the supervisor branches on `mergeMode`:
 
 - `squash` and `rebase` auto-merge through `GitHubClient.mergePullRequest`. On success the task
-  lands in `MERGED`. On failure, [ADR-018](adrs/018-merge-modes-failure-classification.md)
+  lands in `MERGED`. On failure, [ADR-021](adrs/021-merge-modes-failure-classification.md)
   classifies the error: HTTP `405` / `409` from the merge endpoint mean the PR is genuinely not
   mergeable (conflicts, base-branch protection, stale head SHA) and escalate the task to
   `NEEDS_HUMAN`; every other failure is transient and lands the task in `FAILED`.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -422,3 +422,29 @@ export const HOURS_PER_DAY = 24;
  * dominant content of the open palette.
  */
 export const COMMAND_PALETTE_SUGGESTION_WIDTH_CODE_UNITS = 160;
+
+/**
+ * HTTP `405 Method Not Allowed` — the response GitHub returns from the
+ * [merge a PR endpoint](https://docs.github.com/en/rest/pulls/pulls#merge-a-pull-request)
+ * when the pull request is not in a mergeable state (conflicts, missing
+ * reviews on a protected branch, stale head SHA, etc.).
+ *
+ * The supervisor's `classifyMergeError` keys off this status to escalate
+ * the task to `NEEDS_HUMAN`. Centralised here so neither the source
+ * module nor its unit tests carry the bare numeric literal.
+ *
+ * See {@link https://github.com/koraytaylan/makina/blob/develop/docs/adrs/021-merge-modes-failure-classification.md ADR-021}.
+ */
+export const HTTP_STATUS_METHOD_NOT_ALLOWED = 405;
+
+/**
+ * HTTP `409 Conflict` — returned by GitHub's merge endpoint when the
+ * caller passed a `sha` that no longer matches the PR's head (a fresh
+ * commit landed between read and merge). Treated the same as `405` by
+ * the supervisor: the task escalates to `NEEDS_HUMAN` because the
+ * underlying state needs an operator's eyes before another merge
+ * attempt.
+ *
+ * See {@link https://github.com/koraytaylan/makina/blob/develop/docs/adrs/021-merge-modes-failure-classification.md ADR-021}.
+ */
+export const HTTP_STATUS_CONFLICT = 409;

--- a/src/daemon/supervisor.ts
+++ b/src/daemon/supervisor.ts
@@ -57,6 +57,8 @@ import { getLogger } from "@std/log";
 import {
   HEX_BYTE_WIDTH_CHARACTERS,
   HEX_RADIX,
+  HTTP_STATUS_CONFLICT,
+  HTTP_STATUS_METHOD_NOT_ALLOWED,
   TASK_ID_RANDOM_SUFFIX_BYTES,
   TASK_ID_RANDOM_SUFFIX_LENGTH_CHARACTERS,
 } from "../constants.ts";
@@ -324,6 +326,10 @@ export interface TaskSupervisorImpl {
  *   supervisor does not own.
  * - `not-ready-to-merge` — `mergeReadyTask()` was called for a task
  *   not currently in `READY_TO_MERGE`.
+ * - `merge-in-flight` — `mergeReadyTask()` was called concurrently for
+ *   the same task id; an earlier invocation is still mid-flight on the
+ *   GitHub merge call, so the second request is rejected synchronously
+ *   instead of issuing a duplicate `mergePullRequest`.
  * - `persistence` — the initial `start()` save failed (no record on
  *   disk; in-memory entry rolled back so callers can retry).
  */
@@ -331,6 +337,7 @@ export type SupervisorErrorKind =
   | "duplicate-start"
   | "unknown-task"
   | "not-ready-to-merge"
+  | "merge-in-flight"
   | "persistence";
 
 /**
@@ -490,6 +497,25 @@ export function createTaskSupervisor(opts: TaskSupervisorOptions): TaskSuperviso
    * inspect mid-flight transitions.
    */
   const tasks = new Map<TaskId, Task>();
+
+  /**
+   * Set of task ids whose `mergeReadyTask()` invocation is currently
+   * mid-flight on the GitHub merge call. Acts as an in-memory mutex:
+   * the second concurrent `/merge <task-id>` for the same task fails
+   * fast with `SupervisorErrorKind.merge-in-flight` instead of racing
+   * the first call into a duplicate `mergePullRequest` request.
+   *
+   * The guard is process-local (a daemon restart clears it) and lives
+   * alongside the `READY_TO_MERGE` state check inside `mergeReadyTask`:
+   * the state check guarantees that only `READY_TO_MERGE` tasks reach
+   * the GitHub call, but two callers can both pass that check before
+   * either persists a terminal transition. The mid-flight set closes
+   * the gap between "state check accepted" and "transition persisted".
+   *
+   * Cleared in a `finally` so a thrown classifier (or any other
+   * unexpected exception) cannot strand the task forever.
+   */
+  const mergeInFlight = new Set<TaskId>();
 
   /**
    * Run `mutate(prev)` to produce the next task record, persist it,
@@ -993,6 +1019,14 @@ export function createTaskSupervisor(opts: TaskSupervisorOptions): TaskSuperviso
    * a precise error), then re-uses {@link runMergeStep} to share the
    * GitHub call, classification, and cleanup behaviour with the
    * auto-merge path.
+   *
+   * Concurrent invocations for the same task id are guarded by the
+   * {@link mergeInFlight} set: the first caller registers the id
+   * synchronously after the state check passes; any second caller that
+   * arrives before the first persists its terminal transition fails
+   * fast with `SupervisorErrorKind.merge-in-flight`. The guard is
+   * cleared in a `finally` so an unexpected exception inside
+   * `runMergeStep` cannot strand the id.
    */
   async function mergeReadyTask(
     taskId: TaskId,
@@ -1011,15 +1045,31 @@ export function createTaskSupervisor(opts: TaskSupervisorOptions): TaskSuperviso
         `task ${taskId} is not at READY_TO_MERGE (current state: ${task.state})`,
       );
     }
-    // The task's recorded `mergeMode` may be `manual` (the typical
-    // case for `/merge`) or one of the auto modes (rare: an operator
-    // can issue `/merge` to force-finish a parked auto-merge task
-    // that was paused mid-flight by daemon restart). Either way, the
-    // GitHub API needs a concrete strategy: `manual` falls back to
-    // `squash` unless the caller overrode it.
-    const mode: MergeMode = overrideMode ??
-      (task.mergeMode === "manual" ? "squash" : task.mergeMode);
-    return await runMergeStep(task, mode);
+    if (mergeInFlight.has(taskId)) {
+      throw new SupervisorError(
+        "merge-in-flight",
+        `task ${taskId} already has a /merge in flight; refusing duplicate`,
+      );
+    }
+    // Register before the first `await` so a concurrent caller that
+    // arrives during the same microtask sees the in-flight marker. The
+    // `READY_TO_MERGE` check above and this `add` form a synchronous
+    // pair: only one caller can transition from "state check passed"
+    // to "marker registered" before yielding the event loop.
+    mergeInFlight.add(taskId);
+    try {
+      // The task's recorded `mergeMode` may be `manual` (the typical
+      // case for `/merge`) or one of the auto modes (rare: an operator
+      // can issue `/merge` to force-finish a parked auto-merge task
+      // that was paused mid-flight by daemon restart). Either way, the
+      // GitHub API needs a concrete strategy: `manual` falls back to
+      // `squash` unless the caller overrode it.
+      const mode: MergeMode = overrideMode ??
+        (task.mergeMode === "manual" ? "squash" : task.mergeMode);
+      return await runMergeStep(task, mode);
+    } finally {
+      mergeInFlight.delete(taskId);
+    }
   }
 
   return {
@@ -1149,18 +1199,22 @@ function isTerminal(state: TaskState): boolean {
  * Per GitHub's [merge a PR](https://docs.github.com/en/rest/pulls/pulls#merge-a-pull-request)
  * semantics:
  *
- * - `405 Method Not Allowed` — the response GitHub sends for "Pull
- *   Request is not mergeable" (conflicts, missing reviews on a
- *   protected branch, etc.).
- * - `409 Conflict` — head SHA mismatch when the caller passed
- *   `sha`; treated the same way because the underlying state requires
- *   a fresh PR view to resolve.
+ * - {@link HTTP_STATUS_METHOD_NOT_ALLOWED} — the response GitHub sends
+ *   for "Pull Request is not mergeable" (conflicts, missing reviews on
+ *   a protected branch, etc.).
+ * - {@link HTTP_STATUS_CONFLICT} — head SHA mismatch when the caller
+ *   passed `sha`; treated the same way because the underlying state
+ *   requires a fresh PR view to resolve.
  *
  * Centralised here (rather than inlined into a string match) so the
  * unit tests assert against the same constant the production path
- * keys off.
+ * keys off. The numeric values themselves live in `src/constants.ts`
+ * per the bare-literal rule documented at the top of that file.
  */
-export const MERGE_NOT_MERGEABLE_HTTP_STATUSES: readonly number[] = [405, 409];
+export const MERGE_NOT_MERGEABLE_HTTP_STATUSES: readonly number[] = [
+  HTTP_STATUS_METHOD_NOT_ALLOWED,
+  HTTP_STATUS_CONFLICT,
+];
 
 /**
  * Classify a thrown error from `mergePullRequest` into a

--- a/src/daemon/supervisor.ts
+++ b/src/daemon/supervisor.ts
@@ -303,10 +303,20 @@ export interface TaskSupervisorImpl {
    *   otherwise.
    * @returns The persisted task record after the merge attempt
    *   (`MERGED`, `NEEDS_HUMAN`, or `FAILED`).
-   * @throws SupervisorError when the task does not exist, or its
-   *   current state is not `READY_TO_MERGE`. The thrown error carries
-   *   a `kind` discriminator so the daemon's command dispatcher can
-   *   reply with a precise `ack { ok: false, error }`.
+   * @throws SupervisorError synchronously when the call cannot reach
+   *   the FSM transition. Thrown kinds:
+   *   - `unknown-task` — no task exists for the given id.
+   *   - `not-ready-to-merge` — the task is not at `READY_TO_MERGE`.
+   *   - `merge-in-flight` — a prior `/merge` for the same task is
+   *     still mid-flight on the GitHub merge call.
+   *   - `merge-precondition` — `overrideMode === "manual"`, which is
+   *     not a GitHub merge strategy.
+   *
+   *   Each error carries a `kind` discriminator so the daemon's
+   *   command dispatcher can reply with a precise
+   *   `ack { ok: false, error }`. FSM-internal failures (the merge
+   *   itself faulting after preconditions pass) do **not** throw —
+   *   they land the task in `MERGED`, `NEEDS_HUMAN`, or `FAILED`.
    */
   mergeReadyTask(
     taskId: TaskId,
@@ -330,6 +340,11 @@ export interface TaskSupervisorImpl {
  *   the same task id; an earlier invocation is still mid-flight on the
  *   GitHub merge call, so the second request is rejected synchronously
  *   instead of issuing a duplicate `mergePullRequest`.
+ * - `merge-precondition` — `mergeReadyTask()` was called with an
+ *   `overrideMode` that is not a valid GitHub merge strategy
+ *   (currently only `"manual"`, which is a makina-side concept meaning
+ *   "wait for /merge"). Rejected synchronously so a caller bug cannot
+ *   land the task in `FAILED` via `runMergeStep`'s defensive check.
  * - `persistence` — the initial `start()` save failed (no record on
  *   disk; in-memory entry rolled back so callers can retry).
  */
@@ -338,6 +353,7 @@ export type SupervisorErrorKind =
   | "unknown-task"
   | "not-ready-to-merge"
   | "merge-in-flight"
+  | "merge-precondition"
   | "persistence";
 
 /**
@@ -1032,6 +1048,18 @@ export function createTaskSupervisor(opts: TaskSupervisorOptions): TaskSuperviso
     taskId: TaskId,
     overrideMode?: MergeMode,
   ): Promise<Task> {
+    if (overrideMode === "manual") {
+      // `manual` is not a GitHub merge_method (`merge_method` accepts
+      // `merge` / `squash` / `rebase` only). Reject at the entry point
+      // so a caller bug never reaches `runMergeStep`'s defensive check
+      // — that path lands the task in `FAILED`, which would be a
+      // misleading terminal state for what is purely a misuse of the
+      // public API.
+      throw new SupervisorError(
+        "merge-precondition",
+        '/merge overrideMode "manual" is not a GitHub merge strategy; pass "squash" or "rebase"',
+      );
+    }
     const task = tasks.get(taskId);
     if (task === undefined) {
       throw new SupervisorError(

--- a/src/daemon/supervisor.ts
+++ b/src/daemon/supervisor.ts
@@ -193,6 +193,16 @@ export interface TaskSupervisorOptions {
    * `crypto.getRandomValues`.
    */
   readonly randomSource?: SupervisorRandomSource;
+  /**
+   * If `true`, the supervisor leaves the per-task worktree on disk
+   * after `MERGED`; if `false`, it tears the worktree down via
+   * {@link WorktreeManagerImpl.removeWorktree} as the final step of
+   * the merge pipeline. Mirrors `lifecycle.preserveWorktreeOnMerge`
+   * from `config.json`. Defaults to `false` so a fresh `makina setup`
+   * leaves disk usage bounded; operators who want to keep the
+   * worktree for follow-up flip the bit in their config.
+   */
+  readonly preserveWorktreeOnMerge?: boolean;
 }
 
 /**
@@ -268,14 +278,67 @@ export interface TaskSupervisorImpl {
    *   with that id exists.
    */
   getTask(taskId: TaskId): Task | undefined;
+
+  /**
+   * Force the merge of a task currently parked at `READY_TO_MERGE`.
+   *
+   * Wired to the `/merge <task-id>` slash command for tasks configured
+   * with `mergeMode === "manual"` (the only mode that parks rather
+   * than auto-merging once stabilize settles). Re-enters the FSM at
+   * `READY_TO_MERGE` and runs the same merge → cleanup pipeline as the
+   * auto-merge path: GitHub `mergePullRequest` is invoked with the
+   * task's recorded mode (overridden internally to `squash`/`rebase`
+   * — the supervisor refuses to call the API with `manual`, since
+   * GitHub has no equivalent strategy), the worktree is cleaned up
+   * (or preserved per `preserveWorktreeOnMerge`), and the task lands
+   * in `MERGED`. Failures classify the same way as the auto-merge
+   * path (see {@link MergeError.category}).
+   *
+   * @param taskId Identifier of the task to merge.
+   * @param overrideMode Optional override of the merge strategy for
+   *   this single call. Defaults to `"squash"` when the task itself
+   *   carries `manual` (the API needs a concrete strategy); ignored
+   *   otherwise.
+   * @returns The persisted task record after the merge attempt
+   *   (`MERGED`, `NEEDS_HUMAN`, or `FAILED`).
+   * @throws SupervisorError when the task does not exist, or its
+   *   current state is not `READY_TO_MERGE`. The thrown error carries
+   *   a `kind` discriminator so the daemon's command dispatcher can
+   *   reply with a precise `ack { ok: false, error }`.
+   */
+  mergeReadyTask(
+    taskId: TaskId,
+    overrideMode?: MergeMode,
+  ): Promise<Task>;
 }
+
+/**
+ * Categories of caller-visible failures the supervisor surfaces
+ * synchronously through {@link SupervisorError}. The daemon's command
+ * dispatcher reads the `kind` to map an exception onto a precise
+ * `ack { ok: false, error }`:
+ *
+ * - `duplicate-start` — `start()` was called for a `(repo, issue)`
+ *   pair already in flight.
+ * - `unknown-task` — `mergeReadyTask()` was passed a task id the
+ *   supervisor does not own.
+ * - `not-ready-to-merge` — `mergeReadyTask()` was called for a task
+ *   not currently in `READY_TO_MERGE`.
+ * - `persistence` — the initial `start()` save failed (no record on
+ *   disk; in-memory entry rolled back so callers can retry).
+ */
+export type SupervisorErrorKind =
+  | "duplicate-start"
+  | "unknown-task"
+  | "not-ready-to-merge"
+  | "persistence";
 
 /**
  * Domain error class thrown by the supervisor for caller-visible
  * failures (double-start, unknown task, brand violation). FSM-internal
  * failures (worktree creation, PR open, merge) are *not* thrown — they
- * land the task in `FAILED` and the caller observes the terminal
- * record's `terminalReason`.
+ * land the task in `FAILED` (or `NEEDS_HUMAN` for non-mergeable PRs)
+ * and the caller observes the terminal record's `terminalReason`.
  *
  * The class wraps the underlying exception via `cause` so log readers
  * can recover the original stack.
@@ -293,22 +356,91 @@ export interface TaskSupervisorImpl {
  * }
  * ```
  *
- * @throws by {@link TaskSupervisorImpl.start} when the FSM rejects the
+ * @throws by {@link TaskSupervisorImpl.start} and
+ *   {@link TaskSupervisorImpl.mergeReadyTask} when the FSM rejects the
  *   call before any state transition is persisted.
  */
 export class SupervisorError extends Error {
   /** Discriminator visible in stack traces and `error.name === ...` checks. */
   override readonly name = "SupervisorError";
+  /** Category tag — the daemon's `/merge` dispatcher reads this. */
+  readonly kind: SupervisorErrorKind;
 
   /**
    * Build a supervisor error.
    *
+   * @param kind Failure category (see {@link SupervisorErrorKind}).
    * @param message Human-readable description.
    * @param options Optional standard `cause` carrying the underlying
    *   exception.
    */
-  constructor(message: string, options?: { readonly cause?: unknown }) {
+  constructor(
+    kind: SupervisorErrorKind,
+    message: string,
+    options?: { readonly cause?: unknown },
+  ) {
     super(message, options);
+    this.kind = kind;
+  }
+}
+
+/**
+ * Categories of {@link MergeError} the supervisor produces during
+ * `READY_TO_MERGE → MERGED`. Mapped onto a destination FSM state by
+ * {@link mergeErrorTerminalState}:
+ *
+ * - `not-mergeable` — GitHub refused the merge because the PR was
+ *   not in a mergeable state (HTTP `405`, conflicts, base protection,
+ *   stale head SHA). The supervisor escalates to `NEEDS_HUMAN` so an
+ *   operator can investigate without losing the PR.
+ * - `transient` — a 5xx, network glitch, or other category-unaware
+ *   failure. The supervisor lands the task in `FAILED` so a follow-up
+ *   `start()` (or, for manual mode, a follow-up `/merge`) can retry.
+ */
+export type MergeErrorCategory = "not-mergeable" | "transient";
+
+/**
+ * Domain error wrapping a `mergePullRequest` failure with a
+ * caller-visible `category` so the supervisor can decide whether to
+ * escalate the task to `NEEDS_HUMAN` (the PR is genuinely
+ * non-mergeable: conflicts, base-branch protection, stale head) or
+ * `FAILED` (the API call faulted for a transient reason).
+ *
+ * The class never escapes the supervisor — it is constructed inside
+ * the merge step and consumed by the FSM transition. Tests inspect the
+ * resulting `terminalReason` rather than this class directly.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await client.mergePullRequest(repo, prNumber, "squash");
+ * } catch (error) {
+ *   throw classifyMergeError(error);
+ * }
+ * ```
+ */
+export class MergeError extends Error {
+  /** Discriminator visible in stack traces and `error.name === ...` checks. */
+  override readonly name = "MergeError";
+  /** Category tag — drives the FSM destination state. */
+  readonly category: MergeErrorCategory;
+
+  /**
+   * Build a merge error.
+   *
+   * @param category Whether the failure is the PR being non-mergeable
+   *   (operator action required) or a transient API fault.
+   * @param message Human-readable description.
+   * @param options Optional standard `cause` carrying the underlying
+   *   GitHub-client exception.
+   */
+  constructor(
+    category: MergeErrorCategory,
+    message: string,
+    options?: { readonly cause?: unknown },
+  ) {
+    super(message, options);
+    this.category = category;
   }
 }
 
@@ -348,6 +480,7 @@ export function createTaskSupervisor(opts: TaskSupervisorOptions): TaskSuperviso
   const random: SupervisorRandomSource = opts.randomSource ?? defaultRandomSource();
   const cloneUrlFor = opts.cloneUrlFor ??
     ((repo: RepoFullName) => `https://github.com/${repo}.git`);
+  const preserveWorktreeOnMerge: boolean = opts.preserveWorktreeOnMerge ?? false;
 
   /**
    * In-memory task table. Wave 3's daemon hydrates this on boot via
@@ -433,6 +566,7 @@ export function createTaskSupervisor(opts: TaskSupervisorOptions): TaskSuperviso
       // pair is not blocked by a phantom entry.
       tasks.delete(taskId);
       throw new SupervisorError(
+        "persistence",
         `failed to persist initial task record for ${args.repo}#${args.issueNumber}`,
         { cause: saveError },
       );
@@ -679,13 +813,59 @@ export function createTaskSupervisor(opts: TaskSupervisorOptions): TaskSuperviso
     );
   }
 
+  /**
+   * Side effect for `READY_TO_MERGE`. Three branches:
+   *
+   *  - **`manual`** parks the FSM at `READY_TO_MERGE` without calling
+   *    `mergePullRequest`. The auto-driver loop in {@link drive}
+   *    returns the task; the operator unblocks it later through
+   *    {@link mergeReadyTask} (wired to the `/merge <task-id>`
+   *    slash command).
+   *  - **`squash` / `rebase`** call the GitHub API straight through
+   *    {@link runMergeStep}.
+   *
+   * Any failure path inside `runMergeStep` is absorbed into a
+   * persisted `MERGED | NEEDS_HUMAN | FAILED` transition; this helper
+   * never throws.
+   */
   async function runReadyToMerge(task: Task): Promise<Task> {
     if (task.mergeMode === "manual") {
-      // Manual merge mode: stay in READY_TO_MERGE; an operator takes
-      // over from the GitHub UI. The integration test exercises
-      // `squash`, but the manual branch keeps the FSM honest.
+      // Park the task; an operator takes over by issuing
+      // `/merge <task-id>`. The driver loop in `drive()` returns this
+      // task as-is, leaving the in-memory + persistence record at
+      // `READY_TO_MERGE`. We do **not** publish a "parked" event —
+      // the `READY_TO_MERGE` state-changed event already published by
+      // the stabilize loop's exit covers the observer's needs.
       return task;
     }
+    return await runMergeStep(task, task.mergeMode);
+  }
+
+  /**
+   * Perform the merge-then-cleanup pipeline for a task at
+   * `READY_TO_MERGE`. The flow is:
+   *
+   *   1. Validate the precondition (`prNumber !== undefined`).
+   *   2. Call `mergePullRequest(repo, prNumber, mode)`.
+   *   3. Classify any failure via {@link classifyMergeError} and
+   *      escalate to `NEEDS_HUMAN` (non-mergeable PR) or `FAILED`
+   *      (transient API fault).
+   *   4. On success, optionally tear down the worktree per
+   *      `preserveWorktreeOnMerge` and persist `MERGED`.
+   *
+   * Used both from {@link runReadyToMerge} (auto-merge) and from
+   * {@link mergeReadyTask} (the `/merge` slash command) so the two
+   * paths share identical error handling and cleanup behaviour.
+   *
+   * @param task The READY_TO_MERGE task record.
+   * @param mode The merge strategy to use. Callers pass the task's
+   *   own `mergeMode` for auto-merge; the manual-merge entry point
+   *   substitutes a concrete strategy when the task itself was
+   *   configured with `manual`.
+   * @returns The persisted post-merge record (`MERGED`,
+   *   `NEEDS_HUMAN`, or `FAILED`).
+   */
+  async function runMergeStep(task: Task, mode: MergeMode): Promise<Task> {
     if (task.prNumber === undefined) {
       return await fail(
         task,
@@ -693,22 +873,95 @@ export function createTaskSupervisor(opts: TaskSupervisorOptions): TaskSuperviso
         "merge-precondition",
       );
     }
+    if (mode === "manual") {
+      // Defensive: `manual` is not a GitHub merge_method; the caller
+      // (mergeReadyTask) already substitutes a concrete mode before
+      // reaching here. Treat any leak as a programming error rather
+      // than a silent escalation.
+      return await fail(
+        task,
+        new Error('runMergeStep called with mode="manual"; expected squash or rebase'),
+        "merge-precondition",
+      );
+    }
     try {
-      await opts.githubClient.mergePullRequest(
-        task.repo,
-        task.prNumber,
-        task.mergeMode,
+      await opts.githubClient.mergePullRequest(task.repo, task.prNumber, mode);
+    } catch (error) {
+      const merge = classifyMergeError(error);
+      logger.warn(
+        `supervisor: mergePullRequest failed for task ${task.id} (${merge.category}): ${merge.message}`,
+      );
+      if (merge.category === "not-mergeable") {
+        return await escalateToHuman(task, merge);
+      }
+      return await fail(task, merge, "merge");
+    }
+    const merged = await transition(
+      task,
+      { state: "MERGED", terminalReason: "merged" },
+      `PR merged (${mode})`,
+    );
+    await maybeCleanupWorktree(merged);
+    return merged;
+  }
+
+  /**
+   * Tear down the per-task worktree after a successful merge unless
+   * `preserveWorktreeOnMerge` is set. Cleanup failures are logged but
+   * never re-thrown — the merge is the load-bearing transition; a
+   * stuck worktree is recoverable manually and the FSM has already
+   * persisted `MERGED`.
+   *
+   * Logs a single info line either way so an operator scanning logs
+   * sees what happened to the worktree without grepping multiple
+   * sources.
+   */
+  async function maybeCleanupWorktree(task: Task): Promise<void> {
+    const worktreePath = task.worktreePath;
+    if (worktreePath === undefined) {
+      return;
+    }
+    if (preserveWorktreeOnMerge) {
+      logger.info(
+        `supervisor: preserving worktree for task ${task.id} at ${worktreePath}`,
+      );
+      return;
+    }
+    try {
+      await opts.worktreeManager.removeWorktree(task.id);
+      logger.info(
+        `supervisor: removed worktree for task ${task.id} at ${worktreePath}`,
       );
     } catch (error) {
       logger.warn(
-        `supervisor: mergePullRequest failed for task ${task.id}: ${errorMessage(error)}`,
+        `supervisor: removeWorktree failed for task ${task.id} at ${worktreePath}: ${
+          errorMessage(error)
+        }`,
       );
-      return await fail(task, error, "merge");
     }
+  }
+
+  /**
+   * Drive `task` to `NEEDS_HUMAN`, recording the merge error on
+   * `terminalReason` and the bus's `error` event. Reserved for
+   * non-mergeable PRs — i.e. cases an operator must look at (the
+   * code is not at fault but the PR cannot be merged automatically:
+   * conflicts, base-branch protection, stale head SHA).
+   */
+  async function escalateToHuman(task: Task, error: MergeError): Promise<Task> {
+    publish(opts.eventBus, {
+      taskId: task.id,
+      atIso: clock.nowIso(),
+      kind: "error",
+      data: { message: `merge: ${error.message}` },
+    });
     return await transition(
       task,
-      { state: "MERGED", terminalReason: "merged" },
-      "PR merged",
+      {
+        state: "NEEDS_HUMAN",
+        terminalReason: `merge (not-mergeable): ${error.message}`,
+      },
+      "PR not mergeable; escalating to operator",
     );
   }
 
@@ -732,6 +985,43 @@ export function createTaskSupervisor(opts: TaskSupervisorOptions): TaskSuperviso
     );
   }
 
+  /**
+   * Implementation of {@link TaskSupervisorImpl.mergeReadyTask}.
+   *
+   * Validates the task exists and is at `READY_TO_MERGE` synchronously
+   * (so a `/merge` for a `DRAFTING` or `MERGED` task fails fast with
+   * a precise error), then re-uses {@link runMergeStep} to share the
+   * GitHub call, classification, and cleanup behaviour with the
+   * auto-merge path.
+   */
+  async function mergeReadyTask(
+    taskId: TaskId,
+    overrideMode?: MergeMode,
+  ): Promise<Task> {
+    const task = tasks.get(taskId);
+    if (task === undefined) {
+      throw new SupervisorError(
+        "unknown-task",
+        `no task found for id ${taskId}`,
+      );
+    }
+    if (task.state !== "READY_TO_MERGE") {
+      throw new SupervisorError(
+        "not-ready-to-merge",
+        `task ${taskId} is not at READY_TO_MERGE (current state: ${task.state})`,
+      );
+    }
+    // The task's recorded `mergeMode` may be `manual` (the typical
+    // case for `/merge`) or one of the auto modes (rare: an operator
+    // can issue `/merge` to force-finish a parked auto-merge task
+    // that was paused mid-flight by daemon restart). Either way, the
+    // GitHub API needs a concrete strategy: `manual` falls back to
+    // `squash` unless the caller overrode it.
+    const mode: MergeMode = overrideMode ??
+      (task.mergeMode === "manual" ? "squash" : task.mergeMode);
+    return await runMergeStep(task, mode);
+  }
+
   return {
     start,
     listTasks(): readonly Task[] {
@@ -740,6 +1030,7 @@ export function createTaskSupervisor(opts: TaskSupervisorOptions): TaskSuperviso
     getTask(taskId: TaskId): Task | undefined {
       return tasks.get(taskId);
     },
+    mergeReadyTask,
   };
 }
 
@@ -852,6 +1143,82 @@ function isTerminal(state: TaskState): boolean {
 }
 
 /**
+ * HTTP status codes the supervisor treats as "PR is genuinely not
+ * mergeable" — i.e. an operator must look at the PR before merging it.
+ *
+ * Per GitHub's [merge a PR](https://docs.github.com/en/rest/pulls/pulls#merge-a-pull-request)
+ * semantics:
+ *
+ * - `405 Method Not Allowed` — the response GitHub sends for "Pull
+ *   Request is not mergeable" (conflicts, missing reviews on a
+ *   protected branch, etc.).
+ * - `409 Conflict` — head SHA mismatch when the caller passed
+ *   `sha`; treated the same way because the underlying state requires
+ *   a fresh PR view to resolve.
+ *
+ * Centralised here (rather than inlined into a string match) so the
+ * unit tests assert against the same constant the production path
+ * keys off.
+ */
+export const MERGE_NOT_MERGEABLE_HTTP_STATUSES: readonly number[] = [405, 409];
+
+/**
+ * Classify a thrown error from `mergePullRequest` into a
+ * {@link MergeError} carrying a category that drives the FSM
+ * destination state. The classifier inspects:
+ *
+ *  1. Pre-classified `MergeError` instances pass through untouched
+ *     (an already-classified caller wins).
+ *  2. Errors carrying an HTTP `status` (Octokit's `RequestError`
+ *     and similar shapes) get matched against
+ *     {@link MERGE_NOT_MERGEABLE_HTTP_STATUSES}.
+ *  3. Anything else falls back to `transient`.
+ *
+ * Exported alongside the supervisor so unit tests can assert the
+ * mapping directly.
+ *
+ * @param error The raw error thrown by the GitHub client.
+ * @returns A {@link MergeError} ready for FSM consumption.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await client.mergePullRequest(repo, prNumber, "squash");
+ * } catch (error) {
+ *   const merge = classifyMergeError(error);
+ *   if (merge.category === "not-mergeable") escalateToHuman(task, merge);
+ * }
+ * ```
+ */
+export function classifyMergeError(error: unknown): MergeError {
+  if (error instanceof MergeError) {
+    return error;
+  }
+  const status = readHttpStatus(error);
+  const message = errorMessage(error);
+  if (status !== undefined && MERGE_NOT_MERGEABLE_HTTP_STATUSES.includes(status)) {
+    return new MergeError("not-mergeable", message, { cause: error });
+  }
+  return new MergeError("transient", message, { cause: error });
+}
+
+/**
+ * Best-effort extraction of an HTTP status from an error. Mirrors
+ * `src/github/client.ts`'s reader without importing it (keeps the
+ * supervisor decoupled from the concrete client class).
+ */
+function readHttpStatus(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+  const candidate = error as { status?: unknown };
+  if (typeof candidate.status === "number") {
+    return candidate.status;
+  }
+  return undefined;
+}
+
+/**
  * Reject a duplicate {@link TaskSupervisorImpl.start} call for a
  * `(repo, issueNumber)` pair already tracked by a non-terminal task.
  *
@@ -869,6 +1236,7 @@ function rejectDuplicateTask(
     }
     if (!isTerminal(task.state)) {
       throw new SupervisorError(
+        "duplicate-start",
         `task already in flight for ${repo}#${issueNumber} (taskId=${task.id}, state=${task.state})`,
       );
     }

--- a/tests/integration/merge_command_test.ts
+++ b/tests/integration/merge_command_test.ts
@@ -1,0 +1,487 @@
+/**
+ * Integration test for the `/merge <task-id>` slash command, end-to-end
+ * against the daemon server.
+ *
+ * Boots `startDaemon()` on a `Deno.makeTempDir`-backed Unix socket with
+ * a real {@link createTaskSupervisor} (driving an
+ * {@link InMemoryGitHubClient} + {@link MockAgentRunner} +
+ * {@link RecordingWorktreeManager}). A custom `command` handler is wired
+ * in that decodes the `/merge <task-id>` envelope, looks the supervisor
+ * up, and replies with a precise `ack { ok }` per the brief:
+ *
+ *  - `command { name: "merge", args: [taskId] }` → calls
+ *    `supervisor.mergeReadyTask(taskId)` and replies `ack { ok: true }`
+ *    on success.
+ *  - The same call against a task in a non-`READY_TO_MERGE` state
+ *    must reply with `ack { ok: false, error: <descriptive> }`.
+ *  - The same call against an unknown task id must reply with
+ *    `ack { ok: false }`.
+ *
+ * The test connects a real client over `Deno.connect`, sends the
+ * encoded `command` envelope, and asserts the replies.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { join } from "@std/path";
+
+import { decode, encode } from "../../src/ipc/codec.ts";
+import { type AckPayload, type MessageEnvelope } from "../../src/ipc/protocol.ts";
+import {
+  branchNameFor,
+  createTaskSupervisor,
+  DEFAULT_BASE_BRANCH,
+  type SupervisorClock,
+  SupervisorError,
+  type SupervisorRandomSource,
+  type TaskSupervisorImpl,
+} from "../../src/daemon/supervisor.ts";
+import { startDaemon } from "../../src/daemon/server.ts";
+import { createEventBus } from "../../src/daemon/event-bus.ts";
+import { createPersistence } from "../../src/daemon/persistence.ts";
+import {
+  type IssueNumber,
+  makeIssueNumber,
+  makeRepoFullName,
+  makeTaskId,
+  type RepoFullName,
+  type TaskId,
+} from "../../src/types.ts";
+import type { WorktreeManagerImpl } from "../../src/daemon/worktree-manager.ts";
+import { InMemoryGitHubClient } from "../helpers/in_memory_github_client.ts";
+import { MockAgentRunner } from "../helpers/mock_agent_runner.ts";
+
+// ---------------------------------------------------------------------------
+// Test scaffolding
+// ---------------------------------------------------------------------------
+
+class DeterministicClock implements SupervisorClock {
+  private milliseconds = Date.UTC(2026, 3, 26, 12, 0, 0);
+  nowIso(): string {
+    const iso = new Date(this.milliseconds).toISOString();
+    this.milliseconds += 1_000;
+    return iso;
+  }
+}
+
+class FixedRandomSource implements SupervisorRandomSource {
+  fillRandomBytes(bytes: Uint8Array): void {
+    for (let i = 0; i < bytes.length; i += 1) {
+      bytes[i] = (i * 17) & 0xff;
+    }
+  }
+}
+
+class RecordingWorktreeManager implements WorktreeManagerImpl {
+  readonly removed: TaskId[] = [];
+  private readonly registered = new Map<TaskId, string>();
+
+  ensureBareClone(_repo: RepoFullName, _remoteUrl: string): Promise<string> {
+    return Promise.resolve("/tmp/makina-fake/bare.git");
+  }
+  createWorktreeForIssue(
+    _repo: RepoFullName,
+    issueNumber: IssueNumber,
+  ): Promise<string> {
+    return Promise.resolve(`/tmp/makina-fake/wt/issue-${issueNumber}`);
+  }
+  removeWorktree(taskId: TaskId): Promise<void> {
+    this.removed.push(taskId);
+    this.registered.delete(taskId);
+    return Promise.resolve();
+  }
+  pruneAll(): Promise<void> {
+    return Promise.resolve();
+  }
+  registerTaskId(taskId: TaskId, worktreePath: string): void {
+    this.registered.set(taskId, worktreePath);
+  }
+  worktreePathFor(taskId: TaskId): string | undefined {
+    return this.registered.get(taskId);
+  }
+}
+
+/**
+ * Wire a `command` handler that maps `/merge <task-id>` to
+ * `supervisor.mergeReadyTask()`. Production wiring lives in `main.ts`
+ * once the daemon's full command dispatcher lands; this test
+ * encapsulates the same routing so the integration assertion runs
+ * end-to-end against the real socket.
+ *
+ * Other commands (`issue`, `status`, …) are intentionally
+ * unimplemented here — the integration target is the `/merge` path.
+ */
+function buildCommandHandler(supervisor: TaskSupervisorImpl) {
+  return async (
+    envelope: Extract<MessageEnvelope, { type: "command" }>,
+  ): Promise<AckPayload> => {
+    const { name, args } = envelope.payload;
+    if (name !== "merge") {
+      return { ok: false, error: `unsupported command: /${name}` };
+    }
+    const rawTaskId = args[0];
+    if (rawTaskId === undefined) {
+      return { ok: false, error: "/merge requires <task-id>" };
+    }
+    let taskId: TaskId;
+    try {
+      taskId = makeTaskId(rawTaskId);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { ok: false, error: message };
+    }
+    try {
+      const merged = await supervisor.mergeReadyTask(taskId);
+      return { ok: true, error: `merged into ${merged.state}` };
+    } catch (error) {
+      if (error instanceof SupervisorError) {
+        return { ok: false, error: error.message };
+      }
+      throw error;
+    }
+  };
+}
+
+interface MergeCommandRig {
+  readonly socketPath: string;
+  readonly supervisor: TaskSupervisorImpl;
+  readonly githubClient: InMemoryGitHubClient;
+  readonly worktreeManager: RecordingWorktreeManager;
+  readonly agentRunner: MockAgentRunner;
+  readonly repo: RepoFullName;
+  readonly issueNumber: IssueNumber;
+  cleanup(): Promise<void>;
+}
+
+async function makeRig(): Promise<MergeCommandRig> {
+  const dir = await Deno.makeTempDir({ prefix: "makina-merge-cmd-" });
+  const socketPath = join(dir, "sock");
+  const githubClient = new InMemoryGitHubClient();
+  const worktreeManager = new RecordingWorktreeManager();
+  const agentRunner = new MockAgentRunner();
+  const supervisor = createTaskSupervisor({
+    githubClient,
+    worktreeManager,
+    persistence: createPersistence({ path: join(dir, "state.json") }),
+    eventBus: createEventBus(),
+    agentRunner,
+    cloneUrlFor: () => "file:///does-not-matter",
+    clock: new DeterministicClock(),
+    randomSource: new FixedRandomSource(),
+    preserveWorktreeOnMerge: false,
+  });
+  return {
+    socketPath,
+    supervisor,
+    githubClient,
+    worktreeManager,
+    agentRunner,
+    repo: makeRepoFullName("koraytaylan/makina"),
+    issueNumber: makeIssueNumber(7),
+    cleanup: () => Deno.remove(dir, { recursive: true }),
+  };
+}
+
+async function connectClient(socketPath: string) {
+  const conn = await Deno.connect({ transport: "unix", path: socketPath });
+  const writer = conn.writable.getWriter();
+  const reader = (async function* () {
+    for await (const envelope of decode(conn.readable)) {
+      yield envelope;
+    }
+  })();
+  return {
+    send: async (envelope: MessageEnvelope) => {
+      await writer.write(encode(envelope));
+    },
+    next: async (): Promise<MessageEnvelope> => {
+      const result = await reader.next();
+      if (result.done) {
+        throw new Error("connection closed before next envelope");
+      }
+      return result.value;
+    },
+    close: async () => {
+      try {
+        await writer.close();
+      } catch { /* ignore */ }
+      try {
+        conn.close();
+      } catch { /* ignore */ }
+    },
+  };
+}
+
+function scriptParkedTask(rig: MergeCommandRig, prNumber: IssueNumber): void {
+  rig.githubClient.queueGetIssue({
+    kind: "value",
+    value: {
+      number: rig.issueNumber,
+      title: "T",
+      body: "B",
+      state: "open",
+    },
+  });
+  rig.githubClient.queueCreatePullRequest({
+    kind: "value",
+    value: {
+      number: prNumber,
+      headSha: "deadbeef",
+      headRef: branchNameFor(rig.issueNumber),
+      baseRef: DEFAULT_BASE_BRANCH,
+      state: "open",
+    },
+  });
+  rig.githubClient.queueRequestReviewers({ kind: "value", value: undefined });
+  rig.agentRunner.queueRun({
+    messages: [{ role: "assistant", text: "ok" }],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "/merge against a READY_TO_MERGE manual task auto-merges and replies ack { ok: true }",
+  async () => {
+    const rig = await makeRig();
+    try {
+      scriptParkedTask(rig, makeIssueNumber(50));
+      // After /merge: a single mergePullRequest reply.
+      rig.githubClient.queueMergePullRequest({
+        kind: "value",
+        value: undefined,
+      });
+      const parked = await rig.supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "manual",
+      });
+      assertEquals(parked.state, "READY_TO_MERGE");
+
+      const handle = await startDaemon({
+        socketPath: rig.socketPath,
+        handlers: {
+          command: buildCommandHandler(rig.supervisor),
+        },
+      });
+      try {
+        const client = await connectClient(rig.socketPath);
+        try {
+          await client.send({
+            id: "merge-1",
+            type: "command",
+            payload: { name: "merge", args: [parked.id] },
+          });
+          const reply = await client.next();
+          assertEquals(reply.type, "ack");
+          const payload = reply.payload as AckPayload;
+          assertEquals(payload.ok, true);
+        } finally {
+          await client.close();
+        }
+      } finally {
+        await handle.stop();
+      }
+
+      // The supervisor merged the parked task.
+      const finalTask = rig.supervisor.getTask(parked.id);
+      assertEquals(finalTask?.state, "MERGED");
+      const mergeCall = rig.githubClient
+        .recordedCalls()
+        .find((call) => call.method === "mergePullRequest");
+      assert(mergeCall !== undefined);
+      // Worktree was cleaned up.
+      assertEquals(rig.worktreeManager.removed, [parked.id]);
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "/merge against a non-READY_TO_MERGE task replies ack { ok: false } with a clear error",
+  async () => {
+    const rig = await makeRig();
+    try {
+      // Drafting fails so the task lands in FAILED.
+      rig.githubClient.queueGetIssue({
+        kind: "error",
+        error: new Error("404"),
+      });
+      const failed = await rig.supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "manual",
+      });
+      assertEquals(failed.state, "FAILED");
+
+      const handle = await startDaemon({
+        socketPath: rig.socketPath,
+        handlers: {
+          command: buildCommandHandler(rig.supervisor),
+        },
+      });
+      try {
+        const client = await connectClient(rig.socketPath);
+        try {
+          await client.send({
+            id: "merge-bad",
+            type: "command",
+            payload: { name: "merge", args: [failed.id] },
+          });
+          const reply = await client.next();
+          assertEquals(reply.type, "ack");
+          const payload = reply.payload as AckPayload;
+          assertEquals(payload.ok, false);
+          assert(payload.error !== undefined);
+          assert(payload.error.includes("READY_TO_MERGE"));
+          // No GitHub merge call was attempted.
+          assert(
+            !rig.githubClient
+              .recordedCalls()
+              .some((call) => call.method === "mergePullRequest"),
+          );
+        } finally {
+          await client.close();
+        }
+      } finally {
+        await handle.stop();
+      }
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "/merge against an unknown task id replies ack { ok: false }",
+  async () => {
+    const rig = await makeRig();
+    try {
+      const handle = await startDaemon({
+        socketPath: rig.socketPath,
+        handlers: {
+          command: buildCommandHandler(rig.supervisor),
+        },
+      });
+      try {
+        const client = await connectClient(rig.socketPath);
+        try {
+          await client.send({
+            id: "merge-unknown",
+            type: "command",
+            payload: { name: "merge", args: ["task_does_not_exist"] },
+          });
+          const reply = await client.next();
+          assertEquals(reply.type, "ack");
+          const payload = reply.payload as AckPayload;
+          assertEquals(payload.ok, false);
+          assert(payload.error !== undefined);
+          assert(payload.error.includes("no task found"));
+        } finally {
+          await client.close();
+        }
+      } finally {
+        await handle.stop();
+      }
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "/merge with no <task-id> replies ack { ok: false }",
+  async () => {
+    const rig = await makeRig();
+    try {
+      const handle = await startDaemon({
+        socketPath: rig.socketPath,
+        handlers: {
+          command: buildCommandHandler(rig.supervisor),
+        },
+      });
+      try {
+        const client = await connectClient(rig.socketPath);
+        try {
+          await client.send({
+            id: "merge-empty",
+            type: "command",
+            payload: { name: "merge", args: [] },
+          });
+          const reply = await client.next();
+          assertEquals(reply.type, "ack");
+          const payload = reply.payload as AckPayload;
+          assertEquals(payload.ok, false);
+          assert(payload.error !== undefined);
+          assert(payload.error.includes("requires"));
+        } finally {
+          await client.close();
+        }
+      } finally {
+        await handle.stop();
+      }
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "/merge surfaces a NEEDS_HUMAN escalation with a descriptive ack",
+  async () => {
+    const rig = await makeRig();
+    try {
+      scriptParkedTask(rig, makeIssueNumber(70));
+      const notMergeable = new Error("Pull Request is not mergeable") as
+        & Error
+        & { status?: number };
+      notMergeable.status = 405;
+      rig.githubClient.queueMergePullRequest({
+        kind: "error",
+        error: notMergeable,
+      });
+      const parked = await rig.supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "manual",
+      });
+      assertEquals(parked.state, "READY_TO_MERGE");
+
+      const handle = await startDaemon({
+        socketPath: rig.socketPath,
+        handlers: {
+          command: buildCommandHandler(rig.supervisor),
+        },
+      });
+      try {
+        const client = await connectClient(rig.socketPath);
+        try {
+          await client.send({
+            id: "merge-not",
+            type: "command",
+            payload: { name: "merge", args: [parked.id] },
+          });
+          const reply = await client.next();
+          assertEquals(reply.type, "ack");
+          const payload = reply.payload as AckPayload;
+          // The merge step itself ran (the supervisor took ownership),
+          // so the handler reports success — but the task landed in
+          // NEEDS_HUMAN, not MERGED. Both pieces of state are
+          // observable.
+          assertEquals(payload.ok, true);
+        } finally {
+          await client.close();
+        }
+      } finally {
+        await handle.stop();
+      }
+
+      const finalTask = rig.supervisor.getTask(parked.id);
+      assertEquals(finalTask?.state, "NEEDS_HUMAN");
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);

--- a/tests/integration/merge_command_test.ts
+++ b/tests/integration/merge_command_test.ts
@@ -130,13 +130,22 @@ function buildCommandHandler(supervisor: TaskSupervisorImpl) {
       return { ok: false, error: message };
     }
     try {
-      // The merged record is intentionally discarded here: the daemon's
-      // `ack` schema (`AckPayload` in `src/ipc/protocol.ts`) carries
-      // `error` only on failure, so a successful merge returns the bare
-      // `{ ok: true }` and clients observe the resulting state through
-      // the supervisor's `state-changed` event stream instead.
-      await supervisor.mergeReadyTask(taskId);
-      return { ok: true };
+      // Inspect the resulting task: `mergeReadyTask` returns the
+      // post-merge record without throwing for FSM-internal failures
+      // (a non-mergeable PR escalates to `NEEDS_HUMAN`; a transient
+      // API fault lands at `FAILED`). Reporting these as
+      // `{ ok: false, error: ... }` lets the client distinguish
+      // "merged" from "escalated-to-human" via the ack alone, in
+      // addition to the supervisor's `state-changed` event stream.
+      const merged = await supervisor.mergeReadyTask(taskId);
+      if (merged.state === "MERGED") {
+        return { ok: true };
+      }
+      const reason = merged.terminalReason ?? merged.state;
+      return {
+        ok: false,
+        error: `task ${taskId} did not merge (final state: ${merged.state}): ${reason}`,
+      };
     } catch (error) {
       if (error instanceof SupervisorError) {
         return { ok: false, error: error.message };
@@ -434,7 +443,7 @@ Deno.test(
 );
 
 Deno.test(
-  "/merge surfaces a NEEDS_HUMAN escalation with a descriptive ack",
+  "/merge surfaces a NEEDS_HUMAN escalation as ack { ok: false } naming the final state",
   async () => {
     const rig = await makeRig();
     try {
@@ -471,11 +480,15 @@ Deno.test(
           const reply = await client.next();
           assertEquals(reply.type, "ack");
           const payload = reply.payload as AckPayload;
-          // The merge step itself ran (the supervisor took ownership),
-          // so the handler reports success — but the task landed in
-          // NEEDS_HUMAN, not MERGED. Both pieces of state are
-          // observable.
-          assertEquals(payload.ok, true);
+          // The merge step itself ran (the supervisor took ownership)
+          // but the task landed in NEEDS_HUMAN, not MERGED. The
+          // handler reports `ok: false` with an error string that
+          // names the final state so the client can distinguish
+          // "merged" from "escalate-to-human" without subscribing to
+          // the event stream.
+          assertEquals(payload.ok, false);
+          assert(payload.error !== undefined);
+          assert(payload.error.includes("NEEDS_HUMAN"));
         } finally {
           await client.close();
         }

--- a/tests/integration/merge_command_test.ts
+++ b/tests/integration/merge_command_test.ts
@@ -130,8 +130,13 @@ function buildCommandHandler(supervisor: TaskSupervisorImpl) {
       return { ok: false, error: message };
     }
     try {
-      const merged = await supervisor.mergeReadyTask(taskId);
-      return { ok: true, error: `merged into ${merged.state}` };
+      // The merged record is intentionally discarded here: the daemon's
+      // `ack` schema (`AckPayload` in `src/ipc/protocol.ts`) carries
+      // `error` only on failure, so a successful merge returns the bare
+      // `{ ok: true }` and clients observe the resulting state through
+      // the supervisor's `state-changed` event stream instead.
+      await supervisor.mergeReadyTask(taskId);
+      return { ok: true };
     } catch (error) {
       if (error instanceof SupervisorError) {
         return { ok: false, error: error.message };

--- a/tests/integration/supervisor_end_to_end_test.ts
+++ b/tests/integration/supervisor_end_to_end_test.ts
@@ -253,6 +253,11 @@ Deno.test(
         cloneUrlFor: () => rig.source.url,
         clock: rig.clock,
         randomSource: new FixedRandomSource(),
+        // Preserve the worktree across the happy path so the
+        // `Deno.stat(worktreePath)` assertion below still passes.
+        // Cleanup behaviour (default: tear down on merge) has its
+        // own dedicated coverage in `tests/unit/merge_modes_test.ts`.
+        preserveWorktreeOnMerge: true,
       });
 
       const finalTask = await supervisor.start({

--- a/tests/unit/merge_modes_test.ts
+++ b/tests/unit/merge_modes_test.ts
@@ -1,0 +1,1040 @@
+/**
+ * Unit tests for the supervisor's merge-modes handling under
+ * `src/daemon/supervisor.ts`.
+ *
+ * Coverage targets called out in the W4-#18 brief:
+ *
+ *  - **Auto squash** — a `mergeMode: "squash"` task auto-merges via
+ *    `GitHubClient.mergePullRequest` and lands in `MERGED`.
+ *  - **Auto rebase** — same pipeline, rebase strategy.
+ *  - **Manual** — the supervisor parks at `READY_TO_MERGE` and the
+ *    GitHub merge endpoint is **not** invoked. A subsequent
+ *    `mergeReadyTask()` call (the `/merge` slash command's plumbing)
+ *    finishes the merge.
+ *  - **Cleanup** — `preserveWorktreeOnMerge` flips the worktree
+ *    teardown decision either way; both branches are verified against
+ *    a recording {@link WorktreeManagerImpl} double *and* one
+ *    integration check against a real {@link createWorktreeManager}
+ *    over a `Deno.makeTempDir`-backed bare clone.
+ *  - **Failure classification** — a `405` from `mergePullRequest`
+ *    escalates the task to `NEEDS_HUMAN`; a transient (5xx-equivalent)
+ *    failure lands the task in `FAILED`.
+ *  - **`mergeReadyTask` guards** — calling it for an unknown task or
+ *    a task not at `READY_TO_MERGE` rejects synchronously with a
+ *    {@link SupervisorError} carrying the matching `kind`.
+ *
+ * Tests use the in-memory {@link InMemoryGitHubClient} for the
+ * GitHub side and a recording worktree-manager double for the
+ * worktree side; one test exercises the real worktree manager for the
+ * "removeWorktree actually deletes the directory" check called out
+ * in the brief.
+ */
+
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import { join } from "@std/path";
+
+import {
+  branchNameFor,
+  classifyMergeError,
+  createTaskSupervisor,
+  DEFAULT_BASE_BRANCH,
+  MERGE_NOT_MERGEABLE_HTTP_STATUSES,
+  MergeError,
+  type SupervisorClock,
+  SupervisorError,
+  type SupervisorRandomSource,
+} from "../../src/daemon/supervisor.ts";
+import { createEventBus } from "../../src/daemon/event-bus.ts";
+import { createPersistence } from "../../src/daemon/persistence.ts";
+import {
+  createWorktreeManager,
+  type WorktreeManagerImpl,
+} from "../../src/daemon/worktree-manager.ts";
+import {
+  type IssueNumber,
+  makeIssueNumber,
+  makeRepoFullName,
+  type RepoFullName,
+  type Task,
+  type TaskEvent,
+  type TaskId,
+} from "../../src/types.ts";
+import { InMemoryGitHubClient } from "../helpers/in_memory_github_client.ts";
+import { MockAgentRunner } from "../helpers/mock_agent_runner.ts";
+
+// ---------------------------------------------------------------------------
+// Test scaffolding
+// ---------------------------------------------------------------------------
+
+class DeterministicClock implements SupervisorClock {
+  private milliseconds = Date.UTC(2026, 3, 26, 12, 0, 0);
+
+  /** Return the next ISO timestamp. */
+  nowIso(): string {
+    const iso = new Date(this.milliseconds).toISOString();
+    this.milliseconds += 1_000;
+    return iso;
+  }
+}
+
+class FixedRandomSource implements SupervisorRandomSource {
+  fillRandomBytes(bytes: Uint8Array): void {
+    for (let i = 0; i < bytes.length; i += 1) {
+      bytes[i] = (i * 17) & 0xff;
+    }
+  }
+}
+
+/**
+ * Recording {@link WorktreeManagerImpl} double. Returns deterministic
+ * paths so the supervisor's persisted records compare verbatim, and
+ * captures every `removeWorktree` call so cleanup assertions don't
+ * depend on the real filesystem.
+ *
+ * The supervisor's worktree side calls four methods —
+ * `ensureBareClone`, `createWorktreeForIssue`, `registerTaskId`, and
+ * `removeWorktree` — plus `worktreePathFor` and `pruneAll` which the
+ * supervisor never invokes; the latter two are implemented as no-ops
+ * for surface compatibility.
+ */
+class RecordingWorktreeManager implements WorktreeManagerImpl {
+  readonly removed: TaskId[] = [];
+  readonly removeErrors = new Map<TaskId, Error>();
+  readonly registered = new Map<TaskId, string>();
+  private readonly bareClone = "/tmp/makina-fake/bare.git";
+
+  ensureBareClone(_repo: RepoFullName, _remoteUrl: string): Promise<string> {
+    return Promise.resolve(this.bareClone);
+  }
+
+  createWorktreeForIssue(
+    _repo: RepoFullName,
+    issueNumber: IssueNumber,
+  ): Promise<string> {
+    return Promise.resolve(`/tmp/makina-fake/wt/issue-${issueNumber}`);
+  }
+
+  removeWorktree(taskId: TaskId): Promise<void> {
+    this.removed.push(taskId);
+    const error = this.removeErrors.get(taskId);
+    if (error !== undefined) {
+      return Promise.reject(error);
+    }
+    this.registered.delete(taskId);
+    return Promise.resolve();
+  }
+
+  pruneAll(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  registerTaskId(taskId: TaskId, worktreePath: string): void {
+    this.registered.set(taskId, worktreePath);
+  }
+
+  worktreePathFor(taskId: TaskId): string | undefined {
+    return this.registered.get(taskId);
+  }
+}
+
+interface MergeModesRig {
+  readonly githubClient: InMemoryGitHubClient;
+  readonly worktreeManager: RecordingWorktreeManager;
+  readonly agentRunner: MockAgentRunner;
+  readonly events: TaskEvent[];
+  readonly statePath: string;
+  readonly repo: RepoFullName;
+  readonly issueNumber: IssueNumber;
+  cleanup(): Promise<void>;
+}
+
+async function makeRig(): Promise<MergeModesRig> {
+  const dir = await Deno.makeTempDir({ prefix: "makina-merge-modes-" });
+  return {
+    githubClient: new InMemoryGitHubClient(),
+    worktreeManager: new RecordingWorktreeManager(),
+    agentRunner: new MockAgentRunner(),
+    events: [],
+    statePath: join(dir, "state.json"),
+    repo: makeRepoFullName("koraytaylan/makina"),
+    issueNumber: makeIssueNumber(7),
+    cleanup: () => Deno.remove(dir, { recursive: true }),
+  };
+}
+
+/**
+ * Pre-script the GitHub client for a happy-path run with a configurable
+ * merge response. Includes the issue, PR, reviewer-request, and the
+ * caller-supplied merge reply.
+ */
+function scriptHappyPath(
+  rig: MergeModesRig,
+  prNumber: IssueNumber,
+  mergeReply:
+    | { kind: "value"; value: undefined }
+    | { kind: "error"; error: Error }
+    | { kind: "skip" },
+): void {
+  rig.githubClient.queueGetIssue({
+    kind: "value",
+    value: {
+      number: rig.issueNumber,
+      title: "Add a /hello endpoint",
+      body: "Body",
+      state: "open",
+    },
+  });
+  rig.githubClient.queueCreatePullRequest({
+    kind: "value",
+    value: {
+      number: prNumber,
+      headSha: "deadbeef",
+      headRef: branchNameFor(rig.issueNumber),
+      baseRef: DEFAULT_BASE_BRANCH,
+      state: "open",
+    },
+  });
+  rig.githubClient.queueRequestReviewers({ kind: "value", value: undefined });
+  if (mergeReply.kind !== "skip") {
+    rig.githubClient.queueMergePullRequest(mergeReply);
+  }
+  rig.agentRunner.queueRun({
+    messages: [{ role: "assistant", text: "ok" }],
+  });
+}
+
+function buildSupervisor(
+  rig: MergeModesRig,
+  preserveWorktreeOnMerge: boolean,
+) {
+  const bus = createEventBus();
+  bus.subscribe("*", (event) => {
+    rig.events.push(event);
+  });
+  const persistence = createPersistence({ path: rig.statePath });
+  return createTaskSupervisor({
+    githubClient: rig.githubClient,
+    worktreeManager: rig.worktreeManager,
+    persistence,
+    eventBus: bus,
+    agentRunner: rig.agentRunner,
+    cloneUrlFor: () => "file:///does-not-matter",
+    clock: new DeterministicClock(),
+    randomSource: new FixedRandomSource(),
+    preserveWorktreeOnMerge,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Auto-merge happy paths
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "merge mode squash auto-merges via mergePullRequest and lands in MERGED",
+  async () => {
+    const rig = await makeRig();
+    try {
+      scriptHappyPath(rig, makeIssueNumber(11), {
+        kind: "value",
+        value: undefined,
+      });
+      const supervisor = buildSupervisor(rig, false);
+
+      const finalTask = await supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "squash",
+      });
+
+      assertEquals(finalTask.state, "MERGED");
+      assertEquals(finalTask.terminalReason, "merged");
+      const mergeCall = rig.githubClient
+        .recordedCalls()
+        .find((call) => call.method === "mergePullRequest");
+      assert(mergeCall !== undefined);
+      if (mergeCall.method !== "mergePullRequest") throw new Error("unreachable");
+      assertEquals(mergeCall.mode, "squash");
+      assertEquals(mergeCall.pullRequestNumber, makeIssueNumber(11));
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "merge mode rebase forwards the rebase strategy to mergePullRequest",
+  async () => {
+    const rig = await makeRig();
+    try {
+      scriptHappyPath(rig, makeIssueNumber(12), {
+        kind: "value",
+        value: undefined,
+      });
+      const supervisor = buildSupervisor(rig, false);
+
+      const finalTask = await supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "rebase",
+      });
+
+      assertEquals(finalTask.state, "MERGED");
+      const mergeCall = rig.githubClient
+        .recordedCalls()
+        .find((call) => call.method === "mergePullRequest");
+      assert(mergeCall !== undefined);
+      if (mergeCall.method !== "mergePullRequest") throw new Error("unreachable");
+      assertEquals(mergeCall.mode, "rebase");
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Manual mode + /merge plumbing
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "merge mode manual parks at READY_TO_MERGE and never calls mergePullRequest",
+  async () => {
+    const rig = await makeRig();
+    try {
+      scriptHappyPath(rig, makeIssueNumber(21), { kind: "skip" });
+      const supervisor = buildSupervisor(rig, false);
+
+      const finalTask = await supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "manual",
+      });
+
+      assertEquals(finalTask.state, "READY_TO_MERGE");
+      assertEquals(finalTask.terminalReason, undefined);
+      const calls = rig.githubClient.recordedCalls();
+      assert(
+        !calls.some((call) => call.method === "mergePullRequest"),
+        "mergePullRequest must NOT be invoked in manual mode",
+      );
+      assertEquals(rig.worktreeManager.removed, []);
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "mergeReadyTask completes a manual task with squash by default",
+  async () => {
+    const rig = await makeRig();
+    try {
+      scriptHappyPath(rig, makeIssueNumber(22), { kind: "skip" });
+      // After /merge: a single mergePullRequest reply.
+      rig.githubClient.queueMergePullRequest({
+        kind: "value",
+        value: undefined,
+      });
+      const supervisor = buildSupervisor(rig, false);
+
+      const parked = await supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "manual",
+      });
+      assertEquals(parked.state, "READY_TO_MERGE");
+
+      const merged = await supervisor.mergeReadyTask(parked.id);
+
+      assertEquals(merged.state, "MERGED");
+      assertEquals(merged.terminalReason, "merged");
+      const mergeCall = rig.githubClient
+        .recordedCalls()
+        .find((call) => call.method === "mergePullRequest");
+      assert(mergeCall !== undefined);
+      if (mergeCall.method !== "mergePullRequest") throw new Error("unreachable");
+      // Default substitution: manual → squash.
+      assertEquals(mergeCall.mode, "squash");
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "mergeReadyTask honors an explicit override mode",
+  async () => {
+    const rig = await makeRig();
+    try {
+      scriptHappyPath(rig, makeIssueNumber(23), { kind: "skip" });
+      rig.githubClient.queueMergePullRequest({
+        kind: "value",
+        value: undefined,
+      });
+      const supervisor = buildSupervisor(rig, false);
+
+      const parked = await supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "manual",
+      });
+      const merged = await supervisor.mergeReadyTask(parked.id, "rebase");
+
+      assertEquals(merged.state, "MERGED");
+      const mergeCall = rig.githubClient
+        .recordedCalls()
+        .find((call) => call.method === "mergePullRequest");
+      assert(mergeCall !== undefined);
+      if (mergeCall.method !== "mergePullRequest") throw new Error("unreachable");
+      assertEquals(mergeCall.mode, "rebase");
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "mergeReadyTask rejects with kind 'unknown-task' for a missing id",
+  async () => {
+    const rig = await makeRig();
+    try {
+      const supervisor = buildSupervisor(rig, false);
+      const error = await assertRejects(
+        () => supervisor.mergeReadyTask("task_does_not_exist" as TaskId),
+        SupervisorError,
+      );
+      assertEquals(error.kind, "unknown-task");
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "mergeReadyTask rejects with kind 'not-ready-to-merge' for a task in another state",
+  async () => {
+    const rig = await makeRig();
+    try {
+      // Drafting fails so the task lands in FAILED rather than
+      // walking through to READY_TO_MERGE.
+      rig.githubClient.queueGetIssue({
+        kind: "error",
+        error: new Error("404"),
+      });
+      const supervisor = buildSupervisor(rig, false);
+
+      const failed = await supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "manual",
+      });
+      assertEquals(failed.state, "FAILED");
+
+      const error = await assertRejects(
+        () => supervisor.mergeReadyTask(failed.id),
+        SupervisorError,
+      );
+      assertEquals(error.kind, "not-ready-to-merge");
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Cleanup behavior
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "preserveWorktreeOnMerge=false invokes removeWorktree after a successful auto-merge",
+  async () => {
+    const rig = await makeRig();
+    try {
+      scriptHappyPath(rig, makeIssueNumber(31), {
+        kind: "value",
+        value: undefined,
+      });
+      const supervisor = buildSupervisor(rig, false);
+
+      const finalTask = await supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "squash",
+      });
+
+      assertEquals(finalTask.state, "MERGED");
+      assertEquals(rig.worktreeManager.removed, [finalTask.id]);
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "preserveWorktreeOnMerge=true skips removeWorktree after a successful auto-merge",
+  async () => {
+    const rig = await makeRig();
+    try {
+      scriptHappyPath(rig, makeIssueNumber(32), {
+        kind: "value",
+        value: undefined,
+      });
+      const supervisor = buildSupervisor(rig, true);
+
+      const finalTask = await supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "squash",
+      });
+
+      assertEquals(finalTask.state, "MERGED");
+      assertEquals(rig.worktreeManager.removed, []);
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "preserveWorktreeOnMerge applies to the manual-merge path too",
+  async () => {
+    const rig = await makeRig();
+    try {
+      scriptHappyPath(rig, makeIssueNumber(33), { kind: "skip" });
+      rig.githubClient.queueMergePullRequest({
+        kind: "value",
+        value: undefined,
+      });
+      const supervisor = buildSupervisor(rig, false);
+
+      const parked = await supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "manual",
+      });
+      const merged = await supervisor.mergeReadyTask(parked.id);
+
+      assertEquals(merged.state, "MERGED");
+      assertEquals(rig.worktreeManager.removed, [merged.id]);
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "removeWorktree failures after merge are logged but do not change task state",
+  async () => {
+    const rig = await makeRig();
+    try {
+      scriptHappyPath(rig, makeIssueNumber(34), {
+        kind: "value",
+        value: undefined,
+      });
+      const supervisor = buildSupervisor(rig, false);
+      // Pre-load the failure: the recording manager will throw on the
+      // first `removeWorktree`.
+      // We don't know the task id yet; the failure is keyed by id, so
+      // we set up a default-throw via a sentinel after start.
+      const startPromise = supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "squash",
+      });
+      // Configure the failure for whatever id mintTaskId chose. The
+      // deterministic clock + random source makes the id stable; we
+      // can read it back from listTasks once the start resolves. To
+      // observe the error path, we register the failure via a wrapper
+      // by overwriting the manager's behavior post-start.
+      // Simpler: await the merge and assert that even if cleanup
+      // failed, the task is MERGED. We do this by wiring the failure
+      // up-front using a deterministic id.
+      const finalTask = await startPromise;
+      // The task id is now known; teardown already ran (manager
+      // recorded the call). The test is meaningful as a smoke check
+      // that the FSM does not unwind past `MERGED` even when cleanup
+      // throws *after* the persisted transition.
+      assertEquals(finalTask.state, "MERGED");
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "removeWorktree rejection keeps the task at MERGED",
+  async () => {
+    const rig = await makeRig();
+    try {
+      scriptHappyPath(rig, makeIssueNumber(35), {
+        kind: "value",
+        value: undefined,
+      });
+      // Override the recording manager: reject the FIRST removeWorktree.
+      const original = rig.worktreeManager.removeWorktree.bind(
+        rig.worktreeManager,
+      );
+      let firstCall = true;
+      rig.worktreeManager.removeWorktree = (taskId: TaskId): Promise<void> => {
+        rig.worktreeManager.removed.push(taskId);
+        if (firstCall) {
+          firstCall = false;
+          return Promise.reject(new Error("disk full"));
+        }
+        return original(taskId);
+      };
+      const supervisor = buildSupervisor(rig, false);
+
+      const finalTask = await supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "squash",
+      });
+
+      assertEquals(finalTask.state, "MERGED");
+      assert(rig.worktreeManager.removed.length === 1);
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Failure classification
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "merge failure with HTTP 405 escalates the task to NEEDS_HUMAN",
+  async () => {
+    const rig = await makeRig();
+    try {
+      const notMergeable = new Error("Pull Request is not mergeable") as
+        & Error
+        & { status?: number };
+      notMergeable.status = 405;
+      scriptHappyPath(rig, makeIssueNumber(41), {
+        kind: "error",
+        error: notMergeable,
+      });
+      const supervisor = buildSupervisor(rig, false);
+
+      const finalTask = await supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "squash",
+      });
+
+      assertEquals(finalTask.state, "NEEDS_HUMAN");
+      assert(
+        finalTask.terminalReason !== undefined &&
+          finalTask.terminalReason.startsWith("merge (not-mergeable)"),
+      );
+      // Worktree is preserved on NEEDS_HUMAN — the operator may want
+      // to inspect or push fixes from the existing checkout.
+      assertEquals(rig.worktreeManager.removed, []);
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "merge failure with HTTP 409 escalates the task to NEEDS_HUMAN",
+  async () => {
+    const rig = await makeRig();
+    try {
+      const conflict = new Error("Head branch was modified") as
+        & Error
+        & { status?: number };
+      conflict.status = 409;
+      scriptHappyPath(rig, makeIssueNumber(42), {
+        kind: "error",
+        error: conflict,
+      });
+      const supervisor = buildSupervisor(rig, false);
+
+      const finalTask = await supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "squash",
+      });
+
+      assertEquals(finalTask.state, "NEEDS_HUMAN");
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "merge failure with HTTP 500 lands the task in FAILED (transient)",
+  async () => {
+    const rig = await makeRig();
+    try {
+      const transient = new Error("Internal Server Error") as
+        & Error
+        & { status?: number };
+      transient.status = 500;
+      scriptHappyPath(rig, makeIssueNumber(43), {
+        kind: "error",
+        error: transient,
+      });
+      const supervisor = buildSupervisor(rig, false);
+
+      const finalTask = await supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "squash",
+      });
+
+      assertEquals(finalTask.state, "FAILED");
+      assert(
+        finalTask.terminalReason !== undefined &&
+          finalTask.terminalReason.startsWith("merge:"),
+      );
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "merge failure with no HTTP status falls back to transient (FAILED)",
+  async () => {
+    const rig = await makeRig();
+    try {
+      scriptHappyPath(rig, makeIssueNumber(44), {
+        kind: "error",
+        error: new Error("network down"),
+      });
+      const supervisor = buildSupervisor(rig, false);
+
+      const finalTask = await supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "squash",
+      });
+
+      assertEquals(finalTask.state, "FAILED");
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "manual /merge against a non-mergeable PR escalates to NEEDS_HUMAN",
+  async () => {
+    const rig = await makeRig();
+    try {
+      scriptHappyPath(rig, makeIssueNumber(45), { kind: "skip" });
+      const notMergeable = new Error("not mergeable") as
+        & Error
+        & { status?: number };
+      notMergeable.status = 405;
+      rig.githubClient.queueMergePullRequest({
+        kind: "error",
+        error: notMergeable,
+      });
+      const supervisor = buildSupervisor(rig, false);
+
+      const parked = await supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "manual",
+      });
+      const result = await supervisor.mergeReadyTask(parked.id);
+
+      assertEquals(result.state, "NEEDS_HUMAN");
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// classifyMergeError helper
+// ---------------------------------------------------------------------------
+
+Deno.test("classifyMergeError preserves an already-classified MergeError", () => {
+  const original = new MergeError("not-mergeable", "stale head");
+  const classified = classifyMergeError(original);
+  assertEquals(classified, original);
+});
+
+Deno.test("classifyMergeError treats every status in MERGE_NOT_MERGEABLE_HTTP_STATUSES as not-mergeable", () => {
+  for (const status of MERGE_NOT_MERGEABLE_HTTP_STATUSES) {
+    const error = new Error(`HTTP ${status}`) as Error & { status?: number };
+    error.status = status;
+    const classified = classifyMergeError(error);
+    assertEquals(classified.category, "not-mergeable");
+  }
+});
+
+Deno.test("classifyMergeError treats other statuses as transient", () => {
+  for (const status of [400, 401, 403, 404, 422, 500, 502, 503]) {
+    const error = new Error(`HTTP ${status}`) as Error & { status?: number };
+    error.status = status;
+    const classified = classifyMergeError(error);
+    assertEquals(classified.category, "transient");
+  }
+});
+
+Deno.test("classifyMergeError treats non-Error throws as transient", () => {
+  assertEquals(classifyMergeError("string oops").category, "transient");
+  assertEquals(classifyMergeError(null).category, "transient");
+  assertEquals(classifyMergeError(undefined).category, "transient");
+  assertEquals(classifyMergeError(42).category, "transient");
+});
+
+// ---------------------------------------------------------------------------
+// Cleanup against a real worktree manager
+// ---------------------------------------------------------------------------
+
+/** Run `git` against `cwd` for the integration-flavoured cleanup test. */
+async function git(args: readonly string[], cwd: string): Promise<void> {
+  const command = new Deno.Command("git", {
+    args: [...args],
+    cwd,
+    stdout: "piped",
+    stderr: "piped",
+    env: {
+      GIT_AUTHOR_NAME: "makina-test",
+      GIT_AUTHOR_EMAIL: "makina-test@example.com",
+      GIT_COMMITTER_NAME: "makina-test",
+      GIT_COMMITTER_EMAIL: "makina-test@example.com",
+    },
+  });
+  const result = await command.output();
+  if (!result.success) {
+    const stderr = new TextDecoder().decode(result.stderr);
+    throw new Error(`git ${args.join(" ")} failed: ${stderr}`);
+  }
+}
+
+async function makeSourceRepo(): Promise<{ dir: string; url: string }> {
+  const dir = await Deno.makeTempDir({ prefix: "makina-merge-modes-src-" });
+  await git(["init", "--quiet", "--initial-branch=main", dir], dir);
+  await Deno.writeTextFile(join(dir, "README.md"), "# fixture\n");
+  await git(["add", "."], dir);
+  await git(["commit", "--quiet", "-m", "feat: init"], dir);
+  return { dir, url: `file://${dir}` };
+}
+
+Deno.test(
+  "auto-merge with preserveWorktreeOnMerge=false removes the directory on disk",
+  async () => {
+    const workspace = await Deno.makeTempDir({ prefix: "makina-mm-ws-" });
+    const source = await makeSourceRepo();
+    try {
+      const githubClient = new InMemoryGitHubClient();
+      const agentRunner = new MockAgentRunner();
+      const repo = makeRepoFullName("koraytaylan/makina");
+      const issueNumber = makeIssueNumber(99);
+      const prNumber = makeIssueNumber(99);
+      githubClient.queueGetIssue({
+        kind: "value",
+        value: {
+          number: issueNumber,
+          title: "Cleanup integration",
+          body: "Body",
+          state: "open",
+        },
+      });
+      githubClient.queueCreatePullRequest({
+        kind: "value",
+        value: {
+          number: prNumber,
+          headSha: "abc",
+          headRef: branchNameFor(issueNumber),
+          baseRef: DEFAULT_BASE_BRANCH,
+          state: "open",
+        },
+      });
+      githubClient.queueRequestReviewers({ kind: "value", value: undefined });
+      githubClient.queueMergePullRequest({ kind: "value", value: undefined });
+      agentRunner.queueRun({
+        messages: [{ role: "assistant", text: "ok" }],
+      });
+
+      const bus = createEventBus();
+      const persistence = createPersistence({
+        path: join(workspace, "state.json"),
+      });
+      const worktreeManager = createWorktreeManager({ workspace });
+      const supervisor = createTaskSupervisor({
+        githubClient,
+        worktreeManager,
+        persistence,
+        eventBus: bus,
+        agentRunner,
+        cloneUrlFor: () => source.url,
+        clock: new DeterministicClock(),
+        randomSource: new FixedRandomSource(),
+        preserveWorktreeOnMerge: false,
+      });
+
+      const finalTask = await supervisor.start({
+        repo,
+        issueNumber,
+        mergeMode: "squash",
+      });
+
+      assertEquals(finalTask.state, "MERGED");
+      const path = finalTask.worktreePath;
+      assert(path !== undefined);
+      // The worktree directory must be gone after cleanup.
+      await assertRejects(
+        () => Deno.stat(path),
+        Deno.errors.NotFound,
+      );
+    } finally {
+      await Deno.remove(workspace, { recursive: true });
+      await Deno.remove(source.dir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "auto-merge with preserveWorktreeOnMerge=true keeps the directory on disk",
+  async () => {
+    const workspace = await Deno.makeTempDir({ prefix: "makina-mm-ws-" });
+    const source = await makeSourceRepo();
+    try {
+      const githubClient = new InMemoryGitHubClient();
+      const agentRunner = new MockAgentRunner();
+      const repo = makeRepoFullName("koraytaylan/makina");
+      const issueNumber = makeIssueNumber(100);
+      const prNumber = makeIssueNumber(100);
+      githubClient.queueGetIssue({
+        kind: "value",
+        value: {
+          number: issueNumber,
+          title: "Preserve integration",
+          body: "Body",
+          state: "open",
+        },
+      });
+      githubClient.queueCreatePullRequest({
+        kind: "value",
+        value: {
+          number: prNumber,
+          headSha: "abc",
+          headRef: branchNameFor(issueNumber),
+          baseRef: DEFAULT_BASE_BRANCH,
+          state: "open",
+        },
+      });
+      githubClient.queueRequestReviewers({ kind: "value", value: undefined });
+      githubClient.queueMergePullRequest({ kind: "value", value: undefined });
+      agentRunner.queueRun({
+        messages: [{ role: "assistant", text: "ok" }],
+      });
+
+      const bus = createEventBus();
+      const persistence = createPersistence({
+        path: join(workspace, "state.json"),
+      });
+      const worktreeManager = createWorktreeManager({ workspace });
+      const supervisor = createTaskSupervisor({
+        githubClient,
+        worktreeManager,
+        persistence,
+        eventBus: bus,
+        agentRunner,
+        cloneUrlFor: () => source.url,
+        clock: new DeterministicClock(),
+        randomSource: new FixedRandomSource(),
+        preserveWorktreeOnMerge: true,
+      });
+
+      const finalTask = await supervisor.start({
+        repo,
+        issueNumber,
+        mergeMode: "squash",
+      });
+
+      assertEquals(finalTask.state, "MERGED");
+      const path = finalTask.worktreePath;
+      assert(path !== undefined);
+      const stat = await Deno.stat(path);
+      assert(stat.isDirectory);
+    } finally {
+      await Deno.remove(workspace, { recursive: true });
+      await Deno.remove(source.dir, { recursive: true });
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Persistence + event-bus contracts
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "manual mode persists READY_TO_MERGE; mergeReadyTask persists MERGED",
+  async () => {
+    const rig = await makeRig();
+    try {
+      scriptHappyPath(rig, makeIssueNumber(50), { kind: "skip" });
+      rig.githubClient.queueMergePullRequest({
+        kind: "value",
+        value: undefined,
+      });
+      const supervisor = buildSupervisor(rig, false);
+      const persistence = createPersistence({ path: rig.statePath });
+
+      const parked = await supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "manual",
+      });
+      const replay1 = await persistence.loadAll();
+      assertEquals(replay1.length, 1);
+      const parked1 = replay1[0] as Task;
+      assertEquals(parked1.state, "READY_TO_MERGE");
+
+      await supervisor.mergeReadyTask(parked.id);
+      const replay2 = await persistence.loadAll();
+      assertEquals(replay2.length, 1);
+      const merged2 = replay2[0] as Task;
+      assertEquals(merged2.state, "MERGED");
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
+Deno.test(
+  "auto-merge publishes a READY_TO_MERGE → MERGED state-changed event",
+  async () => {
+    const rig = await makeRig();
+    try {
+      scriptHappyPath(rig, makeIssueNumber(60), {
+        kind: "value",
+        value: undefined,
+      });
+      const supervisor = buildSupervisor(rig, false);
+
+      await supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "squash",
+      });
+      // Allow the bus's microtask queue to flush.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      const transitions = rig.events
+        .filter((event) => event.kind === "state-changed")
+        .map((event) =>
+          event.kind === "state-changed"
+            ? { from: event.data.fromState, to: event.data.toState }
+            : { from: "?", to: "?" }
+        );
+      const mergeTransition = transitions.find(
+        (entry) => entry.from === "READY_TO_MERGE" && entry.to === "MERGED",
+      );
+      assert(mergeTransition !== undefined);
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);

--- a/tests/unit/merge_modes_test.ts
+++ b/tests/unit/merge_modes_test.ts
@@ -440,6 +440,64 @@ Deno.test(
   },
 );
 
+Deno.test(
+  "mergeReadyTask rejects concurrent invocations with kind 'merge-in-flight'",
+  async () => {
+    const rig = await makeRig();
+    try {
+      // Park the task at READY_TO_MERGE via manual mode.
+      scriptHappyPath(rig, makeIssueNumber(46), { kind: "skip" });
+      const supervisor = buildSupervisor(rig, false);
+      const parked = await supervisor.start({
+        repo: rig.repo,
+        issueNumber: rig.issueNumber,
+        mergeMode: "manual",
+      });
+      assertEquals(parked.state, "READY_TO_MERGE");
+
+      // Stall the GitHub merge call so the first `mergeReadyTask`
+      // promise is mid-flight when the second is issued. A deferred
+      // promise resolved by the test gives us deterministic control
+      // over the sequencing.
+      let releaseMerge!: () => void;
+      const mergeGate = new Promise<void>((resolve) => {
+        releaseMerge = resolve;
+      });
+      const originalMerge = rig.githubClient.mergePullRequest.bind(
+        rig.githubClient,
+      );
+      rig.githubClient.mergePullRequest = async (repo, pr, mode) => {
+        await mergeGate;
+        // Queue the response just-in-time so the original method has a
+        // scripted reply to consume after the gate releases.
+        rig.githubClient.queueMergePullRequest({
+          kind: "value",
+          value: undefined,
+        });
+        return await originalMerge(repo, pr, mode);
+      };
+
+      // Kick off the first /merge; it pauses inside `mergePullRequest`.
+      const firstMerge = supervisor.mergeReadyTask(parked.id);
+      // The second /merge for the same id must reject synchronously
+      // with `merge-in-flight` while the first call is still pending.
+      const error = await assertRejects(
+        () => supervisor.mergeReadyTask(parked.id),
+        SupervisorError,
+      );
+      assertEquals(error.kind, "merge-in-flight");
+
+      // Release the gate so the first call can finish; the task lands
+      // in MERGED and the in-flight marker is cleared in the `finally`.
+      releaseMerge();
+      const merged = await firstMerge;
+      assertEquals(merged.state, "MERGED");
+    } finally {
+      await rig.cleanup();
+    }
+  },
+);
+
 // ---------------------------------------------------------------------------
 // Cleanup behavior
 // ---------------------------------------------------------------------------
@@ -515,45 +573,6 @@ Deno.test(
 
       assertEquals(merged.state, "MERGED");
       assertEquals(rig.worktreeManager.removed, [merged.id]);
-    } finally {
-      await rig.cleanup();
-    }
-  },
-);
-
-Deno.test(
-  "removeWorktree failures after merge are logged but do not change task state",
-  async () => {
-    const rig = await makeRig();
-    try {
-      scriptHappyPath(rig, makeIssueNumber(34), {
-        kind: "value",
-        value: undefined,
-      });
-      const supervisor = buildSupervisor(rig, false);
-      // Pre-load the failure: the recording manager will throw on the
-      // first `removeWorktree`.
-      // We don't know the task id yet; the failure is keyed by id, so
-      // we set up a default-throw via a sentinel after start.
-      const startPromise = supervisor.start({
-        repo: rig.repo,
-        issueNumber: rig.issueNumber,
-        mergeMode: "squash",
-      });
-      // Configure the failure for whatever id mintTaskId chose. The
-      // deterministic clock + random source makes the id stable; we
-      // can read it back from listTasks once the start resolves. To
-      // observe the error path, we register the failure via a wrapper
-      // by overwriting the manager's behavior post-start.
-      // Simpler: await the merge and assert that even if cleanup
-      // failed, the task is MERGED. We do this by wiring the failure
-      // up-front using a deterministic id.
-      const finalTask = await startPromise;
-      // The task id is now known; teardown already ran (manager
-      // recorded the call). The test is meaningful as a smoke check
-      // that the FSM does not unwind past `MERGED` even when cleanup
-      // throws *after* the persisted transition.
-      assertEquals(finalTask.state, "MERGED");
     } finally {
       await rig.cleanup();
     }


### PR DESCRIPTION
## Summary

- Replace the supervisor's `READY_TO_MERGE` stub with a real merge step covering all three modes (squash, rebase, manual).
- Cleanup behavior per `preserveWorktreeOnMerge`; HTTP-status-based failure classification escalates not-mergeable PRs to `NEEDS_HUMAN` and transient API faults to `FAILED`.
- Wire `/merge <task-id>` end-to-end: new `mergeReadyTask` entry point on `TaskSupervisorImpl`, `SupervisorError.kind` discriminator, integration test boots `startDaemon` with the real supervisor.
- ADR-021 records the merge-step + classifier design choices (the merge-modes branch was originally numbered 018 before sibling W4 PR #39 took that slot; renumbered ahead of merge to keep the sequence collision-free).

## Test plan

- [x] `tests/unit/merge_modes_test.ts` — 25 cases covering squash/rebase auto-merge, manual parking, `/merge` re-entry, override mode, cleanup with both flag values (incl. real `WorktreeManagerImpl` over a temp-dir bare clone), failure classification (405, 409, 500, no-status, MergeError passthrough), and `mergeReadyTask` guard rejections.
- [x] `tests/integration/merge_command_test.ts` — 5 cases against the real `startDaemon` socket: happy-path `/merge`, wrong-state rejection, unknown-task rejection, missing-arg rejection, NEEDS_HUMAN escalation.
- [x] `deno task ci` green: 516 passed, 1 ignored, fmt/lint/doc-lint clean, coverage gate passed.

Closes #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)