### PR TITLE
feat(#32): wire real WizardGitHubClient via App-level GitHub client

### DIFF
--- a/docs/adrs/024-app-level-github-client-for-setup-wizard.md
+++ b/docs/adrs/024-app-level-github-client-for-setup-wizard.md
@@ -1,0 +1,80 @@
+# ADR-024: App-level GitHub client for the setup wizard
+
+## Status
+
+Accepted (2026-04-26).
+
+## Context
+
+When the first-run `makina setup` wizard (#3) was implemented in Wave 2, it depended on a
+`WizardGitHubClient` interface to discover installations. The production wiring was a stub that
+threw "GitHub App auth not yet implemented" because `[W2-github-app-auth]` (#4) had not yet landed.
+With #4 merged, `createGitHubAppAuth` (in `src/github/app-auth.ts`) now provides installation-token
+minting against real GitHub.
+
+The wizard, however, runs **before** any installation has been chosen. It needs two endpoints
+neither of which is reachable from the existing installation-scoped `GitHubClientImpl`:
+
+1. `GET /app/installations` — App-scoped, authenticated with a 10-minute App JWT (RS256).
+2. `GET /installation/repositories` — installation-scoped, but minted under a token that is
+   discarded immediately after the wizard finishes.
+
+`GitHubClientImpl` is constructed with a fixed `installationId` and a `GitHubAuth` strategy that
+mints a token for _that_ installation. It cannot answer App-level questions, and bolting a JWT mode
+onto its already non-trivial rate-limit-retry surface would couple two unrelated concerns
+(installation API ergonomics + setup-time discovery) into one class.
+
+We considered:
+
+- **Option A: Separate `AppClient` companion to `GitHubClient`.** The wizard depends on `AppClient`;
+  the supervisor keeps depending on `GitHubClient`. The two surfaces share Octokit and
+  `@octokit/auth-app` underneath but expose distinct method sets to callers.
+- **Option B: Inline JWT + fetch helpers inside the wizard's production `WizardGitHubClient`
+  factory.** No new module, just a small block of code in `src/config/wizard-github-client.ts` that
+  mints a JWT, calls the two endpoints with raw `fetch`, and projects the result.
+
+## Decision
+
+We took **Option A**. `src/github/app-client.ts` exposes:
+
+- `AppClient` interface — `listAppInstallations()` and `listInstallationRepositories(id)`.
+- `createAppClient(opts)` factory — wires the App credentials to `@octokit/auth-app`, uses
+  `@octokit/core` for the REST calls, and projects responses to typed surfaces.
+- `GitHubAppClientError` — discriminated error matching the convention set by `app-auth.ts`'s
+  `GitHubAppAuthError`. Each error names the failing operation (`createAppAuth` / `mintAppJwt` /
+  `mintInstallationToken` / `listAppInstallations` / `listInstallationRepositories` /
+  `projectInstallations` / `projectRepositories`).
+
+The wizard's production `WizardGitHubClient` lives in `src/config/wizard-github-client.ts`. It:
+
+1. Reads the PEM key from disk via an injectable `ReadKeyFile` callback (production default expands
+   `~/` and uses `Deno.readTextFile`).
+2. Constructs an `AppClient` via an injectable factory (production default uses `createAppClient`).
+3. Calls `listAppInstallations`, then `listInstallationRepositories` per installation, and projects
+   the join into the `WizardInstallation[]` shape the wizard renders to the user.
+
+`main.ts`'s `setup` branch now wires `createWizardGitHubClient()` (no arguments — production
+defaults) instead of the stub.
+
+## Consequences
+
+**Positive:**
+
+- The wizard's logic stays clean — it sees one narrow `WizardGitHubClient` interface, not raw
+  Octokit handles or JWT blobs.
+- The supervisor's installation-scoped client is unchanged; we did not have to widen its surface.
+- Both layers reuse the same `@octokit/auth-app` strategy seam so test patterns (factory + hook
+  stub) carry over directly from `app_auth_test.ts` to `app_client_test.ts`.
+- `GitHubAppClientError` matches the convention of `GitHubAppAuthError`, so call-sites classify
+  auth/network failures the same way regardless of which client raised them.
+
+**Negative:**
+
+- Two GitHub-client modules (`client.ts` for installation-scoped use, `app-client.ts` for App-scoped
+  use). The duplication is intentional — the auth model differs by call site — but reviewers should
+  look in both files when chasing a "GitHub HTTP" question.
+- `createAppClient` does not currently inherit the rate-limit retry policy from `GitHubClientImpl`
+  (ADR-011). The wizard runs at most a handful of requests per `makina setup` invocation against the
+  App's own quota, so a transient 429 is acceptable fallout — the user can simply rerun. If a future
+  caller exercises this client at higher cadence we will lift the retry policy into a shared helper
+  rather than duplicate it.

--- a/docs/setup-github-app.md
+++ b/docs/setup-github-app.md
@@ -1,9 +1,7 @@
 # Setting up the GitHub App
 
 > Wave 2's `setup` wizard drives steps 3.2 onwards. Steps 1 and 2 are manual GitHub actions taken in
-> your browser; the wizard handles everything after the App is installed. The wizard runs end-to-end
-> except for installation discovery, which lands with `[W2-github-app-auth]` (#4) — until then the
-> wizard exits with a clear "not yet implemented" message at that step.
+> your browser; the wizard handles everything after the App is installed.
 
 makina authenticates to GitHub as a GitHub App (rather than a personal access token). This is
 ADR-003: it gives us higher rate limits, fine-grained per-repo permissions, and a clean bot identity
@@ -32,17 +30,11 @@ On the App page → **Install App** → choose the account → choose specific r
 ## 3. Wire up makina
 
 1. Save the `.pem` somewhere private — e.g. `~/.config/makina/app-private-key.pem` with mode `0600`.
-2. Run `makina setup`. Once the App-level client lands (issue #4 — `[W2-github-app-auth]`), the
-   wizard will ask for the App ID, private-key path, query the App's installations endpoint to
-   discover which repos you can target, and write the resulting `config.json` to the
-   platform-appropriate location (see `docs/configuration.md`).
-
-> **Status (this PR):** the wizard's prompts, validation, and config-writing are implemented and run
-> unconditionally. The GitHub App client used for installation discovery is wired in
-> `[W2-github-app-auth]` (#4); until that lands, `makina setup` will fail with a clear "GitHub App
-> auth not yet implemented (#4)" error at the discovery step (after the App ID and private-key path
-> have been collected). When the App client lands the wizard completes end-to-end with no further
-> changes here.
+2. Run `makina setup`. The wizard asks for the App ID and private-key path, queries the App's
+   installations endpoint to discover which repositories you can target, and writes the resulting
+   `config.json` to the platform-appropriate location (see `docs/configuration.md`). The discovery
+   step uses the App-level client documented in
+   [ADR-024](./adrs/024-app-level-github-client-for-setup-wizard.md).
 
 The wizard validates the private-key path against the filesystem before calling GitHub, prints the
 list of reachable repositories with one-based numbers, and writes the resulting `config.json`. On

--- a/main.ts
+++ b/main.ts
@@ -41,9 +41,8 @@ import {
   defaultConfigPath,
   runSetupWizard,
   SetupWizardError,
-  type WizardGitHubClient,
-  type WizardInstallation,
 } from "./src/config/setup-wizard.ts";
+import { createWizardGitHubClient } from "./src/config/wizard-github-client.ts";
 
 if (Deno.args.includes("--version")) {
   console.log(MAKINA_VERSION);
@@ -155,26 +154,24 @@ if (subcommand === "daemon") {
   Deno.addSignalListener("SIGINT", shutdown);
   Deno.addSignalListener("SIGTERM", shutdown);
 } else if (subcommand === "setup") {
-  // The interactive wizard is fully implemented and runs unconditionally.
-  // What is **not** yet wired in this PR is the App-level GitHub client
-  // that lists reachable installations; that lands with
-  // [W2-github-app-auth] (issue #4). Until then, the wizard fails with a
-  // clear "not yet implemented" message at the discovery step — the user
-  // has typed their App ID and key path, but they get a single-line
-  // diagnostic pointing at #4 rather than a stack trace.
+  // First-run wizard wiring (#3 + #32).
+  //
+  // The wizard prompts for App ID + private-key path, then calls into
+  // the {@link WizardGitHubClient} to enumerate installations. The
+  // production client (lives in `src/config/wizard-github-client.ts`)
+  // bridges that narrow interface to the App-level
+  // {@link "./src/github/app-client.ts".AppClient}: it reads the PEM
+  // key from disk (with `~/` expansion), mints a JWT via
+  // `@octokit/auth-app`, walks `/app/installations` +
+  // `/installation/repositories`, and projects the join into the
+  // `WizardInstallation` shape the wizard renders.
   //
   // The wizard's own tests inject their own `WizardGitHubClient` and
-  // never touch this code path; the in-memory doubles are isolated from
+  // never touch this branch; the in-memory doubles are isolated from
   // production wiring by design.
-  const stubClient: WizardGitHubClient = {
-    getInstallations(): Promise<readonly WizardInstallation[]> {
-      throw new Error(
-        "GitHub App auth not yet implemented (#4 — [W2-github-app-auth]).",
-      );
-    },
-  };
+  const githubClient = createWizardGitHubClient();
   try {
-    const config = await runSetupWizard(createStdioWizardIo(stubClient));
+    const config = await runSetupWizard(createStdioWizardIo(githubClient));
     const targetPath = expandHome(defaultConfigPath());
     await ensureDir(dirname(targetPath));
     await Deno.writeTextFile(targetPath, `${JSON.stringify(config, null, 2)}\n`);

--- a/src/config/wizard-github-client.ts
+++ b/src/config/wizard-github-client.ts
@@ -36,6 +36,7 @@
  * @module
  */
 
+import { WIZARD_INSTALLATIONS_MAX_PARALLELISM } from "../constants.ts";
 import {
   type AppClient,
   createAppClient,
@@ -180,32 +181,87 @@ export function createWizardGitHubClient(
       });
 
       const installations = await client.listAppInstallations();
-      // Parallelise the per-installation repo fetch. Each call is
-      // independent (App-scoped pagination per installation id), and
-      // serializing them via a `for-await` made `makina setup`
-      // perceptibly slow for Apps with many installations: N
-      // round-trips at the network's RTT each. `Promise.all` collapses
-      // wall-clock time to the slowest single call, which matters when
-      // the wizard is the user's first impression of the daemon.
-      // GitHub's installation-token rate-limit is per installation, so
-      // parallel calls do not stack against a shared bucket.
+      // Parallelise the per-installation repo fetch with a bounded
+      // worker pool. Each call is independent (App-scoped pagination
+      // per installation id) and GitHub's installation-token rate
+      // limit is per installation, so concurrent calls do not stack
+      // against a shared bucket. Sequencing them via a `for-await` was
+      // perceptibly slow for Apps with many installations; unbounded
+      // `Promise.all` would fan out to hundreds of sockets for a
+      // similarly-large App and risks local socket exhaustion plus a
+      // GitHub-side secondary rate-limit. The
+      // {@link WIZARD_INSTALLATIONS_MAX_PARALLELISM} cap (8) is the
+      // standard async-pool default — fast enough on small Apps,
+      // gentle enough on the network and GitHub's buckets for large
+      // ones.
       //
-      // GitHub's `<owner>/<name>` slug is the wizard's canonical
-      // repo identifier (it is what `config.json` stores as the key
-      // of `github.installations`). Build it once here so the
-      // wizard's downstream logic does not also need to know about
-      // owner/name splitting.
-      return await Promise.all(
-        installations.map(async (installation) => {
+      // GitHub's `<owner>/<name>` slug is the wizard's canonical repo
+      // identifier (it is what `config.json` stores as the key of
+      // `github.installations`). Build it once here so the wizard's
+      // downstream logic does not also need to know about owner/name
+      // splitting.
+      return await mapWithBoundedConcurrency(
+        installations,
+        WIZARD_INSTALLATIONS_MAX_PARALLELISM,
+        async (installation) => {
           const repos = await client.listInstallationRepositories(installation.id);
           return {
             installationId: installation.id,
             repositories: repos.map((repo) => `${repo.owner}/${repo.name}`),
           };
-        }),
+        },
       );
     },
   };
+}
+
+/**
+ * Map every `item` to a `Promise<U>`, running at most `limit` of them in
+ * parallel and preserving the input order in the returned array.
+ *
+ * A small worker-pool implementation. The N workers race for the next
+ * un-claimed index; each worker awaits its task before claiming the
+ * next, so total in-flight promises never exceed `limit`. Any rejection
+ * propagates to the returned promise on the next `await` cycle and
+ * cancels further claims by failing the workers' shared awaits.
+ *
+ * Inlined here rather than added to a shared utility module because
+ * this is the only call site today; once a second consumer appears it
+ * graduates to `src/util/concurrency.ts` (per the project's
+ * minimum-deps + minimum-shared-utility policy).
+ *
+ * @param items Items to map, in order.
+ * @param limit Maximum number of in-flight promises. Must be ? 1.
+ * @param fn Async mapper run for each item.
+ * @returns Mapped values in input order.
+ */
+async function mapWithBoundedConcurrency<T, U>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<U>,
+): Promise<readonly U[]> {
+  const results: U[] = new Array(items.length);
+  let cursor = 0;
+  async function worker(): Promise<void> {
+    while (true) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= items.length) {
+        return;
+      }
+      const item = items[index];
+      if (item === undefined) {
+        // `noUncheckedIndexedAccess` requires a guard; in practice this
+        // branch is unreachable because `cursor` only walks `items`.
+        return;
+      }
+      results[index] = await fn(item);
+    }
+  }
+  const workerCount = Math.min(limit, items.length);
+  const workers = new Array(workerCount).fill(null).map(() => worker());
+  await Promise.all(workers);
+  return results;
 }
 
 /**

--- a/src/config/wizard-github-client.ts
+++ b/src/config/wizard-github-client.ts
@@ -71,9 +71,12 @@ export type ReadKeyFile = (
  *   delegates to `Deno.env.get`.
  * @returns The PEM contents of the file.
  * @throws Whatever `Deno.readTextFile` throws (e.g. `Deno.errors.NotFound`,
- *   `Deno.errors.PermissionDenied`). The wizard wraps these as
- *   {@link SetupWizardError} via the catch block in
- *   {@link "./setup-wizard.ts".fetchInstallations}.
+ *   `Deno.errors.PermissionDenied`). The thrown value is caught and
+ *   re-thrown as a `Setup_*` error in
+ *   {@link createWizardGitHubClient}'s `getInstallations` body before
+ *   it ever reaches `setup-wizard.ts`; that re-throw carries the
+ *   original message in its `cause` chain so operators still see the
+ *   underlying filesystem error.
  */
 export async function defaultReadKeyFile(
   privateKeyPath: string,
@@ -177,21 +180,30 @@ export function createWizardGitHubClient(
       });
 
       const installations = await client.listAppInstallations();
-      const projected: WizardInstallation[] = [];
-      for (const installation of installations) {
-        const repos = await client.listInstallationRepositories(installation.id);
-        // GitHub's `<owner>/<name>` slug is the wizard's canonical
-        // repo identifier (it is what `config.json` stores as the key
-        // of `github.installations`). Build it once here so the
-        // wizard's downstream logic does not also need to know about
-        // owner/name splitting.
-        const repositories = repos.map((repo) => `${repo.owner}/${repo.name}`);
-        projected.push({
-          installationId: installation.id,
-          repositories,
-        });
-      }
-      return projected;
+      // Parallelise the per-installation repo fetch. Each call is
+      // independent (App-scoped pagination per installation id), and
+      // serializing them via a `for-await` made `makina setup`
+      // perceptibly slow for Apps with many installations: N
+      // round-trips at the network's RTT each. `Promise.all` collapses
+      // wall-clock time to the slowest single call, which matters when
+      // the wizard is the user's first impression of the daemon.
+      // GitHub's installation-token rate-limit is per installation, so
+      // parallel calls do not stack against a shared bucket.
+      //
+      // GitHub's `<owner>/<name>` slug is the wizard's canonical
+      // repo identifier (it is what `config.json` stores as the key
+      // of `github.installations`). Build it once here so the
+      // wizard's downstream logic does not also need to know about
+      // owner/name splitting.
+      return await Promise.all(
+        installations.map(async (installation) => {
+          const repos = await client.listInstallationRepositories(installation.id);
+          return {
+            installationId: installation.id,
+            repositories: repos.map((repo) => `${repo.owner}/${repo.name}`),
+          };
+        }),
+      );
     },
   };
 }

--- a/src/config/wizard-github-client.ts
+++ b/src/config/wizard-github-client.ts
@@ -1,0 +1,213 @@
+/**
+ * config/wizard-github-client.ts — production
+ * {@link "./setup-wizard.ts".WizardGitHubClient} backed by an
+ * {@link "../github/app-client.ts".AppClient}.
+ *
+ * The wizard's `WizardGitHubClient` interface is intentionally narrow —
+ * one method, `getInstallations({ appId, privateKeyPath })` — so the
+ * unit tests can stub it without inheriting the full
+ * `@octokit/auth-app` + Octokit surface. This module is the production
+ * wiring that bridges that narrow interface to the real GitHub API:
+ *
+ *   1. Read the PEM private key from disk (with `~/` expansion via
+ *      {@link "./load.ts".expandHome}).
+ *   2. Construct an {@link AppClient} bound to the App credentials.
+ *   3. Call {@link AppClient.listAppInstallations} to enumerate every
+ *      installation the App can see.
+ *   4. For each installation, call
+ *      {@link AppClient.listInstallationRepositories} to fetch the
+ *      repositories that installation can act on.
+ *   5. Project the joined result into the
+ *      {@link WizardInstallation}[] shape the wizard renders to the
+ *      user as a numbered picker.
+ *
+ * The bridge lives in `src/config/` rather than `src/github/` because
+ * the consumer is the config wizard — keeping the module beside
+ * `setup-wizard.ts` makes the wiring locality obvious without bloating
+ * the App-level GitHub surface with config-specific knowledge of the
+ * wizard's `~/`-prefixed paths.
+ *
+ * **Test seam.** Both collaborators are injectable: the disk read goes
+ * through a `readKeyFile` callback (so unit tests can hand in an
+ * in-memory key without writing a temp file) and the AppClient is
+ * created via a `createClient` callback (so unit tests can pass a
+ * scripted double instead of a real `Octokit` round-trip).
+ *
+ * @module
+ */
+
+import {
+  type AppClient,
+  createAppClient,
+  type CreateAppClientOptions,
+} from "../github/app-client.ts";
+import { defaultEnvLookup, type EnvLookup, expandHome } from "./load.ts";
+import {
+  SetupWizardError,
+  type WizardGitHubClient,
+  type WizardInstallation,
+} from "./setup-wizard.ts";
+
+/**
+ * Read a private key from disk given a `~/`-prefixed (or absolute) path.
+ *
+ * Tests inject an in-memory variant; production code uses
+ * {@link defaultReadKeyFile}, which delegates to `Deno.readTextFile`
+ * after expanding `~/`.
+ */
+export type ReadKeyFile = (
+  privateKeyPath: string,
+  envLookup: EnvLookup,
+) => Promise<string>;
+
+/**
+ * Production-time {@link ReadKeyFile}. Expands `~/` and reads the file
+ * as UTF-8 text. The expanded path is the same one the wizard's
+ * existence check uses, so a failure here is unambiguous: the file did
+ * exist when the user typed the path but is no longer readable.
+ *
+ * @param privateKeyPath The user-supplied path (may begin with `~/`).
+ * @param envLookup Env reader for `$HOME` resolution. The default
+ *   delegates to `Deno.env.get`.
+ * @returns The PEM contents of the file.
+ * @throws Whatever `Deno.readTextFile` throws (e.g. `Deno.errors.NotFound`,
+ *   `Deno.errors.PermissionDenied`). The wizard wraps these as
+ *   {@link SetupWizardError} via the catch block in
+ *   {@link "./setup-wizard.ts".fetchInstallations}.
+ */
+export async function defaultReadKeyFile(
+  privateKeyPath: string,
+  envLookup: EnvLookup,
+): Promise<string> {
+  const expanded = expandHome(privateKeyPath, envLookup);
+  return await Deno.readTextFile(expanded);
+}
+
+/**
+ * Factory used to construct the underlying {@link AppClient}. Tests pass
+ * a scripted version; production omits this and the real
+ * {@link createAppClient} is used.
+ *
+ * @internal
+ */
+export type CreateAppClient = (opts: CreateAppClientOptions) => AppClient;
+
+/**
+ * Options accepted by {@link createWizardGitHubClient}.
+ */
+export interface CreateWizardGitHubClientOptions {
+  /**
+   * Disk reader for the App's private key. Defaults to
+   * {@link defaultReadKeyFile}; tests inject an in-memory reader so they
+   * can hand the wizard a synthetic key without writing a temp file.
+   *
+   * @internal
+   */
+  readonly readKeyFile?: ReadKeyFile;
+  /**
+   * Env reader used by the default {@link ReadKeyFile} for `~/`
+   * expansion. Tests inject a per-test stub to avoid mutating
+   * `Deno.env` and racing under `--parallel`. Production omits this and
+   * the wizard falls back to `Deno.env.get`.
+   *
+   * @internal
+   */
+  readonly envLookup?: EnvLookup;
+  /**
+   * Inject an alternative {@link AppClient} factory. Tests pass a
+   * scripted double; production omits this and {@link createAppClient}
+   * is used.
+   *
+   * @internal
+   */
+  readonly createClient?: CreateAppClient;
+}
+
+/**
+ * Build the production-time {@link WizardGitHubClient}.
+ *
+ * The wizard prompts the user for an App ID and a private-key path,
+ * then calls `getInstallations({ appId, privateKeyPath })` exactly once.
+ * This factory returns an object that, on that call, walks
+ * `/app/installations` + `/installation/repositories` and projects the
+ * combined result into the {@link WizardInstallation}[] shape the
+ * wizard renders.
+ *
+ * @param options See {@link CreateWizardGitHubClientOptions}. Every
+ *   field is optional; production callers omit them all.
+ * @returns A wizard-ready {@link WizardGitHubClient}.
+ *
+ * @example
+ * ```ts
+ * const client = createWizardGitHubClient();
+ * const io = createStdioWizardIo(client);
+ * const config = await runSetupWizard(io);
+ * ```
+ */
+export function createWizardGitHubClient(
+  options: CreateWizardGitHubClientOptions = {},
+): WizardGitHubClient {
+  const readKeyFile = options.readKeyFile ?? defaultReadKeyFile;
+  const envLookup = options.envLookup ?? defaultEnvLookup;
+  const createClient = options.createClient ?? createAppClient;
+
+  return {
+    async getInstallations(args: {
+      readonly appId: number;
+      readonly privateKeyPath: string;
+    }): Promise<readonly WizardInstallation[]> {
+      let privateKey: string;
+      try {
+        privateKey = await readKeyFile(args.privateKeyPath, envLookup);
+      } catch (error) {
+        // Promote the disk failure to the wizard's discriminated error so
+        // the `setup` subcommand prints a tidy single-line diagnostic.
+        // Without this rewrap the wizard's own catch block would still
+        // wrap the error, but the message would read "failed to list
+        // installations: ..." even though the failure was a key-read,
+        // which is more confusing than helpful.
+        throw new SetupWizardError(
+          `failed to read private key at ${args.privateKeyPath}: ${describeError(error)}`,
+        );
+      }
+
+      const client = createClient({
+        appId: args.appId,
+        privateKey,
+      });
+
+      const installations = await client.listAppInstallations();
+      const projected: WizardInstallation[] = [];
+      for (const installation of installations) {
+        const repos = await client.listInstallationRepositories(installation.id);
+        // GitHub's `<owner>/<name>` slug is the wizard's canonical
+        // repo identifier (it is what `config.json` stores as the key
+        // of `github.installations`). Build it once here so the
+        // wizard's downstream logic does not also need to know about
+        // owner/name splitting.
+        const repositories = repos.map((repo) => `${repo.owner}/${repo.name}`);
+        projected.push({
+          installationId: installation.id,
+          repositories,
+        });
+      }
+      return projected;
+    },
+  };
+}
+
+/**
+ * Coerce an unknown thrown value to a printable message. Mirrors the
+ * helper in `app-client.ts`; we duplicate the three lines to keep this
+ * module's import surface narrow.
+ */
+function describeError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}

--- a/src/config/wizard-github-client.ts
+++ b/src/config/wizard-github-client.ts
@@ -73,11 +73,12 @@ export type ReadKeyFile = (
  * @returns The PEM contents of the file.
  * @throws Whatever `Deno.readTextFile` throws (e.g. `Deno.errors.NotFound`,
  *   `Deno.errors.PermissionDenied`). The thrown value is caught and
- *   re-thrown as a `Setup_*` error in
+ *   re-thrown as a {@link SetupWizardError} in
  *   {@link createWizardGitHubClient}'s `getInstallations` body before
- *   it ever reaches `setup-wizard.ts`; that re-throw carries the
- *   original message in its `cause` chain so operators still see the
- *   underlying filesystem error.
+ *   it ever reaches `setup-wizard.ts`; the re-thrown error embeds the
+ *   underlying message in its own `message` (via the `describeError`
+ *   helper), so operators still see the filesystem cause even though
+ *   the `Error.cause` field itself is not populated.
  */
 export async function defaultReadKeyFile(
   privateKeyPath: string,
@@ -231,15 +232,25 @@ export function createWizardGitHubClient(
  * minimum-deps + minimum-shared-utility policy).
  *
  * @param items Items to map, in order.
- * @param limit Maximum number of in-flight promises. Must be ? 1.
+ * @param limit Maximum number of in-flight promises. Must be `>= 1`;
+ *   a smaller value would silently return an under-filled `results`
+ *   array because no worker would ever claim an index, so the helper
+ *   throws `RangeError` on a bad value rather than producing a wrong
+ *   result.
  * @param fn Async mapper run for each item.
  * @returns Mapped values in input order.
+ * @throws RangeError if `limit < 1`.
  */
 async function mapWithBoundedConcurrency<T, U>(
   items: readonly T[],
   limit: number,
   fn: (item: T) => Promise<U>,
 ): Promise<readonly U[]> {
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new RangeError(
+      `mapWithBoundedConcurrency: limit must be an integer >= 1; got ${limit}.`,
+    );
+  }
   const results: U[] = new Array(items.length);
   let cursor = 0;
   async function worker(): Promise<void> {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -556,3 +556,29 @@ export const APP_INSTALLATION_REPOSITORIES_PAGE_SIZE = 100;
  * developer knows discovery was incomplete.
  */
 export const APP_INSTALLATION_REPOSITORIES_MAX_PAGES = 1_000;
+
+/**
+ * Page size used by the App-level GitHub client when walking
+ * `GET /app/installations` during the setup wizard.
+ *
+ * GitHub paginates `/app/installations` at a default of thirty entries per
+ * page and accepts up to one hundred via `per_page`. The wizard's discovery
+ * surface assumes an exhaustive list, so we always request the documented
+ * maximum to minimise the round-trip count for Apps installed in many
+ * accounts. Mirrors {@link APP_INSTALLATION_REPOSITORIES_PAGE_SIZE} so both
+ * App-level paginating loops carry the same shape.
+ */
+export const APP_INSTALLATIONS_PAGE_SIZE = 100;
+
+/**
+ * Defensive upper bound on pages walked by the App-level GitHub client when
+ * paginating `GET /app/installations`.
+ *
+ * Mirrors {@link APP_INSTALLATION_REPOSITORIES_MAX_PAGES}: an App with more
+ * than one hundred thousand installations is implausible, but capping the
+ * loop guards against a malformed envelope or an API behaviour change
+ * driving an unbounded walk. If the cap is hit without a short page, the
+ * client surfaces a `pagination-overflow` `GitHubAppClientError` so the
+ * wizard fails loudly rather than presenting a silently-truncated picker.
+ */
+export const APP_INSTALLATIONS_MAX_PAGES = 1_000;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -596,3 +596,18 @@ export const APP_INSTALLATIONS_MAX_PAGES = 1_000;
  * version; bump it when shipping a release.
  */
 export const GITHUB_CLIENT_USER_AGENT = "makina-github-client/0.1";
+
+/**
+ * Maximum number of `listInstallationRepositories` calls the setup
+ * wizard issues in parallel.
+ *
+ * Each App installation needs its own token-mint + repo-listing call to
+ * project the picker the wizard shows. Sequencing them was visibly slow;
+ * unbounded `Promise.all` could fan out to hundreds of simultaneous
+ * sockets for an App with many installations and risks both local socket
+ * exhaustion and a GitHub-side secondary rate-limit. Eight is the
+ * typical "small async pool" default, fast enough that an App with a
+ * few dozen installations finishes in under a second on a normal
+ * connection while keeping the network and GitHub's rate buckets calm.
+ */
+export const WIZARD_INSTALLATIONS_MAX_PARALLELISM = 8;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -528,3 +528,31 @@ export const HTTP_STATUS_METHOD_NOT_ALLOWED = 405;
  * See {@link https://github.com/koraytaylan/makina/blob/develop/docs/adrs/021-merge-modes-failure-classification.md ADR-021}.
  */
 export const HTTP_STATUS_CONFLICT = 409;
+
+/**
+ * Page size used by the App-level GitHub client when walking
+ * `GET /installation/repositories` during the setup wizard.
+ *
+ * GitHub caps a page at 100 for this endpoint; using the documented maximum
+ * minimises the round-trip count for the wizard's one-shot enumeration. The
+ * value is centralised here so neither `src/github/app-client.ts` nor its
+ * pagination tests carry a bare numeric literal, matching the rule at the
+ * top of this file.
+ */
+export const APP_INSTALLATION_REPOSITORIES_PAGE_SIZE = 100;
+
+/**
+ * Defensive upper bound on pages walked by the App-level GitHub client when
+ * paginating `GET /installation/repositories`.
+ *
+ * The realistic ceiling on an installation's repository count is in the
+ * thousands; capping at one thousand pages (= one hundred thousand repos at
+ * {@link APP_INSTALLATION_REPOSITORIES_PAGE_SIZE} per page) protects against
+ * a malformed `total_count` or an API behaviour change driving an unbounded
+ * loop while staying well above every plausible real-world installation. If
+ * the cap is hit without a short page, the client surfaces a
+ * `pagination-overflow` `GitHubAppClientError` rather than silently
+ * truncating the repository list — the wizard should fail loudly so the
+ * developer knows discovery was incomplete.
+ */
+export const APP_INSTALLATION_REPOSITORIES_MAX_PAGES = 1_000;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -582,3 +582,17 @@ export const APP_INSTALLATIONS_PAGE_SIZE = 100;
  * wizard fails loudly rather than presenting a silently-truncated picker.
  */
 export const APP_INSTALLATIONS_MAX_PAGES = 1_000;
+
+/**
+ * `User-Agent` header sent on every outbound GitHub request, both
+ * installation-scoped (`src/github/client.ts`) and App-scoped
+ * (`src/github/app-client.ts`).
+ *
+ * GitHub recommends every API caller identify itself; centralising the string
+ * here keeps the two client surfaces in sync (a drift would surface in
+ * server-side request logs as two distinct callers and is hard to spot
+ * locally) and matches the project's bare-literal policy at the top of this
+ * file. The value pairs the project name with the package's published
+ * version; bump it when shipping a release.
+ */
+export const GITHUB_CLIENT_USER_AGENT = "makina-github-client/0.1";

--- a/src/github/app-client.ts
+++ b/src/github/app-client.ts
@@ -588,6 +588,19 @@ interface InstallationRepositoriesEnvelope {
  * specific projection failure rather than a generic "TypeError" from a
  * downstream `.map`.
  */
+/**
+ * Render a `non-object` entry's type for an error message in a way
+ * that distinguishes `null` from a real object — `typeof null === "object"`
+ * in JavaScript, which makes "unexpected non-object entry: object" a
+ * misleading diagnostic. Used by the projection helpers below.
+ */
+function describeNonObjectEntry(entry: unknown): string {
+  if (entry === null) {
+    return "null";
+  }
+  return typeof entry;
+}
+
 function projectInstallations(data: unknown): readonly AppInstallation[] {
   if (!Array.isArray(data)) {
     throw new GitHubAppClientError(
@@ -603,7 +616,7 @@ function projectInstallations(data: unknown): readonly AppInstallation[] {
       throw new GitHubAppClientError(
         "projectInstallations",
         new TypeError(
-          `unexpected non-object installation entry: ${typeof entry}`,
+          `unexpected non-object installation entry: ${describeNonObjectEntry(entry)}`,
         ),
       );
     }
@@ -661,7 +674,7 @@ function projectRepositories(
       throw new GitHubAppClientError(
         "projectRepositories",
         new TypeError(
-          `unexpected non-object repository entry: ${typeof entry}`,
+          `unexpected non-object repository entry: ${describeNonObjectEntry(entry)}`,
         ),
       );
     }

--- a/src/github/app-client.ts
+++ b/src/github/app-client.ts
@@ -588,19 +588,6 @@ interface InstallationRepositoriesEnvelope {
  * specific projection failure rather than a generic "TypeError" from a
  * downstream `.map`.
  */
-/**
- * Render a `non-object` entry's type for an error message in a way
- * that distinguishes `null` from a real object — `typeof null === "object"`
- * in JavaScript, which makes "unexpected non-object entry: object" a
- * misleading diagnostic. Used by the projection helpers below.
- */
-function describeNonObjectEntry(entry: unknown): string {
-  if (entry === null) {
-    return "null";
-  }
-  return typeof entry;
-}
-
 function projectInstallations(data: unknown): readonly AppInstallation[] {
   if (!Array.isArray(data)) {
     throw new GitHubAppClientError(
@@ -699,6 +686,22 @@ function projectRepositories(
     out.push({ owner, name });
   }
   return out;
+}
+
+/**
+ * Render a `non-object` entry's type for an error message in a way
+ * that distinguishes `null` from a real object. JavaScript's
+ * `typeof null === "object"` makes a bare `${typeof entry}` diagnostic
+ * read "unexpected non-object entry: object" for `null`, which is the
+ * worst possible value to debug from. Used by the projection helpers
+ * above so their thrown {@link GitHubAppClientError} messages carry an
+ * accurate label for any malformed payload shape.
+ */
+function describeNonObjectEntry(entry: unknown): string {
+  if (entry === null) {
+    return "null";
+  }
+  return typeof entry;
 }
 
 /**

--- a/src/github/app-client.ts
+++ b/src/github/app-client.ts
@@ -44,6 +44,8 @@ import { Octokit } from "@octokit/core";
 import {
   APP_INSTALLATION_REPOSITORIES_MAX_PAGES,
   APP_INSTALLATION_REPOSITORIES_PAGE_SIZE,
+  APP_INSTALLATIONS_MAX_PAGES,
+  APP_INSTALLATIONS_PAGE_SIZE,
 } from "../constants.ts";
 
 // ---------------------------------------------------------------------------
@@ -109,7 +111,11 @@ export interface AppClient {
    * Uses an App-level JWT against `GET /app/installations`. The JWT is
    * minted on every call because the wizard runs at most once per
    * `makina setup` invocation; caching a 10-minute JWT for that duration
-   * would buy nothing.
+   * would buy nothing. Pagination follows the same shape as
+   * {@link AppClient.listInstallationRepositories}: walk pages with the
+   * documented `per_page` maximum until a short page is observed, bounded
+   * by a defensive max-page cap that surfaces a `pagination-overflow`
+   * error rather than silently truncating the list.
    *
    * @returns Every installation the App can see, in GitHub's natural order.
    * @throws {GitHubAppClientError} on auth, network, or JSON-projection failure.
@@ -332,15 +338,56 @@ export function createAppClient(opts: CreateAppClientOptions): AppClient {
       } catch (error) {
         throw new GitHubAppClientError("mintAppJwt", error);
       }
-      let response: { data: unknown };
-      try {
-        response = await octokit.request("GET /app/installations", {
-          headers: { authorization: `Bearer ${appAuth.token}` },
-        });
-      } catch (error) {
-        throw new GitHubAppClientError("listAppInstallations", error);
+      // Walk every page of `/app/installations`. The endpoint paginates at a
+      // default of thirty entries; an App installed in many accounts (a
+      // realistic shape for any organisation-wide rollout) silently loses
+      // installations past the first page if we don't ask. The `per_page`
+      // and `page` parameters are GitHub-documented. Page size and the
+      // defensive max-page cap are centralised in `src/constants.ts` so
+      // this module carries no bare numeric literals.
+      const aggregated: AppInstallation[] = [];
+      let sawShortPage = false;
+      for (
+        let page = 1;
+        page <= APP_INSTALLATIONS_MAX_PAGES;
+        page += 1
+      ) {
+        let response: { data: unknown };
+        try {
+          response = await octokit.request("GET /app/installations", {
+            per_page: APP_INSTALLATIONS_PAGE_SIZE,
+            page,
+            headers: { authorization: `Bearer ${appAuth.token}` },
+          });
+        } catch (error) {
+          throw new GitHubAppClientError("listAppInstallations", error);
+        }
+        const projected = projectInstallations(response.data);
+        for (const installation of projected) {
+          aggregated.push(installation);
+        }
+        if (projected.length < APP_INSTALLATIONS_PAGE_SIZE) {
+          // Short page → final page. Saves an extra round-trip for the
+          // common case of an App installed in fewer than 100 accounts.
+          sawShortPage = true;
+          break;
+        }
       }
-      return projectInstallations(response.data);
+      if (!sawShortPage) {
+        // The cap was hit without a short page, which means the list is
+        // almost certainly truncated. Surface this loudly rather than
+        // silently returning a partial installation set: the wizard's
+        // downstream flow trusts the projection to be exhaustive.
+        throw new GitHubAppClientError(
+          "pagination-overflow",
+          new Error(
+            `exceeded MAX_PAGES (${APP_INSTALLATIONS_MAX_PAGES}) ` +
+              `walking GET /app/installations without observing a ` +
+              `short page; refusing to silently truncate`,
+          ),
+        );
+      }
+      return aggregated;
     },
 
     async listInstallationRepositories(

--- a/src/github/app-client.ts
+++ b/src/github/app-client.ts
@@ -41,6 +41,11 @@
 import { createAppAuth } from "@octokit/auth-app";
 import { Octokit } from "@octokit/core";
 
+import {
+  APP_INSTALLATION_REPOSITORIES_MAX_PAGES,
+  APP_INSTALLATION_REPOSITORIES_PAGE_SIZE,
+} from "../constants.ts";
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -358,21 +363,21 @@ export function createAppClient(opts: CreateAppClientOptions): AppClient {
       // caps a page at 100; an installation with hundreds of repos is
       // possible (an org installation with `selected = "all"`), and the
       // wizard's downstream flattener relies on the full list to populate
-      // its picker. The `since`/`per_page` parameters are GitHub-
-      // documented and supported.
+      // its picker. The `page`/`per_page` parameters are GitHub-
+      // documented and supported. Page size and the defensive max-page
+      // cap are centralised in `src/constants.ts` so this module carries
+      // no bare numeric literals.
       const aggregated: InstallationRepository[] = [];
-      const PER_PAGE = 100;
-      // Bound the loop defensively. The realistic ceiling on an
-      // installation's repository count is in the thousands; capping at
-      // 1,000 pages (= 100,000 repos) protects against a malformed
-      // `total_count` driving an unbounded loop while staying well above
-      // every plausible real-world installation.
-      const MAX_PAGES = 1_000;
-      for (let page = 1; page <= MAX_PAGES; page += 1) {
+      let sawShortPage = false;
+      for (
+        let page = 1;
+        page <= APP_INSTALLATION_REPOSITORIES_MAX_PAGES;
+        page += 1
+      ) {
         let response: { data: unknown };
         try {
           response = await octokit.request("GET /installation/repositories", {
-            per_page: PER_PAGE,
+            per_page: APP_INSTALLATION_REPOSITORIES_PAGE_SIZE,
             page,
             headers: { authorization: `token ${installationAuth.token}` },
           });
@@ -383,11 +388,26 @@ export function createAppClient(opts: CreateAppClientOptions): AppClient {
         for (const repo of projected) {
           aggregated.push(repo);
         }
-        if (projected.length < PER_PAGE) {
+        if (projected.length < APP_INSTALLATION_REPOSITORIES_PAGE_SIZE) {
           // Short page → final page. Saves an extra round-trip for the
           // common case of an installation with under 100 repos.
+          sawShortPage = true;
           break;
         }
+      }
+      if (!sawShortPage) {
+        // The cap was hit without a short page, which means the list is
+        // almost certainly truncated. Surface this loudly rather than
+        // silently returning a partial repository set: the wizard's
+        // downstream flow trusts the projection to be exhaustive.
+        throw new GitHubAppClientError(
+          "pagination-overflow",
+          new Error(
+            `exceeded MAX_PAGES (${APP_INSTALLATION_REPOSITORIES_MAX_PAGES}) ` +
+              `walking GET /installation/repositories without observing a ` +
+              `short page; refusing to silently truncate`,
+          ),
+        );
       }
       return aggregated;
     },

--- a/src/github/app-client.ts
+++ b/src/github/app-client.ts
@@ -1,0 +1,586 @@
+/**
+ * github/app-client.ts — App-level GitHub client used by the setup wizard.
+ *
+ * Companion to {@link "./client.ts".GitHubClientImpl}, which is
+ * **installation-scoped** (every request resolves an installation token
+ * before going on the wire). The setup wizard runs **before** any
+ * installation has been chosen, so it cannot use the installation-scoped
+ * client. Instead it needs:
+ *
+ *   1. **App-level** access to `GET /app/installations` — the endpoint
+ *      that lists every installation reachable from the App. This call is
+ *      authenticated with a short-lived App JWT (RS256, 10-minute TTL),
+ *      not an installation token.
+ *   2. **Per-installation** access to `GET /installation/repositories` —
+ *      the endpoint that lists the repos a specific installation can see.
+ *      This call is authenticated with an installation access token.
+ *
+ * Both flows are delegated to `@octokit/auth-app` per
+ * {@link "../../docs/adrs/005-no-jose-using-octokit-auth-app.md" | ADR-005}
+ * and
+ * {@link "../../docs/adrs/024-app-level-github-client-for-setup-wizard.md" | ADR-024}:
+ * the JWT is minted via `auth({ type: "app" })` and the installation
+ * token via `auth({ type: "installation", installationId, refresh: true })`.
+ * We do not reimplement either primitive — the audited path lives inside
+ * `@octokit/auth-app`.
+ *
+ * **Errors.** Anything thrown by `@octokit/auth-app`, `@octokit/core`, or
+ * the underlying fetch is rewrapped as a {@link GitHubAppClientError} that
+ * names the failing operation. The original error is preserved on `cause`
+ * so the wizard's "failed to list installations: <reason>" diagnostic
+ * carries useful context without leaking a stack trace.
+ *
+ * **Test seam.** Like {@link "./client.ts".GitHubClientImpl}, the factory
+ * accepts an `Octokit` constructor and a `createAppAuthStrategy` for
+ * dependency injection. Unit tests pass scripted versions so no real JWT
+ * signing or HTTPS round-trip happens; production callers omit both
+ * options and the real Octokit + `@octokit/auth-app` are used.
+ *
+ * @module
+ */
+import { createAppAuth } from "@octokit/auth-app";
+import { Octokit } from "@octokit/core";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * One installation listed by the App's `/app/installations` endpoint.
+ *
+ * The wizard only reads `id` (to mint a per-installation token) and
+ * `account.login` (informational); no other fields are needed at this
+ * layer, but the projection mirrors the GitHub payload shape so a future
+ * caller can extend it without rewriting the parser.
+ */
+export interface AppInstallation {
+  /**
+   * Numeric installation id used by
+   * `POST /app/installations/{id}/access_tokens` to mint an installation
+   * token. The wizard treats this as the canonical identifier of an
+   * installation.
+   */
+  readonly id: number;
+  /**
+   * Login of the account (user or org) the App is installed on. Optional
+   * because the GitHub payload omits it when the account has been
+   * deleted out from under the installation; the wizard tolerates the
+   * absent case by displaying the installation id alone.
+   */
+  readonly accountLogin?: string;
+}
+
+/**
+ * One repository visible to a specific installation, projected from
+ * `GET /installation/repositories`.
+ *
+ * The wizard renders these as `<owner>/<name>` strings and treats them
+ * as the unit of repository discovery; we do not surface the numeric
+ * repo id because it does not show up in any user-facing config field.
+ */
+export interface InstallationRepository {
+  /** Owning user/org login. */
+  readonly owner: string;
+  /** Repository name (without the owner prefix). */
+  readonly name: string;
+}
+
+/**
+ * App-scoped GitHub client used by the setup wizard.
+ *
+ * Distinct from the installation-scoped {@link "./client.ts".GitHubClientImpl}
+ * because the calls this surface owns are App-level (require a JWT) or
+ * are installation-level under a token minted **before** the daemon
+ * picks an installation to operate on. The supervisor never holds an
+ * `AppClient` — once `setup` is done, every supervisor call is
+ * installation-scoped through `GitHubClient`.
+ *
+ * @see {@link "../../docs/adrs/024-app-level-github-client-for-setup-wizard.md" | ADR-024}
+ */
+export interface AppClient {
+  /**
+   * List every installation reachable from the configured App.
+   *
+   * Uses an App-level JWT against `GET /app/installations`. The JWT is
+   * minted on every call because the wizard runs at most once per
+   * `makina setup` invocation; caching a 10-minute JWT for that duration
+   * would buy nothing.
+   *
+   * @returns Every installation the App can see, in GitHub's natural order.
+   * @throws {GitHubAppClientError} on auth, network, or JSON-projection failure.
+   */
+  listAppInstallations(): Promise<readonly AppInstallation[]>;
+  /**
+   * List the repositories visible to a specific installation.
+   *
+   * Mints a fresh installation token via `@octokit/auth-app` and calls
+   * `GET /installation/repositories`. The token is not retained — the
+   * wizard only needs the repository list once.
+   *
+   * @param installationId Numeric installation id from
+   *   {@link AppClient.listAppInstallations}.
+   * @returns Repositories the installation can see, in GitHub's natural
+   *   order. Returns an empty array if the installation has been granted
+   *   access to no repos.
+   * @throws {GitHubAppClientError} on auth, network, or JSON-projection failure.
+   */
+  listInstallationRepositories(
+    installationId: number,
+  ): Promise<readonly InstallationRepository[]>;
+}
+
+/**
+ * Strategy function compatible with `@octokit/auth-app`'s `createAppAuth`.
+ *
+ * Tests inject a stub strategy so no JWT signing or HTTPS round-trip
+ * happens; production code uses the default that delegates to the real
+ * `@octokit/auth-app`. Mirrors the seam used by
+ * {@link "./app-auth.ts".CreateAppAuthStrategy} so the two modules remain
+ * test-symmetric.
+ */
+export interface AppClientAuthStrategy {
+  (options: {
+    readonly appId: number;
+    readonly privateKey: string;
+  }): AppClientAuthHook;
+}
+
+/**
+ * Narrow subset of `@octokit/auth-app`'s returned `auth()` function this
+ * module uses. Two modes:
+ *
+ *   - `{ type: "app" }` — return an App JWT (`AppAuthentication`).
+ *   - `{ type: "installation", installationId, refresh: true }` — mint
+ *     an installation access token, bypassing the `@octokit/auth-app`
+ *     LRU cache so the wizard always sees fresh state.
+ *
+ * Modeled as a callable interface so tests can implement it without
+ * pulling in the full Octokit `AuthInterface`.
+ */
+export interface AppClientAuthHook {
+  (options: { readonly type: "app" }): Promise<AppAuthResult>;
+  (options: {
+    readonly type: "installation";
+    readonly installationId: number;
+    readonly refresh: true;
+  }): Promise<InstallationAuthResult>;
+}
+
+/**
+ * Subset of `@octokit/auth-app`'s `AppAuthentication` we read.
+ */
+export interface AppAuthResult {
+  /** App JWT used as `Authorization: Bearer <token>`. */
+  readonly token: string;
+}
+
+/**
+ * Subset of `@octokit/auth-app`'s `InstallationAccessTokenAuthentication`
+ * we read.
+ */
+export interface InstallationAuthResult {
+  /** Installation access token used as `Authorization: token <token>`. */
+  readonly token: string;
+}
+
+/**
+ * Construction options for {@link createAppClient}.
+ */
+export interface CreateAppClientOptions {
+  /** GitHub App id (the integer printed on the App settings page). */
+  readonly appId: number;
+  /**
+   * PEM-encoded private key as a string. Reading the key from disk is
+   * the caller's responsibility (the wizard's production wiring expands
+   * `~/` and reads the file before constructing the client).
+   */
+  readonly privateKey: string;
+  /**
+   * Optional injection point for the auth strategy factory. Tests pass
+   * a stub; production callers omit this and `@octokit/auth-app` is used.
+   *
+   * @internal
+   */
+  readonly createAppAuthStrategy?: AppClientAuthStrategy;
+  /**
+   * Optional `User-Agent`. GitHub rejects requests without one. Defaults
+   * to {@link DEFAULT_USER_AGENT}.
+   */
+  readonly userAgent?: string;
+  /**
+   * Optional override of the GitHub API base URL. Useful for testing
+   * against GitHub Enterprise stand-ins. Defaults to Octokit's default
+   * (`https://api.github.com`).
+   */
+  readonly baseUrl?: string;
+  /**
+   * Inject the underlying `fetch`. Tests pass a scripted fake; production
+   * leaves this undefined and `@octokit/core` uses the runtime `fetch`.
+   *
+   * @internal
+   */
+  readonly fetch?: typeof fetch;
+}
+
+/**
+ * Error thrown when an underlying call fails inside an {@link AppClient}.
+ *
+ * The message starts with `GitHub App client failed during <operation>:`
+ * so logs are scannable. The original error is preserved on `cause`.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await appClient.listAppInstallations();
+ * } catch (error) {
+ *   if (error instanceof GitHubAppClientError) {
+ *     console.error(error.operation, error.cause);
+ *   }
+ * }
+ * ```
+ */
+export class GitHubAppClientError extends Error {
+  /** The operation that failed (e.g. `"listAppInstallations"`). */
+  readonly operation: string;
+
+  /**
+   * Construct a new {@link GitHubAppClientError}.
+   *
+   * @param operation A short identifier for the failing operation.
+   * @param cause The original error thrown by the underlying call.
+   */
+  constructor(operation: string, cause: unknown) {
+    super(
+      `GitHub App client failed during ${operation}: ${describeError(cause)}`,
+      { cause },
+    );
+    this.name = "GitHubAppClientError";
+    this.operation = operation;
+  }
+}
+
+/**
+ * Default `User-Agent` string. Mirrors
+ * {@link "./client.ts".GitHubClientImpl} so a single string identifies
+ * the daemon across both client surfaces. GitHub rejects requests
+ * without a `User-Agent`.
+ */
+export const DEFAULT_USER_AGENT = "makina-github-client/0.1";
+
+// ---------------------------------------------------------------------------
+// Public factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an {@link AppClient} backed by `@octokit/auth-app` and
+ * `@octokit/core`.
+ *
+ * The returned object is **stateless** beyond the bound auth function
+ * and Octokit instance: no token cache lives here. Installation tokens
+ * are minted afresh on every call because the wizard's discovery flow
+ * runs at most once per `makina setup` invocation; reuse is not worth
+ * the cache-invalidation surface area.
+ *
+ * @param opts See {@link CreateAppClientOptions}.
+ * @returns An {@link AppClient} bound to the supplied App credentials.
+ *
+ * @example
+ * ```ts
+ * const appClient = createAppClient({
+ *   appId: 1234,
+ *   privateKey: await Deno.readTextFile("private-key.pem"),
+ * });
+ * const installations = await appClient.listAppInstallations();
+ * for (const installation of installations) {
+ *   const repos = await appClient.listInstallationRepositories(installation.id);
+ *   for (const repo of repos) {
+ *     console.log(`${repo.owner}/${repo.name} via installation ${installation.id}`);
+ *   }
+ * }
+ * ```
+ */
+export function createAppClient(opts: CreateAppClientOptions): AppClient {
+  const strategy = opts.createAppAuthStrategy ?? defaultCreateAppAuthStrategy;
+  const userAgent = opts.userAgent ?? DEFAULT_USER_AGENT;
+
+  let authHook: AppClientAuthHook;
+  try {
+    authHook = strategy({ appId: opts.appId, privateKey: opts.privateKey });
+  } catch (error) {
+    throw new GitHubAppClientError("createAppAuth", error);
+  }
+
+  const octokitOptions: Record<string, unknown> = { userAgent };
+  if (opts.baseUrl !== undefined) {
+    octokitOptions.baseUrl = opts.baseUrl;
+  }
+  if (opts.fetch !== undefined) {
+    octokitOptions.request = { fetch: opts.fetch };
+  }
+  const octokit = new Octokit(octokitOptions);
+
+  return {
+    async listAppInstallations(): Promise<readonly AppInstallation[]> {
+      let appAuth: AppAuthResult;
+      try {
+        appAuth = await authHook({ type: "app" });
+      } catch (error) {
+        throw new GitHubAppClientError("mintAppJwt", error);
+      }
+      let response: { data: unknown };
+      try {
+        response = await octokit.request("GET /app/installations", {
+          headers: { authorization: `Bearer ${appAuth.token}` },
+        });
+      } catch (error) {
+        throw new GitHubAppClientError("listAppInstallations", error);
+      }
+      return projectInstallations(response.data);
+    },
+
+    async listInstallationRepositories(
+      installationId: number,
+    ): Promise<readonly InstallationRepository[]> {
+      let installationAuth: InstallationAuthResult;
+      try {
+        installationAuth = await authHook({
+          type: "installation",
+          installationId,
+          // Bypass the `@octokit/auth-app` LRU cache for the same reason
+          // `app-auth.ts` does — the wizard's lifetime is bounded by a
+          // single `makina setup` and we always want the freshest token.
+          refresh: true,
+        });
+      } catch (error) {
+        throw new GitHubAppClientError("mintInstallationToken", error);
+      }
+      // Walk every page of `/installation/repositories`. The endpoint
+      // caps a page at 100; an installation with hundreds of repos is
+      // possible (an org installation with `selected = "all"`), and the
+      // wizard's downstream flattener relies on the full list to populate
+      // its picker. The `since`/`per_page` parameters are GitHub-
+      // documented and supported.
+      const aggregated: InstallationRepository[] = [];
+      const PER_PAGE = 100;
+      // Bound the loop defensively. The realistic ceiling on an
+      // installation's repository count is in the thousands; capping at
+      // 1,000 pages (= 100,000 repos) protects against a malformed
+      // `total_count` driving an unbounded loop while staying well above
+      // every plausible real-world installation.
+      const MAX_PAGES = 1_000;
+      for (let page = 1; page <= MAX_PAGES; page += 1) {
+        let response: { data: unknown };
+        try {
+          response = await octokit.request("GET /installation/repositories", {
+            per_page: PER_PAGE,
+            page,
+            headers: { authorization: `token ${installationAuth.token}` },
+          });
+        } catch (error) {
+          throw new GitHubAppClientError("listInstallationRepositories", error);
+        }
+        const projected = projectRepositories(response.data);
+        for (const repo of projected) {
+          aggregated.push(repo);
+        }
+        if (projected.length < PER_PAGE) {
+          // Short page → final page. Saves an extra round-trip for the
+          // common case of an installation with under 100 repos.
+          break;
+        }
+      }
+      return aggregated;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/**
+ * Default strategy: real `@octokit/auth-app`.
+ *
+ * Returned hook is overloaded so calls into App-mode produce
+ * `{ type: "app", token }` and calls into installation-mode produce the
+ * `InstallationAccessTokenAuthentication` shape. We keep the projected
+ * surface narrow; the rest of `@octokit/auth-app`'s payload (permissions,
+ * repository selection, etc.) is not relevant to the wizard.
+ */
+function defaultCreateAppAuthStrategy(options: {
+  readonly appId: number;
+  readonly privateKey: string;
+}): AppClientAuthHook {
+  const auth = createAppAuth({
+    appId: options.appId,
+    privateKey: options.privateKey,
+  });
+  // Single overloaded hook: forward to `auth(...)` and project the result
+  // shape down to the narrow types this module owns.
+  function hook(options: { readonly type: "app" }): Promise<AppAuthResult>;
+  function hook(options: {
+    readonly type: "installation";
+    readonly installationId: number;
+    readonly refresh: true;
+  }): Promise<InstallationAuthResult>;
+  async function hook(
+    options:
+      | { readonly type: "app" }
+      | {
+        readonly type: "installation";
+        readonly installationId: number;
+        readonly refresh: true;
+      },
+  ): Promise<AppAuthResult | InstallationAuthResult> {
+    if (options.type === "app") {
+      const result = await auth({ type: "app" });
+      return { token: result.token };
+    }
+    const result = await auth({
+      type: "installation",
+      installationId: options.installationId,
+      refresh: options.refresh,
+    });
+    return { token: result.token };
+  }
+  return hook;
+}
+
+interface AppInstallationResponse {
+  readonly id: number;
+  readonly account?: { readonly login?: string | null } | null;
+}
+
+interface InstallationRepositoryResponse {
+  readonly owner?: { readonly login?: string | null } | null;
+  readonly name?: string | null;
+}
+
+interface InstallationRepositoriesEnvelope {
+  readonly repositories?: readonly InstallationRepositoryResponse[];
+}
+
+/**
+ * Project the raw `/app/installations` payload into the typed
+ * {@link AppInstallation} surface.
+ *
+ * Tolerates the documented payload shape strictly: a non-array body,
+ * a missing numeric `id`, or an unknown JSON shape produce a
+ * {@link GitHubAppClientError} so the wizard's diagnostic surfaces the
+ * specific projection failure rather than a generic "TypeError" from a
+ * downstream `.map`.
+ */
+function projectInstallations(data: unknown): readonly AppInstallation[] {
+  if (!Array.isArray(data)) {
+    throw new GitHubAppClientError(
+      "projectInstallations",
+      new TypeError(
+        `expected array from GET /app/installations, received ${typeof data}`,
+      ),
+    );
+  }
+  const out: AppInstallation[] = [];
+  for (const entry of data as readonly AppInstallationResponse[]) {
+    if (entry === null || typeof entry !== "object") {
+      throw new GitHubAppClientError(
+        "projectInstallations",
+        new TypeError(
+          `unexpected non-object installation entry: ${typeof entry}`,
+        ),
+      );
+    }
+    const id = entry.id;
+    if (typeof id !== "number" || !Number.isFinite(id)) {
+      throw new GitHubAppClientError(
+        "projectInstallations",
+        new TypeError(
+          `installation entry missing numeric id: ${JSON.stringify(entry)}`,
+        ),
+      );
+    }
+    const accountLogin = entry.account?.login ?? null;
+    const projected: AppInstallation = accountLogin === null ||
+        accountLogin === undefined
+      ? { id }
+      : { id, accountLogin };
+    out.push(projected);
+  }
+  return out;
+}
+
+/**
+ * Project the raw `/installation/repositories` payload into the typed
+ * {@link InstallationRepository} surface.
+ *
+ * GitHub's response wraps the array in a `{ total_count, repositories }`
+ * envelope (REST) — neither of which we expose. Anything else produces
+ * a {@link GitHubAppClientError}.
+ */
+function projectRepositories(
+  data: unknown,
+): readonly InstallationRepository[] {
+  if (data === null || typeof data !== "object") {
+    throw new GitHubAppClientError(
+      "projectRepositories",
+      new TypeError(
+        `expected object from GET /installation/repositories, received ${typeof data}`,
+      ),
+    );
+  }
+  const envelope = data as InstallationRepositoriesEnvelope;
+  const repositories = envelope.repositories;
+  if (!Array.isArray(repositories)) {
+    throw new GitHubAppClientError(
+      "projectRepositories",
+      new TypeError(
+        `repositories envelope missing array field: ${JSON.stringify(data)}`,
+      ),
+    );
+  }
+  const out: InstallationRepository[] = [];
+  for (const entry of repositories) {
+    if (entry === null || typeof entry !== "object") {
+      throw new GitHubAppClientError(
+        "projectRepositories",
+        new TypeError(
+          `unexpected non-object repository entry: ${typeof entry}`,
+        ),
+      );
+    }
+    const owner = entry.owner?.login;
+    const name = entry.name;
+    if (typeof owner !== "string" || owner.length === 0) {
+      throw new GitHubAppClientError(
+        "projectRepositories",
+        new TypeError(
+          `repository entry missing owner.login: ${JSON.stringify(entry)}`,
+        ),
+      );
+    }
+    if (typeof name !== "string" || name.length === 0) {
+      throw new GitHubAppClientError(
+        "projectRepositories",
+        new TypeError(
+          `repository entry missing name: ${JSON.stringify(entry)}`,
+        ),
+      );
+    }
+    out.push({ owner, name });
+  }
+  return out;
+}
+
+/**
+ * Coerce an unknown thrown value to a printable message. `Error.message`
+ * for true Errors, JSON for everything else.
+ */
+function describeError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}

--- a/src/github/app-client.ts
+++ b/src/github/app-client.ts
@@ -46,6 +46,7 @@ import {
   APP_INSTALLATION_REPOSITORIES_PAGE_SIZE,
   APP_INSTALLATIONS_MAX_PAGES,
   APP_INSTALLATIONS_PAGE_SIZE,
+  GITHUB_CLIENT_USER_AGENT,
 } from "../constants.ts";
 
 // ---------------------------------------------------------------------------
@@ -271,12 +272,13 @@ export class GitHubAppClientError extends Error {
 }
 
 /**
- * Default `User-Agent` string. Mirrors
- * {@link "./client.ts".GitHubClientImpl} so a single string identifies
- * the daemon across both client surfaces. GitHub rejects requests
- * without a `User-Agent`.
+ * Re-export the centralised default `User-Agent` so existing callers that
+ * import from this module continue to work. The single source of truth is
+ * {@link GITHUB_CLIENT_USER_AGENT} in `src/constants.ts`; both client
+ * surfaces (`./client.ts` and this module) point at the same string so
+ * server-side request logs see one caller, not two.
  */
-export const DEFAULT_USER_AGENT = "makina-github-client/0.1";
+export { GITHUB_CLIENT_USER_AGENT as DEFAULT_USER_AGENT };
 
 // ---------------------------------------------------------------------------
 // Public factory
@@ -312,7 +314,7 @@ export const DEFAULT_USER_AGENT = "makina-github-client/0.1";
  */
 export function createAppClient(opts: CreateAppClientOptions): AppClient {
   const strategy = opts.createAppAuthStrategy ?? defaultCreateAppAuthStrategy;
-  const userAgent = opts.userAgent ?? DEFAULT_USER_AGENT;
+  const userAgent = opts.userAgent ?? GITHUB_CLIENT_USER_AGENT;
 
   let authHook: AppClientAuthHook;
   try {

--- a/src/github/app-client.ts
+++ b/src/github/app-client.ts
@@ -154,6 +154,23 @@ export interface AppClientAuthStrategy {
   (options: {
     readonly appId: number;
     readonly privateKey: string;
+    /**
+     * Optional GitHub Enterprise / staging API base URL forwarded from
+     * {@link CreateAppClientOptions.baseUrl}. The default strategy
+     * passes this to `@octokit/auth-app` so installation-token minting
+     * targets the same host as the rest of the client; an unset value
+     * falls back to `@octokit/auth-app`'s default (`api.github.com`).
+     */
+    readonly baseUrl?: string;
+    /**
+     * Optional `fetch` implementation forwarded from
+     * {@link CreateAppClientOptions.fetch}. The default strategy passes
+     * this to `@octokit/auth-app` so installation-token minting goes
+     * through the same test seam as the rest of the client. Unit tests
+     * inject a scripted fake fetch here so the auth path never touches
+     * the network.
+     */
+    readonly fetch?: typeof globalThis.fetch;
   }): AppClientAuthHook;
 }
 
@@ -318,7 +335,23 @@ export function createAppClient(opts: CreateAppClientOptions): AppClient {
 
   let authHook: AppClientAuthHook;
   try {
-    authHook = strategy({ appId: opts.appId, privateKey: opts.privateKey });
+    // Forward `baseUrl`/`fetch` so the auth path goes through the same
+    // host and the same test seam as the client itself. Without this,
+    // installation-token minting (`POST /app/installations/.../access_tokens`)
+    // would always hit github.com via the default fetch even when the
+    // caller injected a custom baseUrl/fetch — invisible to scripted-fetch
+    // unit tests and broken on GitHub Enterprise.
+    //
+    // The conditional spreads exist because the project's
+    // `exactOptionalPropertyTypes: true` setting forbids passing
+    // `undefined` to optional fields; either include the field (with a
+    // defined value) or omit it entirely.
+    authHook = strategy({
+      appId: opts.appId,
+      privateKey: opts.privateKey,
+      ...(opts.baseUrl !== undefined ? { baseUrl: opts.baseUrl } : {}),
+      ...(opts.fetch !== undefined ? { fetch: opts.fetch } : {}),
+    });
   } catch (error) {
     throw new GitHubAppClientError("createAppAuth", error);
   }
@@ -479,11 +512,27 @@ export function createAppClient(opts: CreateAppClientOptions): AppClient {
 function defaultCreateAppAuthStrategy(options: {
   readonly appId: number;
   readonly privateKey: string;
+  readonly baseUrl?: string;
+  readonly fetch?: typeof globalThis.fetch;
 }): AppClientAuthHook {
-  const auth = createAppAuth({
+  // The wider auth-app options object accepts `baseUrl` and a
+  // `request: { fetch }` override — both are documented on
+  // `@octokit/auth-app`. The local typing here is intentionally loose
+  // to avoid pulling the full `@octokit/auth-app` types into our
+  // surface; the runtime contract is what matters.
+  const authOptions: Record<string, unknown> = {
     appId: options.appId,
     privateKey: options.privateKey,
-  });
+  };
+  if (options.baseUrl !== undefined) {
+    authOptions.baseUrl = options.baseUrl;
+  }
+  if (options.fetch !== undefined) {
+    authOptions.request = { fetch: options.fetch };
+  }
+  const auth = createAppAuth(
+    authOptions as unknown as Parameters<typeof createAppAuth>[0],
+  );
   // Single overloaded hook: forward to `auth(...)` and project the result
   // shape down to the narrow types this module owns.
   function hook(options: { readonly type: "app" }): Promise<AppAuthResult>;

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -39,6 +39,7 @@
 
 import { Octokit } from "@octokit/core";
 
+import { GITHUB_CLIENT_USER_AGENT } from "../constants.ts";
 import {
   type CombinedStatus,
   type GitHubAuth,
@@ -429,12 +430,6 @@ const LIST_REVIEW_THREADS_QUERY =
   }
 }`;
 
-/**
- * Default `User-Agent` string. GitHub demands a non-empty UA on every
- * request; ours identifies the daemon and its version line.
- */
-const DEFAULT_USER_AGENT = "makina-github-client/0.1";
-
 // ---------------------------------------------------------------------------
 // GitHubClient implementation
 // ---------------------------------------------------------------------------
@@ -479,7 +474,7 @@ export class GitHubClientImpl implements StabilizeGitHubClient {
     this.maxRetrySleepMilliseconds = options.maxRetrySleepMilliseconds ??
       DEFAULT_MAX_RETRY_SLEEP_MILLISECONDS;
 
-    const userAgent = options.userAgent ?? DEFAULT_USER_AGENT;
+    const userAgent = options.userAgent ?? GITHUB_CLIENT_USER_AGENT;
     const octokitOptions: Record<string, unknown> = { userAgent };
     if (options.baseUrl !== undefined) {
       octokitOptions.baseUrl = options.baseUrl;

--- a/tests/integration/setup_wizard_real_auth_test.ts
+++ b/tests/integration/setup_wizard_real_auth_test.ts
@@ -1,0 +1,85 @@
+/**
+ * Integration test for the setup wizard's real GitHub App auth path.
+ *
+ * Gated by `MAKINA_SETUP_REAL_TEST=1`. When unset (the default for CI),
+ * the test skips: it requires real App credentials and a sandbox
+ * installation that the developer running the test owns. Skipping
+ * loudly is preferable to a no-op `Deno.test.ignore` so the developer
+ * who does have credentials sees the gating env var name.
+ *
+ * The `MAKINA_SETUP_REAL_*` env vars (only read when the gate is set):
+ *
+ *   - `MAKINA_SETUP_REAL_APP_ID` — numeric App id.
+ *   - `MAKINA_SETUP_REAL_PRIVATE_KEY_PATH` — absolute path to the App's
+ *     PEM private key. The test does **not** expand `~/` here; pass the
+ *     literal path the runtime user can read.
+ *   - `MAKINA_SETUP_REAL_EXPECTED_REPO` — `<owner>/<repo>` slug the
+ *     developer's sandbox install grants access to. The test asserts
+ *     it shows up in the discovered list. Optional; if unset the test
+ *     only asserts that *some* installation surfaced.
+ *
+ * The test invokes the production
+ * {@link createWizardGitHubClient} (no scripted doubles), exercising
+ * the full wire path: `@octokit/auth-app` mints a JWT, we call
+ * `GET /app/installations`, and for each installation we call
+ * `GET /installation/repositories`. A successful run proves the wiring
+ * is end-to-end functional against real GitHub. The test does not
+ * write a `config.json` — that branch is owned by the integration
+ * test in `tests/integration/setup_wizard_test.ts` which uses the
+ * scripted client.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+
+import { createWizardGitHubClient } from "../../src/config/wizard-github-client.ts";
+
+const GATE_VAR = "MAKINA_SETUP_REAL_TEST";
+const APP_ID_VAR = "MAKINA_SETUP_REAL_APP_ID";
+const KEY_PATH_VAR = "MAKINA_SETUP_REAL_PRIVATE_KEY_PATH";
+const EXPECTED_REPO_VAR = "MAKINA_SETUP_REAL_EXPECTED_REPO";
+
+function gateActive(): boolean {
+  return Deno.env.get(GATE_VAR) === "1";
+}
+
+Deno.test({
+  name: "setup wizard: real GitHub App auth lists installations + repos",
+  ignore: !gateActive(),
+  async fn() {
+    const rawAppId = Deno.env.get(APP_ID_VAR);
+    const keyPath = Deno.env.get(KEY_PATH_VAR);
+    const expectedRepo = Deno.env.get(EXPECTED_REPO_VAR);
+    assert(
+      rawAppId !== undefined && rawAppId.length > 0,
+      `${GATE_VAR}=1 requires ${APP_ID_VAR} (the App's numeric id).`,
+    );
+    assert(
+      keyPath !== undefined && keyPath.length > 0,
+      `${GATE_VAR}=1 requires ${KEY_PATH_VAR} (absolute PEM path).`,
+    );
+    const appId = Number.parseInt(rawAppId, 10);
+    assert(
+      Number.isInteger(appId) && appId > 0,
+      `${APP_ID_VAR} must be a positive integer; got ${JSON.stringify(rawAppId)}`,
+    );
+
+    const client = createWizardGitHubClient();
+    const installations = await client.getInstallations({
+      appId,
+      privateKeyPath: keyPath,
+    });
+
+    assert(
+      installations.length > 0,
+      "expected at least one installation for the configured App; got zero",
+    );
+    if (expectedRepo !== undefined && expectedRepo.length > 0) {
+      const allRepos = installations.flatMap((installation) => installation.repositories);
+      assertEquals(
+        allRepos.includes(expectedRepo),
+        true,
+        `expected ${expectedRepo} to appear among ${JSON.stringify(allRepos)}`,
+      );
+    }
+  },
+});

--- a/tests/unit/app_client_test.ts
+++ b/tests/unit/app_client_test.ts
@@ -4,10 +4,10 @@
  * The AppClient is the App-level companion to the installation-scoped
  * `GitHubClientImpl`. These tests cover:
  *
- *   1. **`listAppInstallations` happy path** — sends a GET to
- *      `/app/installations` with the JWT minted by the injected auth
- *      strategy and projects the response into the typed
- *      `AppInstallation[]` shape.
+ *   1. **`listAppInstallations` happy path + pagination** — sends a GET
+ *      to `/app/installations` with the JWT minted by the injected auth
+ *      strategy, walks pages until a short page is observed, and
+ *      projects the response into the typed `AppInstallation[]` shape.
  *   2. **`listInstallationRepositories` happy path + pagination** —
  *      mints an installation token, GETs `/installation/repositories`,
  *      and walks pages until a short page is returned.
@@ -17,6 +17,9 @@
  *      response, missing fields) surface as `GitHubAppClientError`.
  *   5. **HTTP failure propagation** — a 5xx from GitHub propagates as
  *      `GitHubAppClientError` with the original Octokit error on `cause`.
+ *   6. **Pagination-overflow regression** — both paginating loops throw
+ *      `GitHubAppClientError("pagination-overflow", ...)` when their
+ *      respective MAX_PAGES caps are hit without a short page.
  *
  * No real network or JWT signing happens: the tests inject a scripted
  * `fetch` (Octokit's `request: { fetch }` test seam) and a stub auth
@@ -28,6 +31,8 @@ import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import {
   APP_INSTALLATION_REPOSITORIES_MAX_PAGES,
   APP_INSTALLATION_REPOSITORIES_PAGE_SIZE,
+  APP_INSTALLATIONS_MAX_PAGES,
+  APP_INSTALLATIONS_PAGE_SIZE,
 } from "../../src/constants.ts";
 import {
   type AppClientAuthStrategy,
@@ -188,10 +193,15 @@ Deno.test("listAppInstallations: happy path projects /app/installations payload"
   assertEquals(authCalls[0]?.type, "app");
 
   // The request hit `/app/installations` with the JWT as a Bearer token.
+  // Octokit serialises `per_page` and `page` as query params on a GET; the
+  // 2-installation payload is short, so the loop terminates after one page.
   assertEquals(harness.recordedRequests.length, 1);
   const recorded = harness.recordedRequests[0];
   assertEquals(recorded?.method, "GET");
-  assertEquals(recorded?.url, "https://api.github.com/app/installations");
+  assertEquals(
+    recorded?.url,
+    "https://api.github.com/app/installations?per_page=100&page=1",
+  );
   assertEquals(recorded?.headers["authorization"], "Bearer jwt-token");
 });
 
@@ -285,7 +295,7 @@ Deno.test("listAppInstallations: forwards a custom baseUrl to Octokit", async ()
   const recorded = harness.recordedRequests[0];
   assertEquals(
     recorded?.url,
-    "https://ghe.example.com/api/v3/app/installations",
+    "https://ghe.example.com/api/v3/app/installations?per_page=100&page=1",
   );
 });
 
@@ -345,6 +355,86 @@ Deno.test("listAppInstallations: auth-hook rejection propagates as mintAppJwt er
   );
   assertEquals(error.operation, "mintAppJwt");
   assertEquals(harness.recordedRequests.length, 0);
+});
+
+Deno.test("listAppInstallations: paginates until a short page", async () => {
+  // Build a first page of exactly PAGE_SIZE installations, then a short
+  // second page. The aggregator should stitch them in order without ever
+  // requesting a third page.
+  const harness = new FakeFetchHarness();
+  const fullPage = Array.from(
+    { length: APP_INSTALLATIONS_PAGE_SIZE },
+    (_value, index) => ({ id: index + 1, account: { login: `org-${index}` } }),
+  );
+  harness.enqueueResponse(200, fullPage);
+  harness.enqueueResponse(200, [
+    { id: 9001, account: { login: "tail-org" } },
+    { id: 9002, account: { login: "tail-org-2" } },
+  ]);
+  const { strategy, authCalls } = createStubStrategy();
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    fetch: harness.fetch,
+  });
+
+  const installations = await client.listAppInstallations();
+  assertEquals(installations.length, APP_INSTALLATIONS_PAGE_SIZE + 2);
+  assertEquals(installations[0]?.id, 1);
+  assertEquals(installations[0]?.accountLogin, "org-0");
+  assertEquals(
+    installations[APP_INSTALLATIONS_PAGE_SIZE - 1]?.id,
+    APP_INSTALLATIONS_PAGE_SIZE,
+  );
+  assertEquals(installations[APP_INSTALLATIONS_PAGE_SIZE]?.id, 9001);
+  assertEquals(installations[APP_INSTALLATIONS_PAGE_SIZE + 1]?.id, 9002);
+
+  // The App JWT was minted exactly once and reused across both page fetches.
+  assertEquals(authCalls.length, 1);
+  assertEquals(authCalls[0]?.type, "app");
+
+  assertEquals(harness.recordedRequests.length, 2);
+  assertEquals(
+    harness.recordedRequests[0]?.url,
+    "https://api.github.com/app/installations?per_page=100&page=1",
+  );
+  assertEquals(
+    harness.recordedRequests[1]?.url,
+    "https://api.github.com/app/installations?per_page=100&page=2",
+  );
+});
+
+Deno.test("listAppInstallations: rejects with pagination-overflow when MAX_PAGES is reached without a short page", async () => {
+  // Regression: an App that returns a full page on every request for
+  // `APP_INSTALLATIONS_MAX_PAGES` consecutive pages used to silently
+  // truncate the installation list once the loop hit the cap. We now throw
+  // a `pagination-overflow` `GitHubAppClientError` so the wizard surfaces
+  // the incomplete enumeration instead of presenting a partial picker.
+  const harness = new FakeFetchHarness();
+  const fullPage = Array.from(
+    { length: APP_INSTALLATIONS_PAGE_SIZE },
+    (_value, index) => ({ id: index + 1, account: { login: `org-${index}` } }),
+  );
+  for (let page = 1; page <= APP_INSTALLATIONS_MAX_PAGES; page += 1) {
+    harness.enqueueResponse(200, fullPage);
+  }
+  const { strategy } = createStubStrategy();
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    fetch: harness.fetch,
+  });
+
+  const error = await assertRejects(
+    () => client.listAppInstallations(),
+    GitHubAppClientError,
+  );
+  assertEquals(error.operation, "pagination-overflow");
+  // The wrapped cause names the cap so logs are scannable.
+  assertStringIncludes(error.message, String(APP_INSTALLATIONS_MAX_PAGES));
+  // Every page-budget request was issued before the overflow fired —
+  // we did not bail early on a transient short read.
+  assertEquals(harness.recordedRequests.length, APP_INSTALLATIONS_MAX_PAGES);
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/app_client_test.ts
+++ b/tests/unit/app_client_test.ts
@@ -23,8 +23,12 @@
  * strategy that returns deterministic tokens.
  */
 
-import { assertEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 
+import {
+  APP_INSTALLATION_REPOSITORIES_MAX_PAGES,
+  APP_INSTALLATION_REPOSITORIES_PAGE_SIZE,
+} from "../../src/constants.ts";
 import {
   type AppClientAuthStrategy,
   createAppClient,
@@ -571,4 +575,51 @@ Deno.test("listInstallationRepositories: hook rejection propagates as mintInstal
   );
   assertEquals(error.operation, "mintInstallationToken");
   assertEquals(harness.recordedRequests.length, 0);
+});
+
+Deno.test("listInstallationRepositories: rejects with pagination-overflow when MAX_PAGES is reached without a short page", async () => {
+  // Regression: an installation that returns a full page on every request
+  // for `APP_INSTALLATION_REPOSITORIES_MAX_PAGES` consecutive pages used to
+  // silently truncate the repository list once the loop hit the cap. We now
+  // throw a `pagination-overflow` `GitHubAppClientError` so the wizard
+  // surfaces the incomplete enumeration instead of presenting a partial
+  // picker.
+  const harness = new FakeFetchHarness();
+  // A single shared full page reused for every response: the harness only
+  // serialises this once per enqueue, but it keeps the test cheap because
+  // every page is structurally identical.
+  const fullPage = Array.from(
+    { length: APP_INSTALLATION_REPOSITORIES_PAGE_SIZE },
+    (_value, index) => ({ name: `repo-${index}`, owner: { login: "org" } }),
+  );
+  for (let page = 1; page <= APP_INSTALLATION_REPOSITORIES_MAX_PAGES; page += 1) {
+    harness.enqueueResponse(200, {
+      total_count: APP_INSTALLATION_REPOSITORIES_MAX_PAGES *
+        APP_INSTALLATION_REPOSITORIES_PAGE_SIZE,
+      repositories: fullPage,
+    });
+  }
+  const { strategy } = createStubStrategy();
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    fetch: harness.fetch,
+  });
+
+  const error = await assertRejects(
+    () => client.listInstallationRepositories(42),
+    GitHubAppClientError,
+  );
+  assertEquals(error.operation, "pagination-overflow");
+  // The wrapped cause names the cap so logs are scannable.
+  assertStringIncludes(
+    error.message,
+    String(APP_INSTALLATION_REPOSITORIES_MAX_PAGES),
+  );
+  // Every page-budget request was issued before the overflow fired —
+  // we did not bail early on a transient short read.
+  assertEquals(
+    harness.recordedRequests.length,
+    APP_INSTALLATION_REPOSITORIES_MAX_PAGES,
+  );
 });

--- a/tests/unit/app_client_test.ts
+++ b/tests/unit/app_client_test.ts
@@ -1,0 +1,574 @@
+/**
+ * Unit tests for `src/github/app-client.ts`.
+ *
+ * The AppClient is the App-level companion to the installation-scoped
+ * `GitHubClientImpl`. These tests cover:
+ *
+ *   1. **`listAppInstallations` happy path** — sends a GET to
+ *      `/app/installations` with the JWT minted by the injected auth
+ *      strategy and projects the response into the typed
+ *      `AppInstallation[]` shape.
+ *   2. **`listInstallationRepositories` happy path + pagination** —
+ *      mints an installation token, GETs `/installation/repositories`,
+ *      and walks pages until a short page is returned.
+ *   3. **Auth failure propagation** — anything thrown by the strategy
+ *      (factory or hook) surfaces as a `GitHubAppClientError`.
+ *   4. **Projection failure propagation** — malformed payloads (non-array
+ *      response, missing fields) surface as `GitHubAppClientError`.
+ *   5. **HTTP failure propagation** — a 5xx from GitHub propagates as
+ *      `GitHubAppClientError` with the original Octokit error on `cause`.
+ *
+ * No real network or JWT signing happens: the tests inject a scripted
+ * `fetch` (Octokit's `request: { fetch }` test seam) and a stub auth
+ * strategy that returns deterministic tokens.
+ */
+
+import { assertEquals, assertRejects } from "@std/assert";
+
+import {
+  type AppClientAuthStrategy,
+  createAppClient,
+  GitHubAppClientError,
+} from "../../src/github/app-client.ts";
+
+interface RecordedRequest {
+  readonly url: string;
+  readonly method: string;
+  readonly headers: Record<string, string>;
+  readonly body: string | null;
+}
+
+/**
+ * Per-test scripted fetch harness. Mirrors the shape used by the
+ * installation-scoped client tests (`tests/unit/github_client_test.ts`)
+ * but stays local to this module — the AppClient does not need the
+ * sleep/now hooks the rate-limit retry harness exposes.
+ */
+class FakeFetchHarness {
+  readonly recordedRequests: RecordedRequest[] = [];
+  private readonly responseQueue: Array<() => Promise<Response>> = [];
+
+  enqueueResponse(
+    status: number,
+    body: unknown,
+    options: { headers?: Record<string, string> } = {},
+  ): void {
+    this.responseQueue.push(() => {
+      const headers = new Headers({
+        "content-type": "application/json",
+        ...(options.headers ?? {}),
+      });
+      return Promise.resolve(
+        new Response(JSON.stringify(body), { status, headers }),
+      );
+    });
+  }
+
+  fetch: typeof fetch = (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.toString()
+      : input.url;
+    const method = init?.method ??
+      (typeof input !== "string" && !(input instanceof URL) ? input.method : "GET");
+    const headersIn = new Headers(init?.headers ?? {});
+    const headers: Record<string, string> = {};
+    headersIn.forEach((value, key) => {
+      headers[key.toLowerCase()] = value;
+    });
+    const bodyRaw = init?.body;
+    const body: string | null = typeof bodyRaw === "string" ? bodyRaw : null;
+    this.recordedRequests.push({ url, method: method ?? "GET", headers, body });
+    const next = this.responseQueue.shift();
+    if (next === undefined) {
+      throw new Error(`FakeFetchHarness: no scripted response for ${method} ${url}`);
+    }
+    return next();
+  };
+}
+
+/**
+ * Build a deterministic stub strategy that mints `{ token: "jwt-..." }`
+ * for App-mode and `{ token: "install-<id>" }` for installation-mode.
+ *
+ * `authCalls` records every invocation so the assertion can verify the
+ * AppClient demanded the right token type at the right boundary.
+ */
+function createStubStrategy(): {
+  strategy: AppClientAuthStrategy;
+  authCalls: Array<
+    { type: "app" } | { type: "installation"; installationId: number; refresh: true }
+  >;
+  factoryCalls: Array<{ appId: number; privateKey: string }>;
+} {
+  const authCalls: Array<
+    { type: "app" } | { type: "installation"; installationId: number; refresh: true }
+  > = [];
+  const factoryCalls: Array<{ appId: number; privateKey: string }> = [];
+  const strategy: AppClientAuthStrategy = (factoryOpts) => {
+    factoryCalls.push({
+      appId: factoryOpts.appId,
+      privateKey: factoryOpts.privateKey,
+    });
+    function hook(options: { readonly type: "app" }): Promise<{ token: string }>;
+    function hook(options: {
+      readonly type: "installation";
+      readonly installationId: number;
+      readonly refresh: true;
+    }): Promise<{ token: string }>;
+    function hook(
+      options:
+        | { readonly type: "app" }
+        | {
+          readonly type: "installation";
+          readonly installationId: number;
+          readonly refresh: true;
+        },
+    ): Promise<{ token: string }> {
+      if (options.type === "app") {
+        authCalls.push({ type: "app" });
+        return Promise.resolve({ token: "jwt-token" });
+      }
+      authCalls.push({
+        type: "installation",
+        installationId: options.installationId,
+        refresh: options.refresh,
+      });
+      return Promise.resolve({ token: `install-${options.installationId}` });
+    }
+    return hook;
+  };
+  return { strategy, authCalls, factoryCalls };
+}
+
+const COMMON_OPTS = {
+  appId: 1234,
+  privateKey: "-----BEGIN RSA PRIVATE KEY-----\nstub\n-----END RSA PRIVATE KEY-----",
+} as const;
+
+// ---------------------------------------------------------------------------
+// listAppInstallations
+// ---------------------------------------------------------------------------
+
+Deno.test("listAppInstallations: happy path projects /app/installations payload", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, [
+    { id: 9876543, account: { login: "octocat" } },
+    { id: 12345, account: { login: "myorg" } },
+  ]);
+  const { strategy, authCalls, factoryCalls } = createStubStrategy();
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    fetch: harness.fetch,
+  });
+
+  const installations = await client.listAppInstallations();
+
+  assertEquals(installations.length, 2);
+  assertEquals(installations[0]?.id, 9876543);
+  assertEquals(installations[0]?.accountLogin, "octocat");
+  assertEquals(installations[1]?.id, 12345);
+  assertEquals(installations[1]?.accountLogin, "myorg");
+
+  // The factory was called once with the App credentials.
+  assertEquals(factoryCalls.length, 1);
+  assertEquals(factoryCalls[0]?.appId, 1234);
+
+  // The hook was asked for an App JWT exactly once.
+  assertEquals(authCalls.length, 1);
+  assertEquals(authCalls[0]?.type, "app");
+
+  // The request hit `/app/installations` with the JWT as a Bearer token.
+  assertEquals(harness.recordedRequests.length, 1);
+  const recorded = harness.recordedRequests[0];
+  assertEquals(recorded?.method, "GET");
+  assertEquals(recorded?.url, "https://api.github.com/app/installations");
+  assertEquals(recorded?.headers["authorization"], "Bearer jwt-token");
+});
+
+Deno.test("listAppInstallations: tolerates installations with missing account login", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, [
+    { id: 1, account: null },
+    { id: 2 },
+    { id: 3, account: { login: "named" } },
+  ]);
+  const { strategy } = createStubStrategy();
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    fetch: harness.fetch,
+  });
+
+  const installations = await client.listAppInstallations();
+  assertEquals(installations.length, 3);
+  assertEquals(installations[0]?.id, 1);
+  assertEquals(installations[0]?.accountLogin, undefined);
+  assertEquals(installations[1]?.id, 2);
+  assertEquals(installations[1]?.accountLogin, undefined);
+  assertEquals(installations[2]?.accountLogin, "named");
+});
+
+Deno.test("listAppInstallations: rejects a non-array payload as projection error", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, { not: "an array" });
+  const { strategy } = createStubStrategy();
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    fetch: harness.fetch,
+  });
+
+  const error = await assertRejects(
+    () => client.listAppInstallations(),
+    GitHubAppClientError,
+  );
+  assertEquals(error.operation, "projectInstallations");
+});
+
+Deno.test("listAppInstallations: non-object installation entry rejects with projection error", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, [42]);
+  const { strategy } = createStubStrategy();
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    fetch: harness.fetch,
+  });
+
+  const error = await assertRejects(
+    () => client.listAppInstallations(),
+    GitHubAppClientError,
+  );
+  assertEquals(error.operation, "projectInstallations");
+});
+
+Deno.test("listAppInstallations: missing numeric id rejects with descriptive error", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, [{ account: { login: "octocat" } }]);
+  const { strategy } = createStubStrategy();
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    fetch: harness.fetch,
+  });
+
+  const error = await assertRejects(
+    () => client.listAppInstallations(),
+    GitHubAppClientError,
+  );
+  assertEquals(error.operation, "projectInstallations");
+});
+
+Deno.test("listAppInstallations: forwards a custom baseUrl to Octokit", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, []);
+  const { strategy } = createStubStrategy();
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    fetch: harness.fetch,
+    baseUrl: "https://ghe.example.com/api/v3",
+  });
+
+  await client.listAppInstallations();
+  assertEquals(harness.recordedRequests.length, 1);
+  const recorded = harness.recordedRequests[0];
+  assertEquals(
+    recorded?.url,
+    "https://ghe.example.com/api/v3/app/installations",
+  );
+});
+
+Deno.test("listAppInstallations: 500 propagates as GitHubAppClientError(listAppInstallations)", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(500, { message: "boom" });
+  const { strategy } = createStubStrategy();
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    fetch: harness.fetch,
+  });
+
+  const error = await assertRejects(
+    () => client.listAppInstallations(),
+    GitHubAppClientError,
+  );
+  assertEquals(error.operation, "listAppInstallations");
+});
+
+Deno.test("listAppInstallations: auth-strategy factory failure propagates as createAppAuth error", () => {
+  const failingStrategy: AppClientAuthStrategy = () => {
+    throw new Error("private key parse failed");
+  };
+  let caught: unknown;
+  try {
+    createAppClient({
+      ...COMMON_OPTS,
+      createAppAuthStrategy: failingStrategy,
+    });
+  } catch (error) {
+    caught = error;
+  }
+  if (!(caught instanceof GitHubAppClientError)) {
+    throw new Error(
+      `expected GitHubAppClientError, got ${caught instanceof Error ? caught.message : caught}`,
+    );
+  }
+  assertEquals(caught.operation, "createAppAuth");
+});
+
+Deno.test("listAppInstallations: auth-hook rejection propagates as mintAppJwt error", async () => {
+  const harness = new FakeFetchHarness();
+  // Don't enqueue a fetch response — the call should fail at JWT minting.
+  const failingStrategy: AppClientAuthStrategy = () => {
+    return () => Promise.reject(new Error("clock skew exceeded"));
+  };
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: failingStrategy,
+    fetch: harness.fetch,
+  });
+
+  const error = await assertRejects(
+    () => client.listAppInstallations(),
+    GitHubAppClientError,
+  );
+  assertEquals(error.operation, "mintAppJwt");
+  assertEquals(harness.recordedRequests.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// listInstallationRepositories
+// ---------------------------------------------------------------------------
+
+Deno.test("listInstallationRepositories: happy path projects single-page payload", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, {
+    total_count: 2,
+    repositories: [
+      { name: "makina", owner: { login: "koraytaylan" } },
+      { name: "other", owner: { login: "koraytaylan" } },
+    ],
+  });
+  const { strategy, authCalls } = createStubStrategy();
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    fetch: harness.fetch,
+  });
+
+  const repos = await client.listInstallationRepositories(9876543);
+  assertEquals(repos.length, 2);
+  assertEquals(repos[0]?.owner, "koraytaylan");
+  assertEquals(repos[0]?.name, "makina");
+  assertEquals(repos[1]?.name, "other");
+
+  // The hook was asked for an installation token (with `refresh: true`).
+  assertEquals(authCalls.length, 1);
+  assertEquals(authCalls[0], {
+    type: "installation",
+    installationId: 9876543,
+    refresh: true,
+  });
+
+  assertEquals(harness.recordedRequests.length, 1);
+  const recorded = harness.recordedRequests[0];
+  assertEquals(recorded?.method, "GET");
+  // Octokit serialises `per_page` and `page` as query params on a GET.
+  assertEquals(
+    recorded?.url,
+    "https://api.github.com/installation/repositories?per_page=100&page=1",
+  );
+  assertEquals(recorded?.headers["authorization"], "token install-9876543");
+});
+
+Deno.test("listInstallationRepositories: paginates until a short page", async () => {
+  const harness = new FakeFetchHarness();
+  // Build a first page of exactly 100 repos, then a short second page.
+  const fullPage = Array.from({ length: 100 }, (_value, index) => ({
+    name: `repo-${index}`,
+    owner: { login: "org" },
+  }));
+  harness.enqueueResponse(200, { total_count: 102, repositories: fullPage });
+  harness.enqueueResponse(200, {
+    total_count: 102,
+    repositories: [
+      { name: "tail-1", owner: { login: "org" } },
+      { name: "tail-2", owner: { login: "org" } },
+    ],
+  });
+  const { strategy } = createStubStrategy();
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    fetch: harness.fetch,
+  });
+
+  const repos = await client.listInstallationRepositories(42);
+  assertEquals(repos.length, 102);
+  assertEquals(repos[0]?.name, "repo-0");
+  assertEquals(repos[99]?.name, "repo-99");
+  assertEquals(repos[100]?.name, "tail-1");
+  assertEquals(repos[101]?.name, "tail-2");
+
+  assertEquals(harness.recordedRequests.length, 2);
+  assertEquals(
+    harness.recordedRequests[0]?.url,
+    "https://api.github.com/installation/repositories?per_page=100&page=1",
+  );
+  assertEquals(
+    harness.recordedRequests[1]?.url,
+    "https://api.github.com/installation/repositories?per_page=100&page=2",
+  );
+});
+
+Deno.test("listInstallationRepositories: empty installation returns empty array", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, { total_count: 0, repositories: [] });
+  const { strategy } = createStubStrategy();
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    fetch: harness.fetch,
+  });
+
+  const repos = await client.listInstallationRepositories(42);
+  assertEquals(repos.length, 0);
+  assertEquals(harness.recordedRequests.length, 1);
+});
+
+Deno.test("listInstallationRepositories: malformed envelope rejects as projectRepositories error", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, { not_repositories: [] });
+  const { strategy } = createStubStrategy();
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    fetch: harness.fetch,
+  });
+
+  const error = await assertRejects(
+    () => client.listInstallationRepositories(42),
+    GitHubAppClientError,
+  );
+  assertEquals(error.operation, "projectRepositories");
+});
+
+Deno.test("listInstallationRepositories: scalar repositories envelope rejects with projection error", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, "not an envelope");
+  const { strategy } = createStubStrategy();
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    fetch: harness.fetch,
+  });
+
+  const error = await assertRejects(
+    () => client.listInstallationRepositories(42),
+    GitHubAppClientError,
+  );
+  assertEquals(error.operation, "projectRepositories");
+});
+
+Deno.test("listInstallationRepositories: non-object repository entry rejects with projection error", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, {
+    total_count: 1,
+    repositories: [42],
+  });
+  const { strategy } = createStubStrategy();
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    fetch: harness.fetch,
+  });
+
+  const error = await assertRejects(
+    () => client.listInstallationRepositories(42),
+    GitHubAppClientError,
+  );
+  assertEquals(error.operation, "projectRepositories");
+});
+
+Deno.test("listInstallationRepositories: missing repository name rejects with descriptive error", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, {
+    total_count: 1,
+    repositories: [{ owner: { login: "octocat" } }],
+  });
+  const { strategy } = createStubStrategy();
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    fetch: harness.fetch,
+  });
+
+  const error = await assertRejects(
+    () => client.listInstallationRepositories(42),
+    GitHubAppClientError,
+  );
+  assertEquals(error.operation, "projectRepositories");
+});
+
+Deno.test("listInstallationRepositories: missing owner.login rejects with descriptive error", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(200, {
+    total_count: 1,
+    repositories: [{ name: "broken", owner: null }],
+  });
+  const { strategy } = createStubStrategy();
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    fetch: harness.fetch,
+  });
+
+  const error = await assertRejects(
+    () => client.listInstallationRepositories(42),
+    GitHubAppClientError,
+  );
+  assertEquals(error.operation, "projectRepositories");
+});
+
+Deno.test("listInstallationRepositories: 500 propagates as listInstallationRepositories error", async () => {
+  const harness = new FakeFetchHarness();
+  harness.enqueueResponse(500, { message: "internal" });
+  const { strategy } = createStubStrategy();
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: strategy,
+    fetch: harness.fetch,
+  });
+
+  const error = await assertRejects(
+    () => client.listInstallationRepositories(42),
+    GitHubAppClientError,
+  );
+  assertEquals(error.operation, "listInstallationRepositories");
+});
+
+Deno.test("listInstallationRepositories: hook rejection propagates as mintInstallationToken error", async () => {
+  const harness = new FakeFetchHarness();
+  const failingStrategy: AppClientAuthStrategy = () => {
+    return () => Promise.reject(new Error("invalid installation"));
+  };
+  const client = createAppClient({
+    ...COMMON_OPTS,
+    createAppAuthStrategy: failingStrategy,
+    fetch: harness.fetch,
+  });
+
+  const error = await assertRejects(
+    () => client.listInstallationRepositories(42),
+    GitHubAppClientError,
+  );
+  assertEquals(error.operation, "mintInstallationToken");
+  assertEquals(harness.recordedRequests.length, 0);
+});

--- a/tests/unit/wizard_github_client_test.ts
+++ b/tests/unit/wizard_github_client_test.ts
@@ -1,0 +1,230 @@
+/**
+ * Unit tests for `src/config/wizard-github-client.ts`.
+ *
+ * The adapter bridges the wizard's narrow
+ * {@link WizardGitHubClient} interface to the App-level
+ * {@link AppClient}. These tests exercise:
+ *
+ *   1. **Happy path** — the adapter reads the private key from the
+ *      injected reader, constructs an AppClient with the prompted
+ *      credentials, calls `listAppInstallations` once and
+ *      `listInstallationRepositories` once per installation, and
+ *      projects the join into the `WizardInstallation[]` shape.
+ *   2. **Empty installation** — an installation with no accessible
+ *      repos surfaces as `WizardInstallation { repositories: [] }`,
+ *      not as a hidden installation.
+ *   3. **Disk read failure** — a thrown {@link Deno.errors.NotFound}
+ *      is rewrapped as a {@link SetupWizardError} so the wizard's
+ *      `setup` subcommand prints a tidy single-line diagnostic.
+ *   4. **AppClient projection failure** — a
+ *      {@link GitHubAppClientError} from the AppClient propagates
+ *      through (the wizard's outer catch block in
+ *      `fetchInstallations` wraps it as `SetupWizardError`).
+ *
+ * No real disk or network IO happens: both collaborators are
+ * injectable, so the tests hand in scripted in-memory doubles.
+ */
+
+import { assertEquals, assertRejects } from "@std/assert";
+
+import { type AppClient, GitHubAppClientError } from "../../src/github/app-client.ts";
+import { createWizardGitHubClient } from "../../src/config/wizard-github-client.ts";
+import { SetupWizardError } from "../../src/config/setup-wizard.ts";
+
+interface ScriptedAppClientCalls {
+  readonly factoryArgs: Array<{ appId: number; privateKey: string }>;
+  readonly listInstallationsCalls: number;
+  readonly listRepositoriesCalls: number[];
+}
+
+interface ScriptedAppClientOptions {
+  readonly installations?: Array<{
+    readonly id: number;
+    readonly accountLogin?: string;
+  }>;
+  readonly repositoriesPerInstallation?: Record<
+    number,
+    Array<{ readonly owner: string; readonly name: string }>
+  >;
+  readonly listInstallationsError?: Error;
+  readonly listRepositoriesError?: Error;
+}
+
+function buildScriptedAppClient(opts: ScriptedAppClientOptions): {
+  client: AppClient;
+  calls: ScriptedAppClientCalls;
+  factoryArgs: Array<{ appId: number; privateKey: string }>;
+} {
+  const factoryArgs: Array<{ appId: number; privateKey: string }> = [];
+  let listInstallationsCalls = 0;
+  const listRepositoriesCalls: number[] = [];
+
+  const client: AppClient = {
+    listAppInstallations() {
+      listInstallationsCalls += 1;
+      if (opts.listInstallationsError !== undefined) {
+        return Promise.reject(opts.listInstallationsError);
+      }
+      return Promise.resolve(opts.installations ?? []);
+    },
+    listInstallationRepositories(installationId) {
+      listRepositoriesCalls.push(installationId);
+      if (opts.listRepositoriesError !== undefined) {
+        return Promise.reject(opts.listRepositoriesError);
+      }
+      const repos = opts.repositoriesPerInstallation?.[installationId] ?? [];
+      return Promise.resolve(repos);
+    },
+  };
+
+  return {
+    client,
+    factoryArgs,
+    calls: {
+      get factoryArgs() {
+        return factoryArgs;
+      },
+      get listInstallationsCalls() {
+        return listInstallationsCalls;
+      },
+      get listRepositoriesCalls() {
+        return listRepositoriesCalls;
+      },
+    },
+  };
+}
+
+Deno.test("createWizardGitHubClient: happy path projects installations + repos", async () => {
+  const { client: appClient, calls, factoryArgs } = buildScriptedAppClient({
+    installations: [
+      { id: 9876543, accountLogin: "octocat" },
+      { id: 12345, accountLogin: "myorg" },
+    ],
+    repositoriesPerInstallation: {
+      9876543: [
+        { owner: "octocat", name: "makina" },
+        { owner: "octocat", name: "other" },
+      ],
+      12345: [
+        { owner: "myorg", name: "service-a" },
+      ],
+    },
+  });
+
+  let readKeyCalls = 0;
+  const wizardClient = createWizardGitHubClient({
+    readKeyFile: (path: string) => {
+      readKeyCalls += 1;
+      assertEquals(path, "~/keys/app.pem");
+      return Promise.resolve("PEM-CONTENTS");
+    },
+    createClient: (opts) => {
+      factoryArgs.push({ appId: opts.appId, privateKey: opts.privateKey });
+      return appClient;
+    },
+  });
+
+  const installations = await wizardClient.getInstallations({
+    appId: 1234,
+    privateKeyPath: "~/keys/app.pem",
+  });
+
+  assertEquals(readKeyCalls, 1);
+  assertEquals(factoryArgs.length, 1);
+  assertEquals(factoryArgs[0]?.appId, 1234);
+  assertEquals(factoryArgs[0]?.privateKey, "PEM-CONTENTS");
+
+  assertEquals(calls.listInstallationsCalls, 1);
+  assertEquals(calls.listRepositoriesCalls, [9876543, 12345]);
+
+  assertEquals(installations.length, 2);
+  assertEquals(installations[0]?.installationId, 9876543);
+  assertEquals(installations[0]?.repositories, [
+    "octocat/makina",
+    "octocat/other",
+  ]);
+  assertEquals(installations[1]?.installationId, 12345);
+  assertEquals(installations[1]?.repositories, ["myorg/service-a"]);
+});
+
+Deno.test("createWizardGitHubClient: installation with no repositories surfaces as empty array", async () => {
+  const { client: appClient } = buildScriptedAppClient({
+    installations: [{ id: 1 }],
+    repositoriesPerInstallation: { 1: [] },
+  });
+  const wizardClient = createWizardGitHubClient({
+    readKeyFile: () => Promise.resolve("PEM"),
+    createClient: () => appClient,
+  });
+
+  const installations = await wizardClient.getInstallations({
+    appId: 1,
+    privateKeyPath: "/abs/path",
+  });
+
+  assertEquals(installations.length, 1);
+  assertEquals(installations[0]?.installationId, 1);
+  assertEquals(installations[0]?.repositories, []);
+});
+
+Deno.test("createWizardGitHubClient: zero installations returns empty array", async () => {
+  const { client: appClient } = buildScriptedAppClient({
+    installations: [],
+  });
+  const wizardClient = createWizardGitHubClient({
+    readKeyFile: () => Promise.resolve("PEM"),
+    createClient: () => appClient,
+  });
+
+  const installations = await wizardClient.getInstallations({
+    appId: 1,
+    privateKeyPath: "/abs/path",
+  });
+  assertEquals(installations.length, 0);
+});
+
+Deno.test("createWizardGitHubClient: disk read failure surfaces as SetupWizardError", async () => {
+  const { client: appClient } = buildScriptedAppClient({});
+  const wizardClient = createWizardGitHubClient({
+    readKeyFile: () => Promise.reject(new Deno.errors.NotFound("no such file")),
+    createClient: () => appClient,
+  });
+
+  const error = await assertRejects(
+    () =>
+      wizardClient.getInstallations({
+        appId: 1,
+        privateKeyPath: "~/missing.pem",
+      }),
+    SetupWizardError,
+  );
+  // The diagnostic includes both the path and the underlying reason so a
+  // user typing a bad path sees what went wrong without a stack trace.
+  assertEquals(error.message.includes("~/missing.pem"), true);
+  assertEquals(error.message.includes("no such file"), true);
+});
+
+Deno.test("createWizardGitHubClient: AppClient errors propagate verbatim", async () => {
+  const { client: appClient } = buildScriptedAppClient({
+    listInstallationsError: new GitHubAppClientError(
+      "listAppInstallations",
+      new Error("403 Bad credentials"),
+    ),
+  });
+  const wizardClient = createWizardGitHubClient({
+    readKeyFile: () => Promise.resolve("PEM"),
+    createClient: () => appClient,
+  });
+
+  // The wizard's outer catch wraps this as SetupWizardError with the
+  // message; here we just assert the typed error reaches the boundary.
+  const error = await assertRejects(
+    () =>
+      wizardClient.getInstallations({
+        appId: 1,
+        privateKeyPath: "/abs/key.pem",
+      }),
+    GitHubAppClientError,
+  );
+  assertEquals(error.operation, "listAppInstallations");
+});


### PR DESCRIPTION
## Summary

Closes #32. Replaces the `setup` branch's stub `WizardGitHubClient` (which threw "GitHub App auth not yet implemented") with a real implementation now that #4 has landed.

- Adds `src/github/app-client.ts` — `AppClient` (App-scoped companion to installation-scoped `GitHubClientImpl`). Mints a JWT via `@octokit/auth-app`, calls `GET /app/installations` and per-installation `GET /installation/repositories`, projects responses into typed surfaces with paginated repo listing. `GitHubAppClientError` matches the discriminated-error convention from `app-auth.ts`.
- Adds `src/config/wizard-github-client.ts` — wizard adapter that reads the PEM private key (with `~/` expansion), constructs an `AppClient`, joins the two endpoints into the `WizardInstallation[]` shape the wizard renders.
- Wires `createWizardGitHubClient()` into `main.ts`'s `setup` branch (replaces the stub).
- Documents the design in **ADR-024** (Option A: separate App-level client) and updates `docs/setup-github-app.md` to remove the "not yet implemented" note.

## Approach

**Option A** — separate `AppClient` companion to `GitHubClient`, kept the wizard logic clean and the App-level surface composable. Both layers reuse the `@octokit/auth-app` strategy seam so test patterns from `app_auth_test.ts` carry over.

## Tests

- `tests/unit/app_client_test.ts` — 19 tests via scripted Octokit `fetch`. Covers happy paths, pagination, projection failures, auth errors, custom baseUrl.
- `tests/unit/wizard_github_client_test.ts` — 5 tests exercising the adapter (happy path, empty installation, disk-read failure → `SetupWizardError`, AppClient error propagation).
- `tests/integration/setup_wizard_real_auth_test.ts` — gated by `MAKINA_SETUP_REAL_TEST=1`; reads `MAKINA_SETUP_REAL_APP_ID` / `_PRIVATE_KEY_PATH` / `_EXPECTED_REPO`. Ignored in CI.

Local CI: `deno task ci` passes (630 tests, 85.4% line / 90.1% branch coverage; gate 80%).

## Test plan

- [x] `deno fmt --check` clean
- [x] `deno lint` clean
- [x] `deno task doc:lint` clean
- [x] `deno check main.ts` clean
- [x] `deno task test:coverage` passes (gate 80%)
- [x] `deno task build:smoke` passes
- [ ] Smoke test against a real GitHub App: set `MAKINA_SETUP_REAL_TEST=1` and run the gated integration test (only the developer with real credentials can run this)

## Coordination note

This PR confines edits to the `setup` branch of `main.ts` plus new modules in `src/github/`, `src/config/`, `tests/`, and `docs/`. The sibling Wave 5 PR (#43, daemon wiring) edits the `daemon` branch of the same file and should not conflict.