### PR TITLE
feat(#19): end-to-end suite (env-gated) and final Wave 5 docs polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 > Agentic CLI that drives a GitHub issue end-to-end: implement, open the PR, request a Copilot
 > review, drive the PR to a stable mergeable state, then merge.
 
-**Status:** under construction. The skeleton, CI, release pipeline, and issue catalog are in place;
-feature work tracks the [open issues](https://github.com/koraytaylan/makina/issues).
+**Status:** Wave 5 complete. The daemon, TUI, supervisor, and stabilize loop are wired end-to-end;
+the v0.1.0 release is cut from `main`. Track future work via the
+[open issues](https://github.com/koraytaylan/makina/issues).
 
 ## Concept
 
@@ -35,16 +36,16 @@ See [`docs/architecture.md`](docs/architecture.md) for the full picture,
 
 ## Quick start
 
-> Not yet — the daemon and TUI are implemented in waves 1–4. Track progress on the
-> [milestones](https://github.com/koraytaylan/makina/milestones).
-
-When ready:
-
 ```bash
 deno install --allow-all --name makina --force https://raw.githubusercontent.com/koraytaylan/makina/main/main.ts
 makina setup     # one-time GitHub App + default repo configuration
 makina           # launch the TUI
 ```
+
+`makina setup` walks you through the GitHub App configuration, discovers the installations the App
+can see, and writes `config.json` to the platform-appropriate path (see
+[`docs/configuration.md`](docs/configuration.md)). After that, launching `makina` auto-spawns the
+daemon if it is not already running and connects the TUI; type `/issue <number>` and walk away.
 
 ## Development
 

--- a/deno.json
+++ b/deno.json
@@ -31,7 +31,7 @@
     "setup": "deno run -A main.ts setup",
     "test": "deno test -A --parallel",
     "test:coverage": "rm -rf cov cov.lcov && deno test -A --parallel --coverage=cov && deno coverage cov --lcov --output=cov.lcov && deno run -A scripts/check_coverage.ts cov.lcov 80",
-    "doc:lint": "deno doc --lint main.ts src/",
+    "doc:lint": "deno doc --lint main.ts src/ tests/e2e/",
     "doc:html": "deno doc --html --name=makina --output=docs/api main.ts src/",
     "build:smoke": "deno compile -A --output=/tmp/makina-smoke main.ts && /tmp/makina-smoke --version",
     "ci": "deno fmt --check && deno lint && deno task doc:lint && deno check main.ts && deno task test:coverage && deno task build:smoke"

--- a/docs/adrs/025-app-level-github-client-for-setup-wizard.md
+++ b/docs/adrs/025-app-level-github-client-for-setup-wizard.md
@@ -1,4 +1,4 @@
-# ADR-024: App-level GitHub client for the setup wizard
+# ADR-025: App-level GitHub client for the setup wizard
 
 ## Status
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,62 +1,75 @@
 # Architecture
 
-> Wave 1 contracts in place; daemon and TUI bodies implemented progressively across Waves 2–4.
+The contracts in `src/types.ts`, `src/ipc/protocol.ts`, and `src/config/schema.ts` are the
+foundation; the daemon, TUI, and the stabilize loop implement them. Every component is wired in
+production by `main.ts daemon` (see ADR-024).
 
 ## Process model
 
-Two cooperating processes communicate over a Unix domain socket using NDJSON:
+Two cooperating processes communicate over a Unix domain socket using a length-prefixed framed JSON
+wire format (`<decimal-length>\n<utf8-json>\n`, see `src/ipc/codec.ts`):
 
 - **`makina daemon`** — long-running supervisor. Owns agents, worktrees, GitHub App auth, polling,
-  and persisted state. Survives TUI exit. Lands in Waves 2–4.
+  and persisted state. Survives TUI exit; restarts replay persisted task projections.
 - **`makina`** (TUI) — Ink-based React app. Connects to the daemon over the socket; auto-spawns the
-  daemon when not running. Lands in Wave 2.
+  daemon when not running.
 
 `main.ts` is an argv-dispatch shell: `daemon`, `setup`, or default → TUI.
 
 ## Daemon internals
 
-| Component       | File                             | Wave | Purpose                                       |
-| --------------- | -------------------------------- | ---- | --------------------------------------------- |
-| TaskSupervisor  | `src/daemon/supervisor.ts`       | W3   | Per-issue state machine (see ADR-016).        |
-| Stabilize loop  | `src/daemon/stabilize.ts`        | W4   | Rebase → CI → conversations after every push. |
-| AgentRunner     | `src/daemon/agent-runner.ts`     | W3   | Wraps `@anthropic-ai/claude-agent-sdk`.       |
-| WorktreeManager | `src/daemon/worktree-manager.ts` | W2   | Bare clone + per-task worktrees.              |
-| GitHubClient    | `src/github/client.ts`           | W2   | High-level methods over `@octokit/core`.      |
-| Poller          | `src/daemon/poller.ts`           | W3   | Per-task polling with backoff.                |
-| Persistence     | `src/daemon/persistence.ts`      | W2   | Atomic JSON state store.                      |
-| EventBus        | `src/daemon/event-bus.ts`        | W2   | In-process pub/sub (see ADR-012).             |
-| Daemon server   | `src/daemon/server.ts`           | W2   | Unix socket listener + dispatch.              |
+| Component       | File                             | Purpose                                                     |
+| --------------- | -------------------------------- | ----------------------------------------------------------- |
+| TaskSupervisor  | `src/daemon/supervisor.ts`       | Per-issue state machine (see ADR-016).                      |
+| Stabilize loop  | `src/daemon/supervisor.ts`       | Rebase → CI → conversations sub-phases after each push.     |
+| AgentRunner     | `src/daemon/agent-runner.ts`     | Wraps `@anthropic-ai/claude-agent-sdk` (see ADR-015).       |
+| WorktreeManager | `src/daemon/worktree-manager.ts` | Bare clone + per-task worktrees (see ADR-007).              |
+| GitHubClient    | `src/github/client.ts`           | High-level methods over `@octokit/core` (see ADR-011).      |
+| Poller          | `src/daemon/poller.ts`           | Per-task polling with backoff (see ADR-017).                |
+| Persistence     | `src/daemon/persistence.ts`      | Atomic JSON state store (see ADR-014).                      |
+| EventBus        | `src/daemon/event-bus.ts`        | In-process pub/sub (see ADR-012).                           |
+| Daemon server   | `src/daemon/server.ts`           | Unix socket listener + dispatch (see ADR-013).              |
+| Handlers        | `src/daemon/handlers.ts`         | IPC `command`/`prompt` routing onto the supervisor surface. |
+| Runtime wiring  | `main.ts` (`wireDaemonRuntime`)  | Boot-time DI for all of the above (see ADR-024).            |
 
 ## TUI
 
-| Component                           | File                              | Wave |
-| ----------------------------------- | --------------------------------- | ---- |
-| `App`                               | `src/tui/App.tsx`                 | W2   |
-| `Header` / `MainPane` / `StatusBar` | `src/tui/components/`             | W2   |
-| `CommandPalette` / `TaskSwitcher`   | `src/tui/components/`             | W3   |
-| `useFocusedTask`                    | `src/tui/hooks/useFocusedTask.ts` | W3   |
-| Slash-command parser                | `src/tui/slash-command-parser.ts` | W3   |
-| Keybindings parser                  | `src/tui/keybindings.ts`          | W3   |
+| Component                           | File                              |
+| ----------------------------------- | --------------------------------- |
+| `App`                               | `src/tui/App.tsx`                 |
+| `Header` / `MainPane` / `StatusBar` | `src/tui/components/`             |
+| `CommandPalette` / `TaskSwitcher`   | `src/tui/components/`             |
+| `useFocusedTask`                    | `src/tui/hooks/useFocusedTask.ts` |
+| Slash-command parser                | `src/tui/slash-command-parser.ts` |
+| Keybindings parser                  | `src/tui/keybindings.ts`          |
 
-### Slash commands (W3)
+### Slash commands
 
 The command palette parses leading-`/` lines through `src/tui/slash-command-parser.ts` and
-dispatches the resulting `CommandPayload` over the daemon socket. Per-command lifecycle is handled
-by the wave that owns the feature; the parser only validates shape:
+dispatches the resulting `CommandPayload` over the daemon socket. The parser only validates shape;
+per-command behaviour lives in `src/daemon/handlers.ts` (which routes `command` envelopes onto
+`TaskSupervisor` methods).
 
-| Command                                 | Behaviour                               | Wave  |
-| --------------------------------------- | --------------------------------------- | ----- |
-| `/issue <number> [--repo <owner/name>]` | Start a new task.                       | W3-W4 |
-| `/repo {add\|default\|list}`            | Manage registered repositories.         | W3    |
-| `/status`                               | Print every in-flight task's state.     | W3    |
-| `/switch <task-id>`                     | Focus the listed task.                  | W3    |
-| `/cancel <task-id>`                     | Cancel a non-terminal task.             | W3    |
-| `/retry <task-id>`                      | Re-enter a `NEEDS_HUMAN` task.          | W3    |
-| `/merge <task-id>`                      | Force the merge of `READY_TO_MERGE`.    | W4    |
-| `/logs <task-id>`                       | Open the task scrollback.               | W3    |
-| `/quit`                                 | Exit the TUI; the daemon keeps running. | W3    |
-| `/daemon stop`                          | Stop the daemon process.                | W3    |
-| `/help [command]`                       | List commands or describe one.          | W3    |
+| Command                                             | Behaviour                               |
+| --------------------------------------------------- | --------------------------------------- |
+| `/issue <number> [--repo <owner/name>] [--merge=…]` | Start a new task.                       |
+| `/repo {add\|default\|list}`                        | Manage registered repositories.         |
+| `/status`                                           | Print every in-flight task's state.     |
+| `/switch <task-id>`                                 | Focus the listed task.                  |
+| `/cancel <task-id>`                                 | Cancel a non-terminal task.             |
+| `/retry <task-id>`                                  | Re-enter a `NEEDS_HUMAN` task.          |
+| `/merge <task-id>`                                  | Force the merge of `READY_TO_MERGE`.    |
+| `/logs <task-id>`                                   | Open the task scrollback.               |
+| `/quit`                                             | Exit the TUI; the daemon keeps running. |
+| `/daemon stop`                                      | Stop the daemon process.                |
+| `/help [command]`                                   | List commands or describe one.          |
+
+Today the supervisor wires `/issue`, `/merge`, and `/status`; the remaining commands are routed by
+the parser and handlers but the supervisor surface for `/cancel`, `/retry`, `/logs`, `/switch`,
+`/repo`, `/help`, `/quit`, and `/daemon` returns a deterministic
+`ack { ok: false, error: "not yet
+implemented" }`. Wiring those onto supervisor methods is tracked
+as v0.2.0 work.
 
 Default overlay toggles: `Ctrl+P` (palette), `Ctrl+G` (switcher); both are configurable via
 `tui.keybindings` in `config.json`. The chord parser in `src/tui/keybindings.ts` accepts
@@ -65,19 +78,19 @@ uniformly across macOS and Linux.
 
 ## IPC protocol
 
-Length-prefixed framed envelopes `{ id, type, payload }` with zod schemas in `src/ipc/protocol.ts`
-(Wave 1). Each frame is `<decimal-length>\n<utf8-json>\n`; the trailing newline keeps the wire
-format human-readable for ad-hoc tooling. The framer lives in `src/ipc/codec.ts` and rejects
-malformed frames (oversize, partial, schema-mismatched, non-UTF8) with a typed `IpcCodecError`.
-Client → Daemon: `subscribe`, `unsubscribe`, `command`, `prompt`, `ping`. Daemon → Client: `event`,
-`ack`, `pong`.
+Length-prefixed framed envelopes `{ id, type, payload }` with zod schemas in `src/ipc/protocol.ts`.
+Each frame is `<decimal-length>\n<utf8-json>\n`; the trailing newline keeps the wire format
+human-readable for ad-hoc tooling. The framer lives in `src/ipc/codec.ts` and rejects malformed
+frames (oversize, partial, schema-mismatched, non-UTF8) with a typed `IpcCodecError`. Client →
+Daemon: `subscribe`, `unsubscribe`, `command`, `prompt`, `ping`. Daemon → Client: `event`, `ack`,
+`pong`.
 
 Consumers do not import zod directly: `src/ipc/protocol.ts` exposes typed interfaces and a
 `parseEnvelope(raw): ParseEnvelopeResult` function; the same idiom in `src/config/schema.ts` exposes
 `parseConfig`. This keeps the public API zod-free so `deno doc --lint` reflects the contract, not
 the validator implementation.
 
-## TUI client (W2)
+## TUI client
 
 `src/tui/ipc-client.ts` exports a `DaemonClient` interface plus a `SocketDaemonClient` that opens a
 Unix-domain socket via `Deno.connect({ transport: "unix" })`, encodes outgoing envelopes through
@@ -91,9 +104,6 @@ in-memory double in tests with no other change.
 `idle → connecting → connected → disconnected | error`. The hook is transport-agnostic: a client
 without `connect`/`close` methods (the in-memory double) starts directly in `connected`.
 
-The Wave-2 shell is intentionally read-only. Wave 3 wires the command palette and task switcher;
-Wave 3 also turns the focused-task id into a real selection driven by the task-list component.
-
 ### Ink-on-Deno feasibility verdict (issue #10)
 
 Ink 5.2 renders cleanly under Deno 2.7 with `npm:ink`/`npm:react` specifiers. Yoga's WASM layer
@@ -103,3 +113,20 @@ ADR-001 risk is closed in favor of the original Deno-native plan; ADR-010 (Node-
 fallback) was not invoked. The single test-side caveat is that the Deno test sanitizer is strict
 about signal-listener leaks during interleaved Ink renders, so the App-level snapshot tests opt out
 of `sanitizeOps`/`sanitizeResources` (component-level tests keep both on).
+
+## End-to-end test suite
+
+`tests/e2e/` is gated by `MAKINA_E2E=1` and a small family of `MAKINA_E2E_*` environment variables
+naming the sandbox repo, GitHub App credentials, and per-scenario issue numbers (see
+`tests/e2e/_e2e_harness.ts`). When the gate is off the tests register cleanly and skip with a
+single-line note, so `deno task ci` continues to run on every push without a sandbox dependency.
+When the gate is on the harness spawns `main.ts daemon` against a synthetic `HOME`, drives the
+supervisor through real GitHub, and observes the FSM via the wildcard event subscription.
+
+Three scenarios cover the verification matrix:
+
+| Scenario         | File                                        | Asserts                                                                 |
+| ---------------- | ------------------------------------------- | ----------------------------------------------------------------------- |
+| Happy path       | `tests/e2e/happy_path_test.ts`              | `MERGED` without operator intervention.                                 |
+| CI-fail recovery | `tests/e2e/ci_fail_recovery_test.ts`        | `STABILIZING/CI` runs at least once, ≥ 2 iterations, lands in `MERGED`. |
+| Review-comment   | `tests/e2e/review_comment_recovery_test.ts` | `STABILIZING/CONVERSATIONS` runs at least once, lands in `MERGED`.      |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,17 +1,18 @@
 # Configuration
 
-> Wave 1 freezes the typed shape (`src/config/schema.ts`); the loader (file IO, `~/` expansion,
-> error pretty-printing) lands with Wave 2.
+`src/config/schema.ts` defines the typed shape; `src/config/load.ts` reads, expands `~/`,
+JSONC-parses, and validates the file. Errors include the failing field path.
 
 ## Location
 
 - macOS: `~/Library/Application Support/makina/config.json`
 - Linux: `~/.config/makina/config.json`
 
-The file is parsed and validated by zod on every daemon start; errors include the failing field
-path.
+The file is parsed and validated on every daemon start; the daemon also tolerates a missing file by
+binding a fallback `${TMPDIR:-/tmp}/makina.sock` so `--version` and the smoke test still work before
+`makina setup` has run.
 
-## Shape (target)
+## Shape
 
 ```jsonc
 {
@@ -55,13 +56,8 @@ path.
 makina setup
 ```
 
-Walks through the App ID, private-key path, installation discovery, and default repo. See
-`docs/setup-github-app.md` for App creation.
-
-> **Status (this PR):** the wizard's interactive flow is implemented and runs unconditionally. The
-> GitHub App client used for installation discovery lands with `[W2-github-app-auth]` (#4); until
-> then, `makina setup` fails at the discovery step with a clear "GitHub App auth not yet implemented
-> (#4)" error (after the App ID and private-key path have been collected).
+Walks through the App ID, private-key path, installation discovery, and default repo, then writes
+`config.json` to the platform-appropriate path. See `docs/setup-github-app.md` for App creation.
 
 ## Loader behavior
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -46,6 +46,50 @@ Stop the auto-spawned instance, run `deno task daemon` in a separate terminal, t
 in another terminal — the TUI connects to the foregrounded daemon over the same socket and you get
 its logs in line.
 
+## Running the e2e suite
+
+`tests/e2e/` exercises the full daemon → supervisor → GitHub → merge flow against a real sandbox
+repo with the GitHub App installed. The suite is **opt-in**: every test calls `registerE2eTest`,
+which registers a `Deno.test` whose body skips with a one-line note when the gate is off.
+`deno task ci` therefore runs the suite on every push without making any GitHub API calls.
+
+Set the gate plus the four required variables to opt in:
+
+| Variable                      | Meaning                                                             |
+| ----------------------------- | ------------------------------------------------------------------- |
+| `MAKINA_E2E=1`                | Gate. Without `=1` every test skips immediately.                    |
+| `MAKINA_E2E_APP_ID`           | Numeric GitHub App id of the sandbox App.                           |
+| `MAKINA_E2E_PRIVATE_KEY_PATH` | Filesystem path to the App's PEM private key.                       |
+| `MAKINA_E2E_REPO`             | `<owner>/<name>` of the sandbox repo (App must be installed there). |
+| `MAKINA_E2E_INSTALLATION_ID`  | Numeric installation id for the sandbox repo.                       |
+
+Each scenario also takes an optional issue-number variable; an unset variable skips that scenario
+only:
+
+| Scenario                | Variable                          | Sandbox precondition                                                                  |
+| ----------------------- | --------------------------------- | ------------------------------------------------------------------------------------- |
+| Happy path              | `MAKINA_E2E_HAPPY_ISSUE`          | A small, well-scoped open issue.                                                      |
+| CI-fail recovery        | `MAKINA_E2E_CI_FAIL_ISSUE`        | An issue whose first agent commit is expected to fail CI; subsequent commit recovers. |
+| Review-comment recovery | `MAKINA_E2E_REVIEW_COMMENT_ISSUE` | A reviewer (human or scripted) leaves a comment on the open PR mid-flight.            |
+
+Optional: `MAKINA_E2E_TIMEOUT_MS` overrides the per-scenario wait (default 30 minutes).
+
+Run a single scenario:
+
+```bash
+deno test -A --no-check tests/e2e/happy_path_test.ts
+```
+
+Or the whole suite:
+
+```bash
+deno test -A --no-check tests/e2e/
+```
+
+The harness builds a synthetic `HOME`, writes `config.json` pointed at the sandbox repo, spawns
+`main.ts daemon`, and drives `/issue <n>` over the daemon's Unix socket. It tears the daemon down
+(SIGTERM → SIGKILL fallback) and removes the temp directory after each scenario.
+
 ## Common pitfalls
 
 See `docs/troubleshooting.md`.

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1,10 +1,8 @@
 # Lifecycle
 
-> Wave 3 ships the supervisor skeleton (#12); Wave 4 fills in the `STABILIZING` sub-phases. Issue
-> #16 implements the **CI** sub-phase end-to-end (poll combined-status, fetch failing-job logs
-> trimmed to `STABILIZE_CI_LOG_BUDGET_BYTES`, dispatch the agent, restart on the new commit, bound
-> by `MAX_TASK_ITERATIONS` → `NEEDS_HUMAN`); the **rebase** (#15) and **conversations** (#17) phases
-> remain stubs that publish their `state-changed` event and yield back to the loop.
+The supervisor (`src/daemon/supervisor.ts`) walks every issue through a per-task FSM. The three
+stabilize sub-phases — rebase, CI, and conversations — are all wired end-to-end and bounded by
+`MAX_TASK_ITERATIONS` (default 8): exhaustion in any phase escalates the task to `NEEDS_HUMAN`.
 
 Every transition the supervisor performs follows the **persist → emit → act** ordering documented in
 [ADR-016](adrs/016-supervisor-persist-then-emit-then-act.md): the new state is durably on disk
@@ -32,11 +30,17 @@ loop restarts at phase 1 against the just-pushed HEAD. The loop exits cleanly to
 only when none of the phases needs to do work AND a configurable settling window has elapsed.
 
 1. **Rebase** — fetch the base branch and `git rebase`. On conflict, dispatch a focused agent run
-   with the conflict diff. Bounded by `maxIterationsPerTask`. Unresolvable → `NEEDS_HUMAN`.
-2. **CI** — poll combined commit status + check runs. On red, fetch failing-job logs trimmed to a
-   configurable byte budget, dispatch the agent. Restart at phase 1 after the fix is pushed.
-3. **Conversations** — fetch new review comments and review summaries since `lastReviewAt`. If any,
-   group them and dispatch the agent. After the fix is pushed, resolve threads via GraphQL
+   with the conflict diff (see [ADR-018](adrs/018-stabilize-rebase-conflict-loop.md)). Bounded by
+   `maxIterationsPerTask`. Unresolvable → `NEEDS_HUMAN`.
+2. **CI** — poll combined commit status + check runs. On red, fetch failing-job logs trimmed to
+   `STABILIZE_CI_LOG_BUDGET_BYTES` (see
+   [ADR-019](adrs/019-stabilize-ci-log-budget-and-trim-policy.md) and
+   [ADR-022](adrs/022-stabilize-ci-zip-extraction.md) for the ZIP-extraction policy), dispatch the
+   agent. Restart at phase 1 after the fix is pushed.
+3. **Conversations** — fetch new review comments and review summaries since `lastReviewAt` (see
+   [ADR-023](adrs/023-conversations-watermark-monotonicity.md) for the monotonic-watermark guarantee
+   and [ADR-020](adrs/020-graphql-via-octokit-core.md) for the GraphQL transport). If any, group
+   them and dispatch the agent. After the fix is pushed, resolve threads via GraphQL
    `resolveReviewThread` and re-request Copilot review. Restart at phase 1.
 
 ## Merge

--- a/docs/release.md
+++ b/docs/release.md
@@ -9,7 +9,8 @@ Semantic versioning. Pre-release tags use the form `vX.Y.Z-rc.N` and ship as Git
 ## Pre-flight checklist
 
 1. `develop` is green on CI.
-2. The release-tracking issue (`chore: release v…`) lists every Wave 4/5 issue as closed.
+2. The release-tracking issue (`chore: release v…`) lists every issue scheduled for the release as
+   closed.
 3. `develop` was merged into `main` via PR (squash or merge — your call; both keep the changelog
    clean since Conventional Commits drives it).
 4. You have `Releases: write` permission on the repo (project owner: yes).

--- a/docs/setup-github-app.md
+++ b/docs/setup-github-app.md
@@ -1,7 +1,7 @@
 # Setting up the GitHub App
 
-> Wave 2's `setup` wizard drives steps 3.2 onwards. Steps 1 and 2 are manual GitHub actions taken in
-> your browser; the wizard handles everything after the App is installed.
+> The `makina setup` wizard drives steps 3.2 onwards. Steps 1 and 2 are manual GitHub actions taken
+> in your browser; the wizard handles everything after the App is installed.
 
 makina authenticates to GitHub as a GitHub App (rather than a personal access token). This is
 ADR-003: it gives us higher rate limits, fine-grained per-repo permissions, and a clean bot identity
@@ -34,7 +34,7 @@ On the App page → **Install App** → choose the account → choose specific r
    installations endpoint to discover which repositories you can target, and writes the resulting
    `config.json` to the platform-appropriate location (see `docs/configuration.md`). The discovery
    step uses the App-level client documented in
-   [ADR-024](./adrs/024-app-level-github-client-for-setup-wizard.md).
+   [ADR-025](./adrs/025-app-level-github-client-for-setup-wizard.md).
 
 The wizard validates the private-key path against the filesystem before calling GitHub, prints the
 list of reachable repositories with one-based numbers, and writes the resulting `config.json`. On

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,7 @@
 # Troubleshooting
 
-> Wave 0 stub. Entries are added as real failure modes are observed in later waves.
+This page collects failure modes observed across Waves 2–5. New entries land here when a real
+operator hits something that is not obvious from the error message alone.
 
 ## Setup
 
@@ -28,18 +29,65 @@ Yoga's WASM and `node:tty` raw-mode are the usual culprits. Workarounds, in orde
 
 ### Copilot review request returns 422
 
-Copilot is not enabled on the target repo. Settings → Code & automation → Copilot → enable. Retry
-the request.
+Two distinct causes share this status code; check the response body to tell them apart:
+
+- **"Could not resolve to a node with the global id of 'Copilot'"** — Copilot is not enabled on the
+  target repository. Settings → Code & automation → Copilot → enable. Retry the request.
+- **"Reviewer is not a collaborator on the repository"** — the repository owner has not granted
+  Copilot the "collaborator" role required to review PRs on that repo. The fix is owner-side: add
+  Copilot via the same Settings page, or add a personal Copilot access entitlement to the
+  installation. The supervisor surfaces this as a transient `github-call` event with the precise
+  body so an operator can see which case fired.
+
+### Copilot reviewer login form
+
+GitHub's PR-reviewer endpoint expects the literal `Copilot` (no suffix) for the App-driven Copilot
+review feature. Some installations historically required the `[bot]` suffix (`copilot[bot]`); this
+has been observed to fail with 422 on more recent App versions. The supervisor uses the unsuffixed
+form by default; if your installation rejects it, the `github-call` event surfaces the body and an
+operator can flip the wire format via the App settings rather than the daemon.
+
+### `git rebase` / `git push` fails with the wrong base branch
+
+The supervisor reads the PR's base branch from the GitHub API at task creation, not at PR open.
+Repos that rename the default branch (e.g. `master` → `main`) mid-flight will surface as a "could
+not read from remote" or "couldn't find remote ref" diagnostic during the stabilize-rebase phase.
+Cancel the task and retry; the new task picks up the renamed base. (See ADR-018 for the rebase
+loop's bounded-retry policy.)
 
 ## Daemon / TUI
 
 ### TUI says "daemon unavailable"
 
-The daemon may have crashed. Check `~/Library/Logs/makina/daemon.log` for the stack. Restart with
-`makina daemon` foregrounded for live logs while the TUI runs.
+The daemon may have crashed. Check `~/Library/Logs/makina/daemon.log` for the stack (or the
+foreground stderr if you launched via `deno task daemon`). Restart with `makina daemon` foregrounded
+for live logs while the TUI runs.
 
 ### A task is stuck in `STABILIZING` forever
 
-Run `/logs <task-id>` to see the current sub-phase. If `AWAITING_CI`, GitHub may be slow — verify on
-github.com. If `ADDRESSING_COMMENTS`, the agent may have hit `maxIterationsPerTask`; check task
-state in the persistence file or use `/cancel` and retry.
+Run `/logs <task-id>` to see the current sub-phase. If the `stabilizePhase` is `CI`, GitHub may be
+slow — verify on github.com. If it is `CONVERSATIONS`, the agent may have hit `maxIterationsPerTask`
+addressing comments; check task state in the persistence file (`<workspace>/state.json`) or use
+`/cancel` and retry.
+
+### Daemon refuses to bind: socket address already in use
+
+A previous daemon process held the socket and did not release it on exit. Per ADR-013, the listener
+removes a stale socket file before binding, but a still-listening peer cannot be reclaimed
+automatically. Find and stop the old process: `lsof -t /path/to/daemon.sock`, then `kill <pid>`.
+Re-run.
+
+### `deno task ci` fails on `deno task build:smoke`
+
+The smoke test compiles `main.ts` and runs `--version`. If your local Deno cache is incomplete this
+step can fail with "module not found"; `deno cache --reload main.ts` repopulates the npm graph.
+
+## End-to-end suite
+
+### `tests/e2e/` are skipping when I expected them to run
+
+The suite is gated by `MAKINA_E2E=1`. Even with the gate on, every `MAKINA_E2E_APP_ID`,
+`MAKINA_E2E_PRIVATE_KEY_PATH`, `MAKINA_E2E_REPO`, and `MAKINA_E2E_INSTALLATION_ID` must be set; a
+missing variable surfaces as a one-line skip note naming the variable. Per-scenario issue numbers
+(`MAKINA_E2E_HAPPY_ISSUE`, `MAKINA_E2E_CI_FAIL_ISSUE`, `MAKINA_E2E_REVIEW_COMMENT_ISSUE`) are
+optional; an unset scenario issue skips that scenario only.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -44,8 +44,11 @@ Two distinct causes share this status code; check the response body to tell them
 GitHub's PR-reviewer endpoint expects the literal `Copilot` (no suffix) for the App-driven Copilot
 review feature. Some installations historically required the `[bot]` suffix (`copilot[bot]`); this
 has been observed to fail with 422 on more recent App versions. The supervisor uses the unsuffixed
-form by default; if your installation rejects it, the `github-call` event surfaces the body and an
-operator can flip the wire format via the App settings rather than the daemon.
+form, hard-coded as `COPILOT_REVIEWER_LOGIN = "Copilot"` in `src/daemon/supervisor.ts`. The form is
+not currently configurable at runtime: there is no daemon flag, App-setting toggle, or `config.json`
+key for switching it. If your installation rejects the unsuffixed form, the `github-call` event
+surfaces the response body so the operator can confirm the failure mode; making the constant
+configurable is tracked as v0.2.0 work.
 
 ### `git rebase` / `git push` fails with the wrong base branch
 

--- a/src/github/app-client.ts
+++ b/src/github/app-client.ts
@@ -18,7 +18,7 @@
  * Both flows are delegated to `@octokit/auth-app` per
  * {@link "../../docs/adrs/005-no-jose-using-octokit-auth-app.md" | ADR-005}
  * and
- * {@link "../../docs/adrs/024-app-level-github-client-for-setup-wizard.md" | ADR-024}:
+ * {@link "../../docs/adrs/025-app-level-github-client-for-setup-wizard.md" | ADR-025}:
  * the JWT is minted via `auth({ type: "app" })` and the installation
  * token via `auth({ type: "installation", installationId, refresh: true })`.
  * We do not reimplement either primitive — the audited path lives inside
@@ -103,7 +103,7 @@ export interface InstallationRepository {
  * `AppClient` — once `setup` is done, every supervisor call is
  * installation-scoped through `GitHubClient`.
  *
- * @see {@link "../../docs/adrs/024-app-level-github-client-for-setup-wizard.md" | ADR-024}
+ * @see {@link "../../docs/adrs/025-app-level-github-client-for-setup-wizard.md" | ADR-025}
  */
 export interface AppClient {
   /**

--- a/tests/e2e/_e2e_harness.ts
+++ b/tests/e2e/_e2e_harness.ts
@@ -33,6 +33,7 @@
  * @module
  */
 
+import { expandHome } from "../../src/config/load.ts";
 import { decode, encode } from "../../src/ipc/codec.ts";
 import {
   type AckPayload,
@@ -92,6 +93,21 @@ export const E2E_REVIEW_COMMENT_ISSUE_ENV = "MAKINA_E2E_REVIEW_COMMENT_ISSUE";
  * variable directly.
  */
 export const E2E_DEFAULT_TIMEOUT_MILLISECONDS = 30 * 60 * 1_000;
+
+/**
+ * Maximum number of unmatched supervisor events the harness keeps in
+ * its in-memory queue. Beyond this size the harness drops the oldest
+ * entry and emits a single warning so the operator notices the leak.
+ *
+ * The cap exists because long-running e2e scenarios (notably the
+ * `ci_fail_recovery` loop) can emit thousands of `agent-message` and
+ * log events that no installed waiter ever consumes; without a bound
+ * the queue would grow until the test runner OOMed. 1024 is large
+ * enough that any realistic scenario sees every interesting transition
+ * without dropping it (the supervisor emits ~tens of events per FSM
+ * cycle), and small enough to keep the resident size negligible.
+ */
+export const EVENT_QUEUE_MAX = 1024;
 
 /**
  * Result of {@link checkGate}: either the gate is open with every
@@ -217,23 +233,30 @@ export function checkGate(): GateResult {
   // permissions in a test runner sandbox. The daemon will reject a
   // missing file with its own diagnostic; the e2e test will then
   // surface the failure through the listen-line wait.
+  //
+  // Expand `~/` in the private-key path so the spawned daemon's auth
+  // loader (which reads the file directly without re-expanding) does
+  // not look up the synthetic HOME we pin in {@link buildSpawnEnv}.
+  // The contract documented on the wider config-loader is "expand at
+  // the boundary"; the harness is the boundary for the synthetic
+  // config it writes.
+  const privateKeyPathRaw = Deno.env.get("MAKINA_E2E_PRIVATE_KEY_PATH") ?? "";
+  const privateKeyPath = expandHome(privateKeyPathRaw);
+  // Conditional spreads keep optional fields absent (rather than
+  // present-with-undefined) under `exactOptionalPropertyTypes: true`.
+  // The same pattern is documented on `createAppClient` in
+  // `src/github/app-client.ts`.
   const env: ResolvedE2eEnv = {
     appId,
-    privateKeyPath: Deno.env.get("MAKINA_E2E_PRIVATE_KEY_PATH") ?? "",
+    privateKeyPath,
     repo,
     installationId,
     timeoutMilliseconds,
+    ...(happyIssue !== undefined ? { happyIssue } : {}),
+    ...(ciFailIssue !== undefined ? { ciFailIssue } : {}),
+    ...(reviewCommentIssue !== undefined ? { reviewCommentIssue } : {}),
   };
-  if (happyIssue !== undefined) {
-    return {
-      mode: "run",
-      env: { ...env, happyIssue, ciFailIssue, reviewCommentIssue } as ResolvedE2eEnv,
-    };
-  }
-  return {
-    mode: "run",
-    env: { ...env, ciFailIssue, reviewCommentIssue } as ResolvedE2eEnv,
-  };
+  return { mode: "run", env };
 }
 
 /**
@@ -402,19 +425,35 @@ export async function bootHarness(env: ResolvedE2eEnv): Promise<Harness> {
     >();
 
     // Read loop: dispatch every decoded envelope.
+    let queueOverflowWarned = false;
     const readLoop = (async () => {
       try {
         for await (const envelope of decode(conn.readable)) {
           if (envelope.type === "event") {
-            eventQueue.push(envelope.payload as EventPayload);
+            const payload = envelope.payload as EventPayload;
+            eventQueue.push(payload);
+            // Cap the queue so a long-running scenario whose installed
+            // waiters do not match every emitted event cannot OOM the
+            // runner. Drop the oldest entry; warn once on the first
+            // overflow so the operator can size up if a real scenario
+            // is losing a transition it cared about.
+            while (eventQueue.length > EVENT_QUEUE_MAX) {
+              eventQueue.shift();
+              if (!queueOverflowWarned) {
+                queueOverflowWarned = true;
+                console.warn(
+                  `[e2e] eventQueue exceeded ${EVENT_QUEUE_MAX}; dropping oldest events.`,
+                );
+              }
+            }
             // Drain any waiter whose predicate now matches.
             for (let i = eventWaiters.length - 1; i >= 0; i -= 1) {
               const waiter = eventWaiters[i];
               if (waiter === undefined) continue;
-              if (waiter.predicate(envelope.payload as EventPayload)) {
+              if (waiter.predicate(payload)) {
                 clearTimeout(waiter.timer);
                 eventWaiters.splice(i, 1);
-                waiter.resolve(envelope.payload as EventPayload);
+                waiter.resolve(payload);
               }
             }
             continue;

--- a/tests/e2e/_e2e_harness.ts
+++ b/tests/e2e/_e2e_harness.ts
@@ -690,17 +690,6 @@ function buildSpawnEnv(fakeHome: string): Record<string, string> {
 }
 
 /**
- * Wait for the daemon's "[daemon] listening on ..." line on stderr. We
- * key off the listen line (rather than the socket file) because a
- * regression that bound the socket but failed to emit the line would
- * leave the test hung; the line guarantees `Deno.listen` returned and
- * any failure surfaces as a parsable diagnostic in the rejection
- * message.
- *
- * @param stderr The daemon's stderr stream.
- * @param timeoutMs Bound on the wait, in milliseconds.
- */
-/**
  * Internal waiter slot for {@link runHarnessReadLoop}. Mirrors the
  * inline shape used by {@link bootHarness}; pulled out as a named type
  * so the harness body and the unit-test stay in lock-step.
@@ -831,6 +820,17 @@ export function runHarnessReadLoop(params: HarnessReadLoopParams): Promise<void>
   })();
 }
 
+/**
+ * Wait for the daemon's "[daemon] listening on ..." line on stderr. We
+ * key off the listen line (rather than the socket file) because a
+ * regression that bound the socket but failed to emit the line would
+ * leave the test hung; the line guarantees `Deno.listen` returned and
+ * any failure surfaces as a parsable diagnostic in the rejection
+ * message.
+ *
+ * @param stderr The daemon's stderr stream.
+ * @param timeoutMs Bound on the wait, in milliseconds.
+ */
 async function waitForListenLine(
   stderr: ReadableStream<Uint8Array>,
   timeoutMs: number,

--- a/tests/e2e/_e2e_harness.ts
+++ b/tests/e2e/_e2e_harness.ts
@@ -1,0 +1,692 @@
+/**
+ * tests/e2e/_e2e_harness.ts — shared scaffolding for the Wave 5
+ * end-to-end suite.
+ *
+ * The three e2e tests (`happy_path_test.ts`, `ci_fail_recovery_test.ts`,
+ * `review_comment_recovery_test.ts`) all need the same shape:
+ *
+ *  1. Read sandbox credentials from environment variables.
+ *  2. If the gate (`MAKINA_E2E=1`) is off **or** any required variable
+ *     is missing, register a `Deno.test` that prints a clear skip note
+ *     and exits.
+ *  3. Otherwise: build a synthetic `HOME` (`Deno.makeTempDir`), write a
+ *     `config.json` pointed at the sandbox repo, spawn `main.ts daemon`
+ *     against that workspace, open a `Deno.connect` socket session, and
+ *     yield a `Harness` to the test body.
+ *  4. Tear down: send `SIGTERM` to the daemon, wait for the socket to
+ *     drain, remove the temp dir, and (if a sandbox PR was opened in the
+ *     test body) attempt to clean it up.
+ *
+ * The harness is **not** in the production code path; it lives entirely
+ * under `tests/e2e/` and is exempt from the production "no global
+ * mutation in tests" rule because it never touches process-wide state
+ * outside of the spawned child. Per-file isolation is preserved via
+ * unique temp directories.
+ *
+ * **Why a separate file** rather than copy-pasting the spawn logic into
+ * each test (the integration suite's pattern): the e2e tests are
+ * intrinsically more expensive to build — each scenario needs a
+ * sandbox-repo precondition, a polling helper that watches the event
+ * bus for FSM transitions, and a robust teardown. Centralising the
+ * boilerplate here keeps each test focused on its own scenario.
+ *
+ * @module
+ */
+
+import { decode, encode } from "../../src/ipc/codec.ts";
+import {
+  type AckPayload,
+  type EventPayload,
+  type MessageEnvelope,
+} from "../../src/ipc/protocol.ts";
+import {
+  type IssueNumber,
+  makeIssueNumber,
+  makeRepoFullName,
+  type RepoFullName,
+} from "../../src/types.ts";
+
+/**
+ * Environment variable that gates the entire e2e suite.
+ *
+ * When unset (or any value other than `"1"`), every e2e test registers
+ * a thin skip body so `deno task test` is fast and offline-safe. This
+ * mirrors the convention used by the `MAKINA_E2E_*` family below.
+ */
+export const E2E_GATE_ENV = "MAKINA_E2E";
+
+/**
+ * Required environment variables when the gate is on. Any missing
+ * variable causes the test to skip with a precise diagnostic naming
+ * the variable.
+ */
+export const E2E_REQUIRED_ENV = [
+  "MAKINA_E2E_APP_ID",
+  "MAKINA_E2E_PRIVATE_KEY_PATH",
+  "MAKINA_E2E_REPO",
+  "MAKINA_E2E_INSTALLATION_ID",
+] as const;
+
+/** Type of {@link E2E_REQUIRED_ENV}'s elements. */
+export type RequiredEnvName = (typeof E2E_REQUIRED_ENV)[number];
+
+/**
+ * Environment variable naming the sandbox issue to start the FSM
+ * against. Each scenario reads a different variable so a single CI
+ * invocation can run all three concurrently without aliasing.
+ */
+export const E2E_HAPPY_ISSUE_ENV = "MAKINA_E2E_HAPPY_ISSUE";
+/** Issue number whose acceptance criteria deliberately fail CI. */
+export const E2E_CI_FAIL_ISSUE_ENV = "MAKINA_E2E_CI_FAIL_ISSUE";
+/** Issue number whose review-comment recovery scenario runs against. */
+export const E2E_REVIEW_COMMENT_ISSUE_ENV = "MAKINA_E2E_REVIEW_COMMENT_ISSUE";
+
+/**
+ * Default upper bound on how long we wait for the supervisor to walk
+ * the FSM to a terminal state, in milliseconds. The end-to-end paths
+ * touch real CI which can take minutes; we bound the wait so a wedged
+ * test does not stall the runner indefinitely.
+ *
+ * Override via `MAKINA_E2E_TIMEOUT_MS`. Tests doing extra-long CI work
+ * (e.g. a fail-recovery loop with multiple iterations) read the
+ * variable directly.
+ */
+export const E2E_DEFAULT_TIMEOUT_MILLISECONDS = 30 * 60 * 1_000;
+
+/**
+ * Result of {@link checkGate}: either the gate is open with every
+ * required variable present, or the test should skip with a message
+ * naming the missing piece.
+ */
+export type GateResult =
+  | { readonly mode: "skip"; readonly reason: string }
+  | { readonly mode: "run"; readonly env: ResolvedE2eEnv };
+
+/**
+ * Parsed view of the e2e environment variables, ready for the test
+ * body to consume. Strings are passed through verbatim; numbers are
+ * branded via the `make*` constructors so a malformed value fails
+ * fast.
+ */
+export interface ResolvedE2eEnv {
+  /** GitHub App id (numeric). */
+  readonly appId: number;
+  /** Filesystem path of the GitHub App private key (PEM). */
+  readonly privateKeyPath: string;
+  /** Sandbox `<owner>/<name>` pair. */
+  readonly repo: RepoFullName;
+  /** Installation id for the sandbox repo (numeric). */
+  readonly installationId: number;
+  /** Optional issue number for the happy path. */
+  readonly happyIssue?: IssueNumber;
+  /** Optional issue number for the CI-fail recovery scenario. */
+  readonly ciFailIssue?: IssueNumber;
+  /** Optional issue number for the review-comment recovery scenario. */
+  readonly reviewCommentIssue?: IssueNumber;
+  /** Optional max-wait override in milliseconds. */
+  readonly timeoutMilliseconds: number;
+}
+
+/**
+ * Parse the e2e environment. Returns either a skip reason or a fully
+ * resolved {@link ResolvedE2eEnv} ready for the harness to consume.
+ *
+ * The function is pure: it only reads `Deno.env`, never spawns
+ * processes or touches the filesystem. Each test calls it once and
+ * branches.
+ *
+ * @returns Whether the test should run or skip.
+ *
+ * @example
+ * ```ts
+ * Deno.test("happy path", async () => {
+ *   const gate = checkGate();
+ *   if (gate.mode === "skip") {
+ *     console.error(gate.reason);
+ *     return;
+ *   }
+ *   // ... use gate.env
+ * });
+ * ```
+ */
+export function checkGate(): GateResult {
+  if (Deno.env.get(E2E_GATE_ENV) !== "1") {
+    return {
+      mode: "skip",
+      reason:
+        `[e2e] skipped — set ${E2E_GATE_ENV}=1 to enable the end-to-end suite (see docs/development.md).`,
+    };
+  }
+  const missing: RequiredEnvName[] = [];
+  for (const name of E2E_REQUIRED_ENV) {
+    const value = Deno.env.get(name);
+    if (value === undefined || value.length === 0) {
+      missing.push(name);
+    }
+  }
+  if (missing.length > 0) {
+    return {
+      mode: "skip",
+      reason: `[e2e] skipped — required env not set: ${missing.join(", ")}.`,
+    };
+  }
+  const appId = Number(Deno.env.get("MAKINA_E2E_APP_ID"));
+  const installationId = Number(Deno.env.get("MAKINA_E2E_INSTALLATION_ID"));
+  if (!Number.isFinite(appId) || !Number.isInteger(appId) || appId <= 0) {
+    return {
+      mode: "skip",
+      reason: `[e2e] skipped — MAKINA_E2E_APP_ID must be a positive integer.`,
+    };
+  }
+  if (
+    !Number.isFinite(installationId) || !Number.isInteger(installationId) ||
+    installationId <= 0
+  ) {
+    return {
+      mode: "skip",
+      reason: `[e2e] skipped — MAKINA_E2E_INSTALLATION_ID must be a positive integer.`,
+    };
+  }
+  let repo: RepoFullName;
+  const repoRaw = Deno.env.get("MAKINA_E2E_REPO");
+  if (repoRaw === undefined) {
+    return { mode: "skip", reason: "[e2e] skipped — MAKINA_E2E_REPO missing." };
+  }
+  try {
+    repo = makeRepoFullName(repoRaw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { mode: "skip", reason: `[e2e] skipped — MAKINA_E2E_REPO invalid: ${message}` };
+  }
+
+  const happyIssue = optionalIssueNumber(E2E_HAPPY_ISSUE_ENV);
+  const ciFailIssue = optionalIssueNumber(E2E_CI_FAIL_ISSUE_ENV);
+  const reviewCommentIssue = optionalIssueNumber(E2E_REVIEW_COMMENT_ISSUE_ENV);
+
+  const timeoutRaw = Deno.env.get("MAKINA_E2E_TIMEOUT_MS");
+  let timeoutMilliseconds = E2E_DEFAULT_TIMEOUT_MILLISECONDS;
+  if (timeoutRaw !== undefined) {
+    const parsed = Number(timeoutRaw);
+    if (Number.isFinite(parsed) && Number.isInteger(parsed) && parsed > 0) {
+      timeoutMilliseconds = parsed;
+    }
+  }
+
+  // The PEM path was checked for non-emptiness above; we deliberately
+  // do not stat it here to avoid coupling the gate to filesystem
+  // permissions in a test runner sandbox. The daemon will reject a
+  // missing file with its own diagnostic; the e2e test will then
+  // surface the failure through the listen-line wait.
+  const env: ResolvedE2eEnv = {
+    appId,
+    privateKeyPath: Deno.env.get("MAKINA_E2E_PRIVATE_KEY_PATH") ?? "",
+    repo,
+    installationId,
+    timeoutMilliseconds,
+  };
+  if (happyIssue !== undefined) {
+    return {
+      mode: "run",
+      env: { ...env, happyIssue, ciFailIssue, reviewCommentIssue } as ResolvedE2eEnv,
+    };
+  }
+  return {
+    mode: "run",
+    env: { ...env, ciFailIssue, reviewCommentIssue } as ResolvedE2eEnv,
+  };
+}
+
+/**
+ * Read an optional issue-number environment variable and brand it.
+ *
+ * Returns `undefined` when the variable is unset or empty so the
+ * caller can branch without re-reading the variable.
+ *
+ * @param name Variable name to read.
+ * @returns The branded {@link IssueNumber} or `undefined`.
+ */
+function optionalIssueNumber(name: string): IssueNumber | undefined {
+  const raw = Deno.env.get(name);
+  if (raw === undefined || raw.length === 0) return undefined;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    return undefined;
+  }
+  return makeIssueNumber(parsed);
+}
+
+/**
+ * Live socket session: the spawned daemon, a connected client, and the
+ * helpers each scenario needs to drive the FSM and observe transitions.
+ *
+ * Returned by {@link bootHarness}. The {@link Harness.cleanup} method
+ * is called by the test body's `finally` so the daemon and temp
+ * directory are always released even if the test rejects.
+ */
+export interface Harness {
+  /** Spawned daemon child handle. */
+  readonly child: Deno.ChildProcess;
+  /** Synthetic `HOME` directory the daemon was launched against. */
+  readonly home: string;
+  /** Resolved socket path inside the synthetic HOME. */
+  readonly socketPath: string;
+  /** The branded sandbox repo name. */
+  readonly repo: RepoFullName;
+  /**
+   * Send an envelope and resolve when the matching reply arrives. The
+   * `id` is enforced unique by the harness; reply correlation is by
+   * envelope id, matching the production client.
+   *
+   * @param envelope The envelope to send.
+   * @returns The decoded reply envelope.
+   */
+  send(envelope: MessageEnvelope): Promise<MessageEnvelope>;
+  /**
+   * Wait for the next event matching `predicate`, or reject when the
+   * supervisor emits a terminal `state-changed` event whose `toState`
+   * matches a terminal value. Each scenario passes its own predicate
+   * (e.g. "the task reached `READY_TO_MERGE`").
+   *
+   * @param predicate Returns `true` when the awaited event arrives.
+   * @param timeoutMs Bound on the wait, in milliseconds.
+   * @returns The matching event payload.
+   */
+  waitForEvent(
+    predicate: (event: EventPayload) => boolean,
+    timeoutMs: number,
+  ): Promise<EventPayload>;
+  /**
+   * Tear down the daemon and remove the temp directory. Safe to call
+   * multiple times.
+   */
+  cleanup(): Promise<void>;
+}
+
+/**
+ * Boot a harness against the resolved e2e environment.
+ *
+ * Builds a synthetic HOME, writes a `config.json` keyed at the
+ * sandbox repo, spawns the daemon, waits for the listen line, opens a
+ * client socket, and subscribes to wildcard events.
+ *
+ * @param env The resolved environment (see {@link checkGate}).
+ * @returns A {@link Harness} whose `cleanup` must be awaited from the
+ *   caller's `finally`.
+ *
+ * @example
+ * ```ts
+ * const gate = checkGate();
+ * if (gate.mode === "skip") return;
+ * const harness = await bootHarness(gate.env);
+ * try {
+ *   // ... drive the daemon
+ * } finally {
+ *   await harness.cleanup();
+ * }
+ * ```
+ */
+export async function bootHarness(env: ResolvedE2eEnv): Promise<Harness> {
+  const home = await Deno.makeTempDir({ dir: "/tmp", prefix: "makina-e2e-" });
+  try {
+    const configDir = Deno.build.os === "darwin"
+      ? `${home}/Library/Application Support/makina`
+      : `${home}/.config/makina`;
+    await Deno.mkdir(configDir, { recursive: true });
+    const workspace = `${home}/workspace`;
+    await Deno.mkdir(workspace, { recursive: true });
+    const socketDir = `${home}/run`;
+    await Deno.mkdir(socketDir, { recursive: true });
+    const socketPath = `${socketDir}/daemon.sock`;
+    const configPath = `${configDir}/config.json`;
+    const config = {
+      github: {
+        appId: env.appId,
+        privateKeyPath: env.privateKeyPath,
+        installations: { [env.repo as string]: env.installationId },
+        defaultRepo: env.repo as string,
+      },
+      agent: {
+        model: "claude-sonnet-4-6",
+        permissionMode: "acceptEdits",
+        maxIterationsPerTask: 4,
+      },
+      lifecycle: {
+        mergeMode: "squash",
+        settlingWindowMilliseconds: 60_000,
+        pollIntervalMilliseconds: 30_000,
+        preserveWorktreeOnMerge: false,
+      },
+      workspace,
+      daemon: { socketPath, autoStart: true },
+      tui: { keybindings: { commandPalette: "ctrl+p", taskSwitcher: "ctrl+g" } },
+    };
+    await Deno.writeTextFile(configPath, `${JSON.stringify(config, null, 2)}\n`);
+
+    const spawnEnv = buildSpawnEnv(home);
+    const command = new Deno.Command(Deno.execPath(), {
+      args: ["run", "-A", "main.ts", "daemon"],
+      env: spawnEnv,
+      clearEnv: true,
+      cwd: Deno.cwd(),
+      stdout: "null",
+      stderr: "piped",
+      stdin: "null",
+    });
+    const child = command.spawn();
+
+    await waitForListenLine(child.stderr, 30_000);
+
+    // The listen line confirms `Deno.listen` returned; the kernel may
+    // still be racing the inode entry on macOS' tmpfs. Wait briefly
+    // for the file to materialise before opening the client.
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      try {
+        await Deno.lstat(socketPath);
+        break;
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    }
+    const conn = await Deno.connect({ transport: "unix", path: socketPath });
+    const writer = conn.writable.getWriter();
+    const eventQueue: EventPayload[] = [];
+    const eventWaiters: Array<{
+      predicate: (event: EventPayload) => boolean;
+      resolve: (event: EventPayload) => void;
+      reject: (error: Error) => void;
+      timer: number;
+    }> = [];
+    const replyWaiters = new Map<
+      string,
+      { resolve: (envelope: MessageEnvelope) => void; reject: (error: Error) => void }
+    >();
+
+    // Read loop: dispatch every decoded envelope.
+    const readLoop = (async () => {
+      try {
+        for await (const envelope of decode(conn.readable)) {
+          if (envelope.type === "event") {
+            eventQueue.push(envelope.payload as EventPayload);
+            // Drain any waiter whose predicate now matches.
+            for (let i = eventWaiters.length - 1; i >= 0; i -= 1) {
+              const waiter = eventWaiters[i];
+              if (waiter === undefined) continue;
+              if (waiter.predicate(envelope.payload as EventPayload)) {
+                clearTimeout(waiter.timer);
+                eventWaiters.splice(i, 1);
+                waiter.resolve(envelope.payload as EventPayload);
+              }
+            }
+            continue;
+          }
+          const slot = replyWaiters.get(envelope.id);
+          if (slot !== undefined) {
+            replyWaiters.delete(envelope.id);
+            slot.resolve(envelope);
+          }
+        }
+      } catch (error) {
+        const cause = error instanceof Error ? error : new Error(String(error));
+        for (const slot of replyWaiters.values()) slot.reject(cause);
+        replyWaiters.clear();
+        for (const waiter of eventWaiters) {
+          clearTimeout(waiter.timer);
+          waiter.reject(cause);
+        }
+        eventWaiters.length = 0;
+      }
+    })();
+
+    const send = async (envelope: MessageEnvelope): Promise<MessageEnvelope> => {
+      if (replyWaiters.has(envelope.id)) {
+        throw new Error(`duplicate envelope id ${JSON.stringify(envelope.id)}`);
+      }
+      const reply = new Promise<MessageEnvelope>((resolve, reject) => {
+        replyWaiters.set(envelope.id, { resolve, reject });
+      });
+      await writer.write(encode(envelope));
+      return reply;
+    };
+
+    const waitForEvent = (
+      predicate: (event: EventPayload) => boolean,
+      timeoutMs: number,
+    ): Promise<EventPayload> => {
+      // Drain anything already queued before installing the waiter so
+      // an event the test missed cannot be lost behind a slow predicate.
+      for (let i = 0; i < eventQueue.length; i += 1) {
+        const event = eventQueue[i];
+        if (event !== undefined && predicate(event)) {
+          eventQueue.splice(i, 1);
+          return Promise.resolve(event);
+        }
+      }
+      return new Promise<EventPayload>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          // Remove ourselves from the waiter list before rejecting so a
+          // late-arriving event after the timeout does not double-fire.
+          const idx = eventWaiters.findIndex((w) => w.timer === timer);
+          if (idx >= 0) eventWaiters.splice(idx, 1);
+          reject(new Error(`waitForEvent timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+        eventWaiters.push({ predicate, resolve, reject, timer });
+      });
+    };
+
+    // Subscribe to wildcard so every supervisor event lands in our queue.
+    const subscribeReply = await send({
+      id: "harness-subscribe",
+      type: "subscribe",
+      payload: { target: "*" },
+    });
+    if (subscribeReply.type !== "ack") {
+      throw new Error(
+        `harness subscribe expected ack, got ${subscribeReply.type}`,
+      );
+    }
+    const ack = subscribeReply.payload as AckPayload;
+    if (!ack.ok) {
+      throw new Error(`harness subscribe rejected: ${ack.error ?? "(no detail)"}`);
+    }
+
+    let cleaned = false;
+    const cleanup = async (): Promise<void> => {
+      if (cleaned) return;
+      cleaned = true;
+      try {
+        await writer.close();
+      } catch {
+        // Ignore.
+      }
+      try {
+        conn.close();
+      } catch {
+        // Ignore.
+      }
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // Already gone.
+      }
+      try {
+        await child.stderr.cancel();
+      } catch {
+        // Already drained.
+      }
+      let shutdownTimer: number | undefined;
+      const shutdownTimeout = new Promise<void>((resolve) => {
+        shutdownTimer = setTimeout(resolve, 2_000);
+      });
+      try {
+        await Promise.race([child.status, shutdownTimeout]);
+      } finally {
+        if (shutdownTimer !== undefined) clearTimeout(shutdownTimer);
+      }
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // Already gone.
+      }
+      await child.status;
+      await readLoop;
+      try {
+        await Deno.remove(home, { recursive: true });
+      } catch {
+        // Best-effort cleanup; a wedged FS leaves the dir behind for
+        // the operator to inspect.
+      }
+    };
+
+    return {
+      child,
+      home,
+      socketPath,
+      repo: env.repo,
+      send,
+      waitForEvent,
+      cleanup,
+    };
+  } catch (error) {
+    // Boot failed — make sure the temp dir is removed.
+    try {
+      await Deno.remove(home, { recursive: true });
+    } catch {
+      // Ignore.
+    }
+    throw error;
+  }
+}
+
+/**
+ * Build the environment a spawned `deno run` invocation needs.
+ *
+ * Mirrors the helper in `tests/integration/main_daemon_runtime_test.ts`:
+ * pin `HOME` to the synthetic dir, share `DENO_DIR` with the parent so
+ * the spawned binary does not re-download every dep, and pass through a
+ * minimal POSIX env so the runtime can locate sub-tools.
+ *
+ * @param fakeHome The synthetic HOME directory to pin.
+ * @returns The env map for `Deno.Command`'s `env` option.
+ */
+function buildSpawnEnv(fakeHome: string): Record<string, string> {
+  const out: Record<string, string> = { HOME: fakeHome };
+  const denoDir = Deno.env.get("DENO_DIR");
+  if (denoDir !== undefined) {
+    out.DENO_DIR = denoDir;
+  } else {
+    const parentHome = Deno.env.get("HOME");
+    if (parentHome !== undefined) {
+      out.DENO_DIR = Deno.build.os === "darwin"
+        ? `${parentHome}/Library/Caches/deno`
+        : `${parentHome}/.cache/deno`;
+    }
+  }
+  for (const passthrough of ["PATH", "TMPDIR", "LANG"]) {
+    const value = Deno.env.get(passthrough);
+    if (value !== undefined) out[passthrough] = value;
+  }
+  return out;
+}
+
+/**
+ * Wait for the daemon's "[daemon] listening on ..." line on stderr. We
+ * key off the listen line (rather than the socket file) because a
+ * regression that bound the socket but failed to emit the line would
+ * leave the test hung; the line guarantees `Deno.listen` returned and
+ * any failure surfaces as a parsable diagnostic in the rejection
+ * message.
+ *
+ * @param stderr The daemon's stderr stream.
+ * @param timeoutMs Bound on the wait, in milliseconds.
+ */
+async function waitForListenLine(
+  stderr: ReadableStream<Uint8Array>,
+  timeoutMs: number,
+): Promise<void> {
+  const decoder = new TextDecoder();
+  const reader = stderr.getReader();
+  let buffer = "";
+  let deadlineTimer: number | undefined;
+  try {
+    const deadlinePromise = new Promise<never>((_, reject) => {
+      deadlineTimer = setTimeout(() => {
+        reject(
+          new Error(
+            `[e2e] daemon never logged "[daemon] listening on ..." within ` +
+              `${timeoutMs}ms; stderr was:\n${buffer}`,
+          ),
+        );
+      }, timeoutMs);
+    });
+    while (true) {
+      const result = await Promise.race([reader.read(), deadlinePromise]);
+      if (result.done) {
+        throw new Error(
+          `[e2e] daemon stderr closed before logging the listen line; stderr was:\n${buffer}`,
+        );
+      }
+      buffer += decoder.decode(result.value, { stream: true });
+      if (buffer.includes("[daemon] listening on ")) {
+        return;
+      }
+    }
+  } finally {
+    if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
+    reader.releaseLock();
+  }
+}
+
+/**
+ * Convenience helper: register a `Deno.test` whose body skips with a
+ * clear note when the gate is closed.
+ *
+ * Each scenario file calls this once. The skip note goes through
+ * `console.error` (visible in `deno test --quiet` output) and the
+ * test resolves successfully so coverage reports stay clean.
+ *
+ * @param name Test name displayed by Deno's test runner.
+ * @param scenarioIssueEnv Environment variable naming the per-scenario
+ *   issue number; if unset, the scenario also skips.
+ * @param body The actual test body, called only when the gate is open
+ *   and the scenario issue is set. Receives the resolved environment
+ *   and the live harness; `cleanup` runs from a `finally` here.
+ *
+ * @example
+ * ```ts
+ * registerE2eTest("e2e: happy path", "MAKINA_E2E_HAPPY_ISSUE", async (env, harness) => {
+ *   // ... use harness.send / harness.waitForEvent
+ * });
+ * ```
+ */
+export function registerE2eTest(
+  name: string,
+  scenarioIssueEnv: string,
+  body: (env: ResolvedE2eEnv, harness: Harness) => Promise<void>,
+): void {
+  Deno.test({
+    name,
+    // The harness opens a real socket and spawns a child; let Deno's
+    // sanitizers flag any leak. If a future scenario needs to disable
+    // a sanitizer, it should do so locally rather than in this helper.
+    fn: async () => {
+      const gate = checkGate();
+      if (gate.mode === "skip") {
+        console.error(gate.reason);
+        return;
+      }
+      const issueRaw = Deno.env.get(scenarioIssueEnv);
+      if (issueRaw === undefined || issueRaw.length === 0) {
+        console.error(
+          `[e2e] ${name}: skipped — ${scenarioIssueEnv} not set.`,
+        );
+        return;
+      }
+      const harness = await bootHarness(gate.env);
+      try {
+        await body(gate.env, harness);
+      } finally {
+        await harness.cleanup();
+      }
+    },
+  });
+}

--- a/tests/e2e/_e2e_harness.ts
+++ b/tests/e2e/_e2e_harness.ts
@@ -110,6 +110,38 @@ export const E2E_DEFAULT_TIMEOUT_MILLISECONDS = 30 * 60 * 1_000;
 export const EVENT_QUEUE_MAX = 1024;
 
 /**
+ * Discriminator tags for {@link HarnessError}. Tests can pattern-match
+ * on `.kind` to distinguish a clean peer close from a decode failure
+ * without relying on message string matching.
+ */
+export type HarnessErrorKind = "connection-closed";
+
+/**
+ * Typed error raised by the harness when an internal invariant
+ * surfaces. Currently carries a single `kind` discriminator
+ * (`"connection-closed"`) so the regression test for the read-loop
+ * clean-close path can assert against the cause without parsing the
+ * message; future kinds can be added without breaking the existing
+ * surface.
+ */
+export class HarnessError extends Error {
+  /** Tag identifying which invariant surfaced the error. */
+  readonly kind: HarnessErrorKind;
+
+  /**
+   * Construct a harness error.
+   *
+   * @param kind Discriminator the test pattern-matches on.
+   * @param message Human-readable description.
+   */
+  constructor(kind: HarnessErrorKind, message: string) {
+    super(message);
+    this.name = "HarnessError";
+    this.kind = kind;
+  }
+}
+
+/**
  * Result of {@link checkGate}: either the gate is open with every
  * required variable present, or the test should skip with a message
  * naming the missing piece.
@@ -332,6 +364,16 @@ export interface Harness {
  * sandbox repo, spawns the daemon, waits for the listen line, opens a
  * client socket, and subscribes to wildcard events.
  *
+ * **Failure semantics.** If any step after the temp-dir creation
+ * fails, the catch path tears down every resource that was actually
+ * allocated before rethrowing — in order: close the client socket
+ * (if connected), `SIGTERM` the daemon child (followed by `SIGKILL`
+ * after a short grace), await `child.status` so the kernel reaps the
+ * pid, then remove the temp dir. Each step is wrapped so a failure
+ * in one (e.g. socket already closed) does not prevent the others.
+ * The original error is rethrown unchanged so the test sees the same
+ * diagnostic it would have on a normal failure path.
+ *
  * @param env The resolved environment (see {@link checkGate}).
  * @returns A {@link Harness} whose `cleanup` must be awaited from the
  *   caller's `finally`.
@@ -350,6 +392,12 @@ export interface Harness {
  */
 export async function bootHarness(env: ResolvedE2eEnv): Promise<Harness> {
   const home = await Deno.makeTempDir({ dir: "/tmp", prefix: "makina-e2e-" });
+  // Track partially-allocated resources so the catch path can release
+  // every one that was actually opened. `child` and `conn` are
+  // assigned mid-try; the catch reads what's set and tears down each
+  // independently so a failure in one step does not strand the others.
+  let child: Deno.ChildProcess | undefined;
+  let conn: Deno.UnixConn | undefined;
   try {
     const configDir = Deno.build.os === "darwin"
       ? `${home}/Library/Application Support/makina`
@@ -395,7 +443,7 @@ export async function bootHarness(env: ResolvedE2eEnv): Promise<Harness> {
       stderr: "piped",
       stdin: "null",
     });
-    const child = command.spawn();
+    child = command.spawn();
 
     await waitForListenLine(child.stderr, 30_000);
 
@@ -410,7 +458,7 @@ export async function bootHarness(env: ResolvedE2eEnv): Promise<Harness> {
         await new Promise((resolve) => setTimeout(resolve, 50));
       }
     }
-    const conn = await Deno.connect({ transport: "unix", path: socketPath });
+    conn = await Deno.connect({ transport: "unix", path: socketPath });
     const writer = conn.writable.getWriter();
     const eventQueue: EventPayload[] = [];
     const eventWaiters: Array<{
@@ -425,56 +473,12 @@ export async function bootHarness(env: ResolvedE2eEnv): Promise<Harness> {
     >();
 
     // Read loop: dispatch every decoded envelope.
-    let queueOverflowWarned = false;
-    const readLoop = (async () => {
-      try {
-        for await (const envelope of decode(conn.readable)) {
-          if (envelope.type === "event") {
-            const payload = envelope.payload as EventPayload;
-            eventQueue.push(payload);
-            // Cap the queue so a long-running scenario whose installed
-            // waiters do not match every emitted event cannot OOM the
-            // runner. Drop the oldest entry; warn once on the first
-            // overflow so the operator can size up if a real scenario
-            // is losing a transition it cared about.
-            while (eventQueue.length > EVENT_QUEUE_MAX) {
-              eventQueue.shift();
-              if (!queueOverflowWarned) {
-                queueOverflowWarned = true;
-                console.warn(
-                  `[e2e] eventQueue exceeded ${EVENT_QUEUE_MAX}; dropping oldest events.`,
-                );
-              }
-            }
-            // Drain any waiter whose predicate now matches.
-            for (let i = eventWaiters.length - 1; i >= 0; i -= 1) {
-              const waiter = eventWaiters[i];
-              if (waiter === undefined) continue;
-              if (waiter.predicate(payload)) {
-                clearTimeout(waiter.timer);
-                eventWaiters.splice(i, 1);
-                waiter.resolve(payload);
-              }
-            }
-            continue;
-          }
-          const slot = replyWaiters.get(envelope.id);
-          if (slot !== undefined) {
-            replyWaiters.delete(envelope.id);
-            slot.resolve(envelope);
-          }
-        }
-      } catch (error) {
-        const cause = error instanceof Error ? error : new Error(String(error));
-        for (const slot of replyWaiters.values()) slot.reject(cause);
-        replyWaiters.clear();
-        for (const waiter of eventWaiters) {
-          clearTimeout(waiter.timer);
-          waiter.reject(cause);
-        }
-        eventWaiters.length = 0;
-      }
-    })();
+    const readLoop = runHarnessReadLoop({
+      readable: conn.readable,
+      eventQueue,
+      eventWaiters,
+      replyWaiters,
+    });
 
     const send = async (envelope: MessageEnvelope): Promise<MessageEnvelope> => {
       if (replyWaiters.has(envelope.id)) {
@@ -528,6 +532,11 @@ export async function bootHarness(env: ResolvedE2eEnv): Promise<Harness> {
       throw new Error(`harness subscribe rejected: ${ack.error ?? "(no detail)"}`);
     }
 
+    // Capture into consts so the cleanup closure narrows these to
+    // their non-undefined types (the outer `let` bindings are widened
+    // to `T | undefined` for the catch path).
+    const liveChild = child;
+    const liveConn = conn;
     let cleaned = false;
     const cleanup = async (): Promise<void> => {
       if (cleaned) return;
@@ -538,17 +547,17 @@ export async function bootHarness(env: ResolvedE2eEnv): Promise<Harness> {
         // Ignore.
       }
       try {
-        conn.close();
+        liveConn.close();
       } catch {
         // Ignore.
       }
       try {
-        child.kill("SIGTERM");
+        liveChild.kill("SIGTERM");
       } catch {
         // Already gone.
       }
       try {
-        await child.stderr.cancel();
+        await liveChild.stderr.cancel();
       } catch {
         // Already drained.
       }
@@ -557,16 +566,16 @@ export async function bootHarness(env: ResolvedE2eEnv): Promise<Harness> {
         shutdownTimer = setTimeout(resolve, 2_000);
       });
       try {
-        await Promise.race([child.status, shutdownTimeout]);
+        await Promise.race([liveChild.status, shutdownTimeout]);
       } finally {
         if (shutdownTimer !== undefined) clearTimeout(shutdownTimer);
       }
       try {
-        child.kill("SIGKILL");
+        liveChild.kill("SIGKILL");
       } catch {
         // Already gone.
       }
-      await child.status;
+      await liveChild.status;
       await readLoop;
       try {
         await Deno.remove(home, { recursive: true });
@@ -577,7 +586,7 @@ export async function bootHarness(env: ResolvedE2eEnv): Promise<Harness> {
     };
 
     return {
-      child,
+      child: liveChild,
       home,
       socketPath,
       repo: env.repo,
@@ -586,11 +595,64 @@ export async function bootHarness(env: ResolvedE2eEnv): Promise<Harness> {
       cleanup,
     };
   } catch (error) {
-    // Boot failed — make sure the temp dir is removed.
+    // Boot failed — release every resource that was actually allocated
+    // before rethrowing. Each step is wrapped so a failure in one
+    // (socket already closed, child already exited) does not prevent
+    // the others. Order:
+    //   1. Close the client socket (if connected) so the daemon's
+    //      accept loop sees the peer drop.
+    //   2. SIGTERM the daemon child (if spawned), then await its
+    //      status with a short grace before SIGKILL — we cannot
+    //      remove the temp dir while the daemon still holds open
+    //      file descriptors under it.
+    //   3. Remove the temp dir.
+    if (conn !== undefined) {
+      try {
+        conn.close();
+      } catch {
+        // Already closed (or never bound) — ignore.
+      }
+    }
+    // Bind to a const so TypeScript narrows the type across the
+    // `await` boundaries below; the outer `child` is `let`-scoped.
+    const childToKill = child;
+    if (childToKill !== undefined) {
+      try {
+        childToKill.kill("SIGTERM");
+      } catch {
+        // Already gone — ignore.
+      }
+      try {
+        await childToKill.stderr.cancel();
+      } catch {
+        // Already drained — ignore.
+      }
+      let shutdownTimer: number | undefined;
+      const shutdownTimeout = new Promise<void>((resolve) => {
+        shutdownTimer = setTimeout(resolve, 2_000);
+      });
+      try {
+        await Promise.race([childToKill.status, shutdownTimeout]);
+      } catch {
+        // Status may already have rejected — ignore.
+      } finally {
+        if (shutdownTimer !== undefined) clearTimeout(shutdownTimer);
+      }
+      try {
+        childToKill.kill("SIGKILL");
+      } catch {
+        // Already gone — ignore.
+      }
+      try {
+        await childToKill.status;
+      } catch {
+        // Already reaped — ignore.
+      }
+    }
     try {
       await Deno.remove(home, { recursive: true });
     } catch {
-      // Ignore.
+      // Best-effort: leave the dir for the operator if removal fails.
     }
     throw error;
   }
@@ -638,6 +700,137 @@ function buildSpawnEnv(fakeHome: string): Record<string, string> {
  * @param stderr The daemon's stderr stream.
  * @param timeoutMs Bound on the wait, in milliseconds.
  */
+/**
+ * Internal waiter slot for {@link runHarnessReadLoop}. Mirrors the
+ * inline shape used by {@link bootHarness}; pulled out as a named type
+ * so the harness body and the unit-test stay in lock-step.
+ *
+ * @internal
+ */
+export interface HarnessEventWaiter {
+  predicate: (event: EventPayload) => boolean;
+  resolve: (event: EventPayload) => void;
+  reject: (error: Error) => void;
+  timer: number;
+}
+
+/**
+ * Internal reply-waiter slot for {@link runHarnessReadLoop}.
+ *
+ * @internal
+ */
+export interface HarnessReplyWaiter {
+  resolve: (envelope: MessageEnvelope) => void;
+  reject: (error: Error) => void;
+}
+
+/**
+ * Dependencies the harness's read loop needs from {@link bootHarness}.
+ * Exported so a regression test can drive the loop in isolation
+ * against a synthetic readable; the production caller wires the
+ * connection's `.readable` and the same waiter collections it owns.
+ *
+ * @internal
+ */
+export interface HarnessReadLoopParams {
+  readable: ReadableStream<Uint8Array>;
+  eventQueue: EventPayload[];
+  eventWaiters: HarnessEventWaiter[];
+  replyWaiters: Map<string, HarnessReplyWaiter>;
+}
+
+/**
+ * Drive the harness's read loop against the supplied readable. On a
+ * decoded `event` envelope, push the payload onto `eventQueue`
+ * (capped at {@link EVENT_QUEUE_MAX}, oldest dropped) and notify any
+ * matching waiter. On any other envelope, resolve the matching reply
+ * waiter by id.
+ *
+ * **Termination semantics.** The loop ends in one of two ways:
+ *
+ *   1. Decode throws (malformed frame, abrupt connection reset). All
+ *      pending waiters reject with the underlying cause.
+ *   2. Decode runs to clean EOF (peer closed the socket at a frame
+ *      boundary, e.g. after a `SIGTERM`). All pending waiters reject
+ *      with {@link HarnessError}`("connection-closed", ...)` so the
+ *      caller can distinguish a clean close from a decode failure.
+ *
+ * Splitting this out of {@link bootHarness} keeps the function unit
+ * testable: the regression test in `_e2e_harness_test.ts` drives it
+ * with a synthetic Unix socket that closes after one frame and
+ * asserts the typed close error.
+ *
+ * @internal
+ */
+export function runHarnessReadLoop(params: HarnessReadLoopParams): Promise<void> {
+  const { readable, eventQueue, eventWaiters, replyWaiters } = params;
+  let queueOverflowWarned = false;
+  const rejectAllWaiters = (cause: Error): void => {
+    for (const slot of replyWaiters.values()) slot.reject(cause);
+    replyWaiters.clear();
+    for (const waiter of eventWaiters) {
+      clearTimeout(waiter.timer);
+      waiter.reject(cause);
+    }
+    eventWaiters.length = 0;
+  };
+  return (async () => {
+    try {
+      for await (const envelope of decode(readable)) {
+        if (envelope.type === "event") {
+          const payload = envelope.payload as EventPayload;
+          eventQueue.push(payload);
+          // Cap the queue so a long-running scenario whose installed
+          // waiters do not match every emitted event cannot OOM the
+          // runner. Drop the oldest entry; warn once on the first
+          // overflow so the operator can size up if a real scenario
+          // is losing a transition it cared about.
+          while (eventQueue.length > EVENT_QUEUE_MAX) {
+            eventQueue.shift();
+            if (!queueOverflowWarned) {
+              queueOverflowWarned = true;
+              console.warn(
+                `[e2e] eventQueue exceeded ${EVENT_QUEUE_MAX}; dropping oldest events.`,
+              );
+            }
+          }
+          // Drain any waiter whose predicate now matches.
+          for (let i = eventWaiters.length - 1; i >= 0; i -= 1) {
+            const waiter = eventWaiters[i];
+            if (waiter === undefined) continue;
+            if (waiter.predicate(payload)) {
+              clearTimeout(waiter.timer);
+              eventWaiters.splice(i, 1);
+              waiter.resolve(payload);
+            }
+          }
+          continue;
+        }
+        const slot = replyWaiters.get(envelope.id);
+        if (slot !== undefined) {
+          replyWaiters.delete(envelope.id);
+          slot.resolve(envelope);
+        }
+      }
+      // Clean EOF: the peer closed the socket at a frame boundary.
+      // The `for await` loop exits without throwing, so without this
+      // branch any pending `send()` (whose reply was still in flight)
+      // and any installed `waitForEvent` waiter would hang
+      // indefinitely. Reject them all with a typed cause so callers
+      // can pattern-match on `error.kind === "connection-closed"`.
+      rejectAllWaiters(
+        new HarnessError(
+          "connection-closed",
+          "harness socket closed cleanly with pending waiters",
+        ),
+      );
+    } catch (error) {
+      const cause = error instanceof Error ? error : new Error(String(error));
+      rejectAllWaiters(cause);
+    }
+  })();
+}
+
 async function waitForListenLine(
   stderr: ReadableStream<Uint8Array>,
   timeoutMs: number,

--- a/tests/e2e/ci_fail_recovery_test.ts
+++ b/tests/e2e/ci_fail_recovery_test.ts
@@ -1,0 +1,115 @@
+/**
+ * tests/e2e/ci_fail_recovery_test.ts — Wave 5 verification scenario 2.
+ *
+ * **Scenario.** An issue is intentionally constructed so the first
+ * agent commit fails CI. The supervisor's `STABILIZING` loop detects
+ * the red status, fetches the failing-job logs, dispatches the agent
+ * with the failure context, observes the new green CI after the
+ * follow-up push, settles, and merges.
+ *
+ * The test asserts:
+ *   1. The supervisor enters `STABILIZING` with a `CI` sub-phase at
+ *      least once.
+ *   2. The supervisor produces at least one additional iteration after
+ *      the initial commit (i.e. it actually re-ran the agent in
+ *      response to red CI).
+ *   3. The task lands in `MERGED`. (`NEEDS_HUMAN` from
+ *      `MAX_TASK_ITERATIONS` exhaustion is a scenario failure unless
+ *      the sandbox is misconfigured; the rejection prints the path.)
+ *
+ * **Inputs.** Same `MAKINA_E2E_*` env family as the happy path. The
+ * scenario issue is `MAKINA_E2E_CI_FAIL_ISSUE`. The sandbox repo is
+ * expected to have a CI workflow that fails on the first agent commit
+ * but passes after the agent's fix; setting that up is the operator's
+ * responsibility (documented in `docs/development.md`).
+ *
+ * @module
+ */
+
+import { assert, assertEquals } from "@std/assert";
+
+import { type AckPayload } from "../../src/ipc/protocol.ts";
+import { makeIssueNumber } from "../../src/types.ts";
+import { type Harness, registerE2eTest, type ResolvedE2eEnv } from "./_e2e_harness.ts";
+
+registerE2eTest(
+  "e2e: CI-fail recovery — red CI → agent fix → green CI → merged",
+  "MAKINA_E2E_CI_FAIL_ISSUE",
+  async (env: ResolvedE2eEnv, harness: Harness): Promise<void> => {
+    const issueRaw = Deno.env.get("MAKINA_E2E_CI_FAIL_ISSUE");
+    assert(issueRaw !== undefined, "CI-fail issue env was checked by the harness");
+    const issueNumber = makeIssueNumber(Number(issueRaw));
+
+    const issueAck = await harness.send({
+      id: "cifail-issue-1",
+      type: "command",
+      payload: {
+        name: "issue",
+        args: [String(issueNumber)],
+        repo: env.repo,
+        issueNumber,
+      },
+    });
+    assertEquals(issueAck.type, "ack");
+    const ack = issueAck.payload as AckPayload;
+    assertEquals(
+      ack.ok,
+      true,
+      `expected ack.ok=true; got error=${ack.error ?? "(none)"}`,
+    );
+
+    // Track CI-phase entries so we can assert the loop actually ran at
+    // least once. The sandbox is expected to fail CI on the initial
+    // commit; if the supervisor reaches MERGED without ever entering
+    // the CI phase, the sandbox CI is mis-wired.
+    let observedCiPhase = false;
+    let observedTaskId: string | undefined;
+    const terminal = await harness.waitForEvent((event) => {
+      if (event.kind !== "state-changed") return false;
+      if (event.data.stabilizePhase === "CI") {
+        observedCiPhase = true;
+      }
+      const { toState } = event.data;
+      if (toState === "MERGED" || toState === "NEEDS_HUMAN" || toState === "FAILED") {
+        observedTaskId = event.taskId;
+        return true;
+      }
+      return false;
+    }, env.timeoutMilliseconds);
+
+    assert(observedCiPhase, "expected supervisor to enter the CI sub-phase at least once");
+    assert(
+      terminal.kind === "state-changed",
+      `expected state-changed event, got ${terminal.kind}`,
+    );
+    assertEquals(
+      terminal.data.toState,
+      "MERGED",
+      `expected MERGED; supervisor reported ${terminal.data.toState}` +
+        (terminal.data.reason !== undefined ? ` (reason: ${terminal.data.reason})` : ""),
+    );
+
+    // Verify iterationCount > 1, proving the agent ran at least twice
+    // (initial draft + at least one CI-fix). The supervisor mints a
+    // single `iterationCount` field per task; the projection on
+    // `/status` exposes it.
+    if (observedTaskId !== undefined) {
+      const statusReply = await harness.send({
+        id: "cifail-status-1",
+        type: "command",
+        payload: { name: "status", args: [] },
+      });
+      const statusAck = statusReply.payload as AckPayload;
+      const data = statusAck.data as
+        | { tasks?: Array<{ id: string; iterationCount?: number; state?: string }> }
+        | undefined;
+      const merged = data?.tasks?.find((task) => task.id === observedTaskId);
+      assert(merged !== undefined, "merged task missing from /status");
+      assert(
+        (merged.iterationCount ?? 0) >= 2,
+        `expected iterationCount >= 2 (initial draft + CI fix); ` +
+          `got ${merged.iterationCount}`,
+      );
+    }
+  },
+);

--- a/tests/e2e/happy_path_test.ts
+++ b/tests/e2e/happy_path_test.ts
@@ -1,0 +1,99 @@
+/**
+ * tests/e2e/happy_path_test.ts — Wave 5 verification scenario 1.
+ *
+ * **Scenario.** A small, well-scoped issue is picked up via `/issue`,
+ * the agent implements, commits, pushes, opens a PR, requests Copilot
+ * review, watches CI to green, observes no review comments, settles,
+ * and squash-merges. The supervisor lands the task in `MERGED` without
+ * any operator intervention.
+ *
+ * **Inputs.** Sandbox repo + GitHub App credentials via the
+ * `MAKINA_E2E_*` env family. The specific issue is named via
+ * `MAKINA_E2E_HAPPY_ISSUE`. See `_e2e_harness.ts` for the full
+ * environment contract.
+ *
+ * **Skip behaviour.** Without the gate (`MAKINA_E2E=1`) or any required
+ * variable, the test prints a one-line skip note and resolves
+ * successfully. `deno task test` therefore stays fast and offline-safe;
+ * `deno task ci` continues to run on every push without any sandbox
+ * dependency.
+ *
+ * @module
+ */
+
+import { assert, assertEquals } from "@std/assert";
+
+import { type AckPayload } from "../../src/ipc/protocol.ts";
+import { makeIssueNumber } from "../../src/types.ts";
+import { type Harness, registerE2eTest, type ResolvedE2eEnv } from "./_e2e_harness.ts";
+
+registerE2eTest(
+  "e2e: happy path — agent ships, CI green, Copilot clean, squash-merged",
+  "MAKINA_E2E_HAPPY_ISSUE",
+  async (env: ResolvedE2eEnv, harness: Harness): Promise<void> => {
+    const issueRaw = Deno.env.get("MAKINA_E2E_HAPPY_ISSUE");
+    assert(issueRaw !== undefined, "happy issue env was checked by the harness");
+    const issueNumber = makeIssueNumber(Number(issueRaw));
+
+    // Drive the supervisor.
+    const issueAck = await harness.send({
+      id: "happy-issue-1",
+      type: "command",
+      payload: {
+        name: "issue",
+        args: [String(issueNumber)],
+        repo: env.repo,
+        issueNumber,
+      },
+    });
+    assertEquals(issueAck.type, "ack");
+    const ack = issueAck.payload as AckPayload;
+    assertEquals(
+      ack.ok,
+      true,
+      `expected ack.ok=true; got error=${ack.error ?? "(none)"}`,
+    );
+
+    // Wait for the supervisor to land the task in MERGED. Any other
+    // terminal state (`NEEDS_HUMAN`, `FAILED`) is a scenario failure
+    // — surface it as the test rejection.
+    let observedTaskId: string | undefined;
+    const terminal = await harness.waitForEvent((event) => {
+      if (event.kind !== "state-changed") return false;
+      const { toState } = event.data;
+      if (toState === "MERGED" || toState === "NEEDS_HUMAN" || toState === "FAILED") {
+        observedTaskId = event.taskId;
+        return true;
+      }
+      return false;
+    }, env.timeoutMilliseconds);
+    assert(
+      terminal.kind === "state-changed",
+      `expected state-changed event, got ${terminal.kind}`,
+    );
+    assertEquals(
+      terminal.data.toState,
+      "MERGED",
+      `expected MERGED; supervisor reported ${terminal.data.toState}` +
+        (terminal.data.reason !== undefined ? ` (reason: ${terminal.data.reason})` : ""),
+    );
+
+    // Sanity-check `/status` reflects the merged task.
+    if (observedTaskId !== undefined) {
+      const statusReply = await harness.send({
+        id: "happy-status-1",
+        type: "command",
+        payload: { name: "status", args: [] },
+      });
+      const statusAck = statusReply.payload as AckPayload;
+      assertEquals(statusAck.ok, true, "status command should succeed");
+      const data = statusAck.data as { tasks?: Array<{ id: string; state: string }> } | undefined;
+      const merged = data?.tasks?.find((task) => task.id === observedTaskId);
+      assert(
+        merged !== undefined,
+        `task ${observedTaskId} missing from /status output`,
+      );
+      assertEquals(merged.state, "MERGED");
+    }
+  },
+);

--- a/tests/e2e/review_comment_recovery_test.ts
+++ b/tests/e2e/review_comment_recovery_test.ts
@@ -1,0 +1,123 @@
+/**
+ * tests/e2e/review_comment_recovery_test.ts — Wave 5 verification
+ * scenario 3.
+ *
+ * **Scenario.** A review comment is left manually (or by a teammate)
+ * on the PR mid-flight. The supervisor's `STABILIZING` loop's
+ * `CONVERSATIONS` phase observes the new comment, dispatches the agent
+ * with the comment context, pushes the fix, resolves the thread via
+ * GraphQL, re-requests Copilot review, and eventually settles +
+ * merges.
+ *
+ * The test asserts:
+ *   1. The supervisor enters `STABILIZING` with a `CONVERSATIONS`
+ *      sub-phase at least once.
+ *   2. The task lands in `MERGED` (the supervisor closed the loop).
+ *
+ * **Important operator setup.** This scenario presumes a manual or
+ * scripted reviewer leaves a comment on the PR after the initial push
+ * but before settling. Two plausible setups:
+ *
+ *   - **Manual.** Run the test from a paired environment where a
+ *     human reviewer is watching the sandbox PR and types a comment
+ *     when the PR opens.
+ *   - **Scripted.** Use a side-channel script (not in this repo) to
+ *     poll the GitHub API for the new PR and post a deterministic
+ *     review comment as soon as it appears.
+ *
+ * Either way, this test only drives the daemon and observes events;
+ * the comment-injection step is out of scope.
+ *
+ * **Inputs.** Sandbox repo + GitHub App credentials via the
+ * `MAKINA_E2E_*` env family. The scenario issue is named via
+ * `MAKINA_E2E_REVIEW_COMMENT_ISSUE`.
+ *
+ * @module
+ */
+
+import { assert, assertEquals } from "@std/assert";
+
+import { type AckPayload } from "../../src/ipc/protocol.ts";
+import { makeIssueNumber } from "../../src/types.ts";
+import { type Harness, registerE2eTest, type ResolvedE2eEnv } from "./_e2e_harness.ts";
+
+registerE2eTest(
+  "e2e: review-comment recovery — comment → agent fix → thread resolved → merged",
+  "MAKINA_E2E_REVIEW_COMMENT_ISSUE",
+  async (env: ResolvedE2eEnv, harness: Harness): Promise<void> => {
+    const issueRaw = Deno.env.get("MAKINA_E2E_REVIEW_COMMENT_ISSUE");
+    assert(
+      issueRaw !== undefined,
+      "review-comment issue env was checked by the harness",
+    );
+    const issueNumber = makeIssueNumber(Number(issueRaw));
+
+    const issueAck = await harness.send({
+      id: "rc-issue-1",
+      type: "command",
+      payload: {
+        name: "issue",
+        args: [String(issueNumber)],
+        repo: env.repo,
+        issueNumber,
+      },
+    });
+    assertEquals(issueAck.type, "ack");
+    const ack = issueAck.payload as AckPayload;
+    assertEquals(
+      ack.ok,
+      true,
+      `expected ack.ok=true; got error=${ack.error ?? "(none)"}`,
+    );
+
+    // The conversations phase only fires after the comment lands; we
+    // observe its first entry as evidence that the supervisor saw the
+    // comment and dispatched the agent.
+    let observedConversationsPhase = false;
+    let observedTaskId: string | undefined;
+    const terminal = await harness.waitForEvent((event) => {
+      if (event.kind !== "state-changed") return false;
+      if (event.data.stabilizePhase === "CONVERSATIONS") {
+        observedConversationsPhase = true;
+      }
+      const { toState } = event.data;
+      if (toState === "MERGED" || toState === "NEEDS_HUMAN" || toState === "FAILED") {
+        observedTaskId = event.taskId;
+        return true;
+      }
+      return false;
+    }, env.timeoutMilliseconds);
+
+    assert(
+      observedConversationsPhase,
+      "expected supervisor to enter the CONVERSATIONS sub-phase at least once " +
+        "(was a review comment posted on the PR while the agent was running?)",
+    );
+    assert(
+      terminal.kind === "state-changed",
+      `expected state-changed event, got ${terminal.kind}`,
+    );
+    assertEquals(
+      terminal.data.toState,
+      "MERGED",
+      `expected MERGED; supervisor reported ${terminal.data.toState}` +
+        (terminal.data.reason !== undefined ? ` (reason: ${terminal.data.reason})` : ""),
+    );
+
+    if (observedTaskId !== undefined) {
+      const statusReply = await harness.send({
+        id: "rc-status-1",
+        type: "command",
+        payload: { name: "status", args: [] },
+      });
+      const statusAck = statusReply.payload as AckPayload;
+      assertEquals(statusAck.ok, true);
+      const data = statusAck.data as
+        | { tasks?: Array<{ id: string; state?: string }> }
+        | undefined;
+      const merged = data?.tasks?.find((task) => task.id === observedTaskId);
+      assert(merged !== undefined, "merged task missing from /status");
+      assertEquals(merged.state, "MERGED");
+    }
+  },
+);

--- a/tests/unit/e2e_harness_test.ts
+++ b/tests/unit/e2e_harness_test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for `tests/e2e/_e2e_harness.ts`'s read loop.
+ *
+ * The e2e harness opens a Unix socket to the daemon and runs an async
+ * read loop that decodes IPC envelopes, dispatches them to either the
+ * `eventQueue`/`eventWaiters` (for `event` envelopes) or the
+ * `replyWaiters` (for `ack`/`pong`/...). The loop is the only thing
+ * that resolves outstanding `send()` promises.
+ *
+ * This file regression-tests the **clean-close** path: when the peer
+ * closes the socket at a frame boundary, `decode()` runs to EOF
+ * without throwing. A previous version of the loop relied on the
+ * `catch` block to fail pending waiters, so a clean close left
+ * `replyWaiters` and `eventWaiters` hanging indefinitely. The fix is
+ * to detect the EOF and reject every pending waiter with a typed
+ * {@link HarnessError}`("connection-closed", ...)`.
+ *
+ * The test uses a real Unix socket on a temp directory rather than a
+ * synthetic `ReadableStream` because the bug only surfaces when the
+ * peer-side close model matches the production daemon's lifecycle —
+ * a manually-controlled `ReadableStream.close()` happens to behave
+ * the same way today, but the on-the-wire path is the contract.
+ *
+ * @module
+ */
+
+import { assertEquals, assertInstanceOf, assertRejects } from "@std/assert";
+
+import { encode } from "../../src/ipc/codec.ts";
+import { type EventPayload, type MessageEnvelope } from "../../src/ipc/protocol.ts";
+import {
+  HarnessError,
+  type HarnessEventWaiter,
+  type HarnessReplyWaiter,
+  runHarnessReadLoop,
+} from "../../tests/e2e/_e2e_harness.ts";
+
+/**
+ * Spin up a one-shot Unix socket server that writes the supplied
+ * frames to the first peer that connects, then closes the connection
+ * at a frame boundary.
+ *
+ * @returns The socket path and a promise that resolves when the
+ *   server has accepted-and-closed exactly one peer.
+ */
+async function makeOneShotServer(
+  frames: Uint8Array[],
+): Promise<{ path: string; closed: Promise<void>; tempDir: string }> {
+  const tempDir = await Deno.makeTempDir({
+    dir: "/tmp",
+    prefix: "makina-harness-readloop-",
+  });
+  const path = `${tempDir}/peer.sock`;
+  const listener = Deno.listen({ transport: "unix", path });
+  const closed = (async () => {
+    try {
+      const conn = await listener.accept();
+      const writer = conn.writable.getWriter();
+      try {
+        for (const frame of frames) {
+          await writer.write(frame);
+        }
+        await writer.close();
+      } catch {
+        // Peer dropped — drop our side too.
+      }
+      try {
+        conn.close();
+      } catch {
+        // Already closed.
+      }
+    } finally {
+      try {
+        listener.close();
+      } catch {
+        // Already closed.
+      }
+    }
+  })();
+  return { path, closed, tempDir };
+}
+
+Deno.test(
+  "runHarnessReadLoop rejects pending waiters with HarnessError on clean close",
+  async () => {
+    // Send one valid event, then close the connection. A pending
+    // reply waiter (whose id never appeared on the wire) and a
+    // pending event waiter (whose predicate never fires) should both
+    // reject with HarnessError("connection-closed").
+    const eventEnvelope: MessageEnvelope = {
+      id: "synthetic-event-1",
+      type: "event",
+      payload: {
+        taskId: "synthetic-task",
+        atIso: new Date(0).toISOString(),
+        kind: "log",
+        data: { level: "info", message: "synthetic frame" },
+      },
+    };
+    const server = await makeOneShotServer([encode(eventEnvelope)]);
+    try {
+      const conn = await Deno.connect({
+        transport: "unix",
+        path: server.path,
+      });
+      const eventQueue: EventPayload[] = [];
+      const eventWaiters: HarnessEventWaiter[] = [];
+      const replyWaiters = new Map<string, HarnessReplyWaiter>();
+
+      // Install a reply waiter for an id that will never come.
+      const replyPromise = new Promise<MessageEnvelope>((resolve, reject) => {
+        replyWaiters.set("never-arrives", { resolve, reject });
+      });
+      // Install an event waiter whose predicate matches nothing.
+      const eventPromise = new Promise<EventPayload>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          reject(new Error("unit-test timer fired (should not happen)"));
+        }, 30_000);
+        eventWaiters.push({
+          predicate: () => false,
+          resolve,
+          reject,
+          timer,
+        });
+      });
+
+      const loopDone = runHarnessReadLoop({
+        readable: conn.readable,
+        eventQueue,
+        eventWaiters,
+        replyWaiters,
+      });
+
+      // Both waiters should reject with HarnessError once the loop
+      // observes the clean EOF.
+      const replyError = await assertRejects(
+        () => replyPromise,
+        HarnessError,
+      );
+      assertEquals(replyError.kind, "connection-closed");
+
+      const eventError = await assertRejects(
+        () => eventPromise,
+        HarnessError,
+      );
+      assertEquals(eventError.kind, "connection-closed");
+      assertInstanceOf(eventError, Error);
+
+      await loopDone;
+      await server.closed;
+      // The valid frame should have made it through before the close.
+      assertEquals(eventQueue.length, 1);
+      assertEquals(eventQueue[0]?.kind, "log");
+      // Both waiter collections must be empty; the loop drained them.
+      assertEquals(replyWaiters.size, 0);
+      assertEquals(eventWaiters.length, 0);
+    } finally {
+      try {
+        await Deno.remove(server.tempDir, { recursive: true });
+      } catch {
+        // Best-effort.
+      }
+    }
+  },
+);

--- a/tests/unit/e2e_harness_test.ts
+++ b/tests/unit/e2e_harness_test.ts
@@ -98,8 +98,9 @@ Deno.test(
       },
     };
     const server = await makeOneShotServer([encode(eventEnvelope)]);
+    let conn: Deno.UnixConn | undefined;
     try {
-      const conn = await Deno.connect({
+      conn = await Deno.connect({
         transport: "unix",
         path: server.path,
       });
@@ -155,6 +156,19 @@ Deno.test(
       assertEquals(replyWaiters.size, 0);
       assertEquals(eventWaiters.length, 0);
     } finally {
+      // Close the client connection to keep `sanitizeResources` happy
+      // even after the server's clean EOF: Deno does not auto-close the
+      // client side when the server side closes, so without this the
+      // open `UnixConn` resource trips the test sanitizer at end of
+      // test.
+      if (conn !== undefined) {
+        try {
+          conn.close();
+        } catch {
+          // Connection may already be closed by the read loop's
+          // releaseLock; ignore.
+        }
+      }
       try {
         await Deno.remove(server.tempDir, { recursive: true });
       } catch {


### PR DESCRIPTION
## Summary

- Adds `tests/e2e/{happy_path,ci_fail_recovery,review_comment_recovery}_test.ts` plus a shared `_e2e_harness.ts` that boots `main.ts daemon` against a synthetic `HOME` and drives `/issue` over the daemon socket. The suite is gated by `MAKINA_E2E=1` + four required env vars + three optional per-scenario issue numbers; absent variables produce one-line skips so `deno task ci` stays offline-safe.
- Walks every `docs/*.md` and `docs/adrs/*.md` for stale Wave-stub references and renumbers ADR-024 (app-level GitHub client for setup wizard, the later-landing of two ADR-024 collisions on develop) to ADR-025; cross-references in `docs/setup-github-app.md` and `src/github/app-client.ts` updated.
- Documents the e2e env-var contract in `docs/development.md` ("Running the e2e suite") and extends `deno task doc:lint` to cover `tests/e2e/` so the harness JSDoc stays honest.

Closes #19.

## Test plan

- [x] `deno task ci` green locally (663 passed, coverage gate passed).
- [x] `deno test -A --no-check tests/e2e/` prints the three skip notes when no env vars are set.
- [x] `deno doc --lint main.ts src/ tests/e2e/` green.
- [x] `deno fmt --check` and `deno lint` green.
- [ ] CI green on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)